### PR TITLE
Add redirects to GitHub content.

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -1,0 +1,4 @@
+# Redirects from what the browser requests to what we serve
+/version/stable/gke/scripts/deploy.sh              https://raw.githubusercontent.com/kubeflow/kubeflow/v0.2.2/scripts/gke/deploy.sh
+/version/stable/scripts/deploy.sh      https://raw.githubusercontent.com/kubeflow/kubeflow/v0.2.2/scripts/deploy.sh
+/version/stable/source.tar.gz          https://github.com/kubeflow/kubeflow/archive/v0.2.2.tar.gz


### PR DESCRIPTION
Fix kubeflow/kubeflow#1156

After this PR you could something like

```
curl -L https://kubeflow.org/version/stable/gke/scripts/deploy.sh | bash
```

We can then update the version that stable points to as part of our release process.
