### PR TITLE
Moved pytorch doc from 'About' to 'Getting Started' - issue #82

### DIFF
--- a/content/docs/started/pytorch.md
+++ b/content/docs/started/pytorch.md
@@ -6,7 +6,7 @@ toc = true
 bref= "This guide will walk you through using PyTorch with Kubeflow"
 aliases = ["/docs/pytorch/"]
 [menu.docs]
-  parent = "about"
+  parent = "started"
   weight = 3
 +++
 


### PR DESCRIPTION
Fix #82 