### PR TITLE
Override table of contents layout to enable dynamic positioning

### DIFF
--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -8,7 +8,7 @@
            {{ .Params.bref | safeHTML }}.
       </p>
 
-    </div> 
+    </div>
     <div id="toc" data-component="toclocator">
     {{ partial "toc" .}}
     </div>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,0 +1,25 @@
+{{ define "title"}} {{ .Title}} {{end}}
+{{ define "header"}} {{ partial "header" .}} {{end}}
+{{ define "main"}}
+  <div id="main">
+    <div id="hero">
+      <h1> {{ .Title}} </h1>
+      <p class="hero-lead">
+           {{ .Params.bref | safeHTML }}.
+      </p>
+
+    </div> 
+    <div id="toc" data-component="toclocator">
+    {{ partial "toc" .}}
+    </div>
+    <div id="kube-component" class="content">
+
+    {{ .Content}}
+<!-- Inject script tag in this template  -->
+    {{if .Params.script}}
+     {{ $script := (delimit (slice "scripts" .Params.script) "/")}}
+    {{ partial (string $script) .}}
+    {{end }}
+    </div>
+    </div>
+{{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,4 @@
+div#toc {
+    position: static;
+    z-index: 10000;
+}

--- a/static/js/master.js
+++ b/static/js/master.js
@@ -1,0 +1,43 @@
+(function(Kube) {
+    Kube.TocLocator = function(element, options) {
+        this.namespace = "toclocator";
+
+        // Parent Constructor
+        Kube.apply(this, arguments);
+
+        // Services
+        this.detect = new Kube.Detect();
+
+        // Initialization
+        this.start();
+    };
+
+    // Functionality
+    Kube.TocLocator.prototype = {
+        start: function() {
+            this.$element = $( "#toc" )
+
+            p = this
+            $(document).scroll(function() {
+                p.styleToc();
+            });
+        },
+        styleToc: function() {
+          if (this.detect.isDesktopScreen()) {
+            if ($(document).scrollTop() > 100) {
+                this.$element.css({ position: "fixed", right: "1em" });
+            } else {
+                this.$element.css({ position: "static" });
+            }
+          }
+        }
+    };
+
+    // Inheritance
+    Kube.TocLocator.inherits(Kube);
+
+    // Plugin
+    Kube.Plugin.create("TocLocator");
+    Kube.Plugin.autoload("TocLocator");
+
+}(Kube));


### PR DESCRIPTION
Enable single page Table of Contents layout to dynamically move out to the right when scrolling down. Move back on top when scrolled back to top.

- Will not change position on mobile devices.
- Will not change position on smaller desktop browser windows either.
<img width="1508" alt="screen shot 2018-05-31 at 10 11 48 pm" src="https://user-images.githubusercontent.com/11774566/40822309-7f2197d0-6520-11e8-8e7f-795e5cdbf556.png">
<img width="486" alt="screen shot 2018-05-31 at 10 14 44 pm" src="https://user-images.githubusercontent.com/11774566/40822310-7f39323c-6520-11e8-833f-deee68615094.png">
<img width="601" alt="screen shot 2018-05-31 at 10 14 57 pm" src="https://user-images.githubusercontent.com/11774566/40822311-7f50ed28-6520-11e8-84d8-6bc5095253ad.png">
<img width="1552" alt="screen shot 2018-05-31 at 10 15 21 pm" src="https://user-images.githubusercontent.com/11774566/40822312-7f68fda0-6520-11e8-902f-effd76de683b.png">
<img width="1035" alt="screen shot 2018-05-31 at 10 15 35 pm" src="https://user-images.githubusercontent.com/11774566/40822313-7f936c0c-6520-11e8-85ff-c3c17f6973c8.png">
<img width="1035" alt="screen shot 2018-05-31 at 10 15 42 pm" src="https://user-images.githubusercontent.com/11774566/40822314-7faaa6f6-6520-11e8-831f-8d023f26b8b8.png">





