### PR TITLE
Create a prow_config file with an empty list of workflows.

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,0 +1,1 @@
+workflows: []


### PR DESCRIPTION
* This allows the prow jobs to run.

/assign @gaocegege 