### PR TITLE
NAMESPACE is set in Jupyter guide

### DIFF
--- a/content/docs/guides/components/jupyter.md
+++ b/content/docs/guides/components/jupyter.md
@@ -10,6 +10,12 @@ toc = true
 
 ## Bringing up a Jupyter Notebook
 
+Beforehand we need to setup a NAMESPACE variable.
+
+```commandline
+export NAMESPACE=kubeflow
+```
+
 The jupyterhub component deployed JupyterHub and a corresponding load balancer service. You can check its status using the kubectl command line.
 
 ```commandline


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/website/issues/171

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/187)
<!-- Reviewable:end -->
