### PR TITLE
Update broken links to user_guide.

### DIFF
--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -49,15 +49,13 @@ export KUBEFLOW_VERSION=0.2.2
 curl https://raw.githubusercontent.com/kubeflow/kubeflow/v${KUBEFLOW_VERSION}/scripts/deploy.sh | bash
 ```
 
-For more detailed instructions about how to use Kubeflow please refer to the [user guide](/docs/about/user_guide/).
-
 **Important**: The commands above will enable collection of **anonymous** user data to help us improve Kubeflow; for more information including instructions for explictly
-disabling it please refer to the [Usage Reporting section](/docs/about/user_guide/#usage-reporting) of the user guide.
+disabling it please refer to the [Usage Reporting section](/docs/guides/usage-reporting/) of the user guide.
 
 ## Troubleshooting
-For detailed troubleshooting instructions, please refer to [this section of the user guide](/docs/about/user_guide/#usage-reporting#troubleshooting).
+For detailed troubleshooting instructions, please refer to the [Troubleshooting Guide](/docs/guides/troubleshooting/).
 
 ## Resources
 
-* The [kubeflow user guide](/docs/about/user_guide/) provides in-depth instructions for using Kubeflow
+* The Guides section (see sections on left) provides in-depth instructions for using Kubeflow
 * Katacoda has produced a [self-paced scenario](https://www.katacoda.com/kubeflow) for learning and trying out Kubeflow


### PR DESCRIPTION
Fixes #117 

The user guide  was broken into smaller topic pages and added into a Guides section. Updating all links to it.