### PR TITLE
Various updates to emphasize community resources

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,7 +42,7 @@ Paginate = 20
     weight = -100
     url = "/blog/"
 [[menu.main]]
-    name = "Github"
+    name = "GitHub"
     weight = -99
     url = "https://github.com/kubeflow/"
 

--- a/content/docs/about/community.md
+++ b/content/docs/about/community.md
@@ -7,7 +7,7 @@ bref= ""
 aliases = ["/docs/community/"]
 [menu.docs]
   parent = "about"
-  weight = 5
+  weight = 4
 +++
 
 In the interest of fostering an open and welcoming environment, we as
@@ -21,9 +21,49 @@ The Kubeflow community is guided by our [Code of
 Conduct](https://github.com/kubeflow/community/blob/master/CODE_OF_CONDUCT.md),
 which we encourage everybody to read before participating.
 
-* [Slack Channel](https://join.slack.com/t/kubeflow/shared_invite/enQtMjgyMzMxNDgyMTQ5LWUwMTIxNmZlZTk2NGU0MmFiNDE4YWJiMzFiOGNkZGZjZmRlNTExNmUwMmQ2NzMwYzk5YzQxOWQyODBlZGY2OTg)
+## Community discussions
+
+There are many ways to contribute! Join one of our communication channels, 
+attend a community meeting, get to know the community, discuss updates, suggest
+exciting new integrations.
+
+### Community meetings
+
+[**Meeting calendar**](https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com&ctz=America%2FLos_Angeles) ([iCal version](https://calendar.google.com/calendar/ical/kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com/public/basic.ics)).
+
+[Meeting notes](http://bit.ly/kf-meeting-notes).
+
+If your group has a regular meeting, talk to
+[@ewilderj](https://github.com/ewilderj) about getting it added to the calendar.
+
+### Kubeflow community call
+
+The project team holds a weekly community call on Tuesdays. This call alternates
+weekly between US East/EMEA and US West/APAC friendly times. Joining the
+[kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss)
+mailing list will automatically send you calendar invitations for the meetings, or you can subscribe to the community meeting calendar above.
+
+Agenda, notes, and a reminder of the next call are sent to the kubeflow-discuss
+mailing list.
+
+### Forums and mailing groups
+
+Summary:
+
+* [Invitation to our Slack channel](https://join.slack.com/t/kubeflow/shared_invite/enQtMjgyMzMxNDgyMTQ5LWUwMTIxNmZlZTk2NGU0MmFiNDE4YWJiMzFiOGNkZGZjZmRlNTExNmUwMmQ2NzMwYzk5YzQxOWQyODBlZGY2OTg)
 * [Twitter](http://twitter.com/kubeflow)
-* [Mailing List](https://groups.google.com/forum/#!forum/kubeflow-discuss)
+* [Mailing list: kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss)
+
+<br>
+More detail:
+
+| Topic                                                           | Mailing list                                                                      | Slack                                                                                             |
+| :----                                                           | :------------                                                                     | :-------------                                                                                    |
+| General discussion                                              | [kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss)      | [#general](https://kubeflow.slack.com/messages/C7REE0EHK)                                         |
+| TF Operator ([Github](https://github.com/kubeflow/tf-operator)) | [tf-operator](https://groups.google.com/a/kubeflow.org/forum/#!forum/tf-operator) | [#tf-operator](https://kubeflow.slack.com/messages/https://kubeflow.slack.com/messages/C985VJN9F) |
+| Community meeting chat                                          | n/a                                                                               | [#community](https://kubeflow.slack.com/messages/C8Q0QJYNB)                                       |
+
+Slack server: [kubeflow.slack.com](https://kubeflow.slack.com/)
 
 ## Who should consider contributing to Kubeflow?
 
@@ -31,6 +71,6 @@ which we encourage everybody to read before participating.
 * Folks who want to bring more Kubernetes magic to ML (e.g. ISTIO integration for prediction)
 * Folks who want to make Kubeflow a richer ML platform (e.g. support for ML pipelines, hyperparameter tuning)
 * Folks who want to tune Kubeflow for their particular Kubernetes distribution or Cloud
-* Folks who want to write tutorials/blog posts showing how to use Kubeflow to solve ML problems
+* Folks who want to write tutorials or blog posts showing how to use Kubeflow to solve ML problems
 
-For more details on contributing please look at [Contributing to Kubeflow](/docs/about/contributing/).
+For details on contributing please look at [the contributor's guide](/docs/about/contributing/).

--- a/content/docs/about/contributing.md
+++ b/content/docs/about/contributing.md
@@ -51,7 +51,7 @@ Please send a PR adding yourself to
   * The only **required** field is your GitHub username.
   * This is a **prerequisite** for joining the Kubeflow org on GitHub.
 
-### Companies/Organizations
+### Companies/organizations
 
 If you would like your company or organization to be acknowledged for contributing to
 Kubeflow or participatng in the community (being a user counts) please send a PR
@@ -62,7 +62,7 @@ adding the relevant info to
 
 There are many ways to contribute! Join one of our communication channels, 
 attend a community meeting, get to know the community. Read the details in
-our [community guide](docs/about/community).
+our [community guide](/docs/about/community).
 
 ## Your first contribution
 

--- a/content/docs/about/contributing.md
+++ b/content/docs/about/contributing.md
@@ -3,14 +3,15 @@ title =  "Contributing to Kubeflow"
 description = "Information on how to start contributing to Kubeflow"
 weight = 10
 toc = true
-bref = "Get involved"
+bref = "Welcome to the Kubeflow project! "
 aliases = ["/docs/contributing/"]
 [menu.docs]
   parent = "about"
   weight = 3
 +++
-## Kubeflow Contributor Guide
-Welcome to the Kubeflow project! This document is the single source of truth for how to contribute to the code base.
+## Getting started as a Kubeflow contributor
+
+This document is the single source of truth for how to contribute to the code base.
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
@@ -26,14 +27,42 @@ You generally only need to submit a CLA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it
 again.
 
-### Code of Conduct
+### Follow the code of conduct
 
 Please make sure to read and observe our [Code of Conduct](https://github.com/kubeflow/community/blob/master/CODE_OF_CONDUCT.md).
 
-### Call for Participation in Kubeflow User Research
+### Consider participating in Kubeflow user research
 
 Maggie Lynn, a user experience researcher, is conducting user studies to inform future developments for Kubeflow. These typically involve a one hour study session conducted online with a thank you gift for providing your feedback. As a member of the Kubeflow community, your feedback and expertise are extremely valuable to us, so if you have time in the next month, please consider participating. To gather your interest, availability, and some basic information about you, please fill out this form where you’ll find out more details about this research opportunity: [https://goo.gl/forms/sv5sRo3UfsgeUEjK2](https://goo.gl/forms/sv5sRo3UfsgeUEjK2)
 
+## Joining the community
+
+Follow these instructions if you want to
+
+* Become a member of the Kubeflow GitHub org (so you can trigger tests)
+* Become part of the Kubeflow build cop or release teams
+* Be recognized as an individual or organization contributing to Kubeflow
+
+### Individual contributors
+
+Please send a PR adding yourself to 
+[members](https://github.com/kubeflow/community/blob/master/members.yaml).
+
+  * The only **required** field is your GitHub username.
+  * This is a **prerequisite** for joining the Kubeflow org on GitHub.
+
+### Companies/Organizations
+
+If you would like your company or organization to be acknowledged for contributing to
+Kubeflow or participatng in the community (being a user counts) please send a PR
+adding the relevant info to
+[member_organizations.yaml](https://github.com/kubeflow/community/blob/master/member_organizations.yaml).
+
+### Community discussions
+
+There are many ways to contribute! Join one of our communication channels, 
+attend a community meeting, get to know the community. Read the details in
+our [community guide](docs/about/community).
 
 ## Your first contribution
 
@@ -47,33 +76,10 @@ should be fixed, you should own it. Here is how you get started.
 
 ### Starter issues
 
-Kubeflow issues that would make good entry points can be found by looking at
-the following tags:
+To find Kubeflow issues that make good entry points, look at the following tags:
 
 * [`good first issue`](https://github.com/kubeflow/kubeflow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 * [`help wanted`](https://github.com/kubeflow/kubeflow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-
-## Joining the community
-
-Follow these instructions if
-
-* You want to become a member of the Kubeflow GitHub org (so you can trigger tests)
-* Become part of the Kubeflow build cop or release teams
-* Be recognized as an individual or organization as contributing to Kubeflow
-
-### Individual contributors
-
-Please send a PR adding yourself to [members](https://github.com/kubeflow/community/blob/master/members.yaml)
-
-  * The only **required** field is your GitHub id
-  * This is a **prerequisite** for joining the GitHub org
-
-### Companies/Organizations
-
-If you would like your company or organization to be acknowledged for contributing to
-Kubeflow or participatng in the community (being a user counts) please send a PR
-adding the relevant info to[member_organizations.yaml](https://github.com/kubeflow/community/blob/master/member_organizations.yaml).
-
 
 ## Owners files and PR workflow
 
@@ -137,7 +143,7 @@ OWNERS_ALIAS files are in YAML format and support the following keys:
 We use aliases for groups instead of GitHub Teams, because changes to GitHub Teams are not
 publicly auditable.
 
-A sample OWNERS_ALISES file looks like:
+A sample OWNERS_ALIASES file looks like:
 
 ```
 aliases:
@@ -151,7 +157,7 @@ aliases:
 
 GitHub usernames and aliases listed in OWNERS files are case-insensitive.
 
-### The Code Review Process
+### The code review process
 
 - The **author** submits a PR
 - Phase 0: Automation suggests **reviewers** and **approvers** for the PR
@@ -182,16 +188,21 @@ GitHub usernames and aliases listed in OWNERS files are case-insensitive.
     [prow](https://prow.k8s.io) ([@k8s-ci-robot](https://github.com/k8s-ci-robot/)) applies an
     `approved` label
 - Phase 3: Automation merges the PR:
+
   - If all of the following are true:
-    - All required labels are present (eg: `lgtm`, `approved`)
-    - Any blocking labels are missing (eg: there is no `do-not-merge/hold`, `needs-rebase`)
+
+      - All required labels are present (eg: `lgtm`, `approved`)
+      - Any blocking labels are missing (eg: there is no `do-not-merge/hold`, `needs-rebase`)
+
   - And if any of the following are true:
-    - there are no presubmit prow jobs configured for this repo
-    - there are presubmit prow jobs configured for this repo, and they all pass after automatically
-      being re-run one last time
+
+      - there are no presubmit prow jobs configured for this repo
+      - there are presubmit prow jobs configured for this repo, and they all pass after automatically
+        being re-run one last time
+
   - Then the PR will automatically be merged
 
-### Quirks of the Process
+### Quirks of the process
 
 There are a number of behaviors we've observed that while _possible_ are discouraged, as they go
 against the intent of this review process.  Some of these could be prevented in the future, but this

--- a/content/docs/about/events.md
+++ b/content/docs/about/events.md
@@ -7,7 +7,7 @@ bref= ""
 aliases = ["/docs/events/"]
 [menu.docs]
   parent = "about"
-  weight = 4
+  weight = 5
 +++
 
 This is a nonexhaustive list of events (in reverse chronological order) with talks and workshops about Kubeflow.

--- a/content/docs/about/kubeflow.md
+++ b/content/docs/about/kubeflow.md
@@ -48,3 +48,10 @@ to use for each stage of the ML workflow: data preparation, model training,
 prediction serving, and service management.
 
 You can choose to deploy your workloads locally or to a cloud environment.
+
+## Getting involved
+
+There are many ways to contribute to Kubeflow, and we welcome contributions! 
+Read the [contributor's guide](/docs/about/contributing) to get started on the 
+code, and get to know the community in the 
+[community guide](/docs/about/community).

--- a/themes/kf/layouts/index.html
+++ b/themes/kf/layouts/index.html
@@ -74,7 +74,7 @@
 				</div>
 				<div class="text">
 					<h4>Community</h4>
-					<p>We are an open and welcoming community of software developers, data scientists and organizations that are working to make it easier to develop and deploy scalable ML workflows across the industry. <a href="/docs/about/contributing/">Start contributing.</a>
+					<p>We are an open and welcoming community of software developers, data scientists, and organizations that are working to make it easier to develop and deploy scalable ML workflows across the industry. <a href="/docs/about/contributing/">Start contributing.</a>
 				</div>
 			</div>
 

--- a/themes/kf/layouts/index.html
+++ b/themes/kf/layouts/index.html
@@ -10,6 +10,7 @@
 				<h1>Kubeflow</h1>
 				<h5>The Machine Learning Toolkit for Kubernetes</h5>
 				<a class="button" href="/docs/started/getting-started/">Get Started</a>
+				<a class="button" href="/docs/about/contributing/">Contribute</a>
 			</div>
 
 		</section>


### PR DESCRIPTION
Fixes #185 which requests that we make it easier to find community resources on the website:

* Adds a **Contribute** button to the front page of the site, linking to the contributor's guide.
* Adds a section in the contributor's guide about the community page.
* Moves the community page higher in the list of "about" pages.
* Updates the info on the community page.
* Adds a section on the Kubeflow page about the community and contributor's guides.
* Makes various small improvements to the contributor's guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/203)
<!-- Reviewable:end -->
