### PR TITLE
Renaming tf-hub to jupyterhub

### DIFF
--- a/content/docs/guides/components/jupyter.md
+++ b/content/docs/guides/components/jupyter.md
@@ -23,8 +23,8 @@ kubectl get svc -n=${NAMESPACE}
 
 NAME               TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
 ...
-tf-hub-0           ClusterIP      None            <none>        8000/TCP       1m
-tf-hub-lb          ClusterIP      10.11.245.94    <none>        80/TCP         1m
+jupyterhub-0           ClusterIP      None            <none>        8000/TCP       1m
+jupyterhub-lb          ClusterIP      10.11.245.94    <none>        80/TCP         1m
 ...
 ```
 
@@ -47,7 +47,7 @@ however this will leave your Jupyter notebook open to the Internet.
 To connect to your [Jupyter Notebook](http://jupyter.org/index.html) locally:
 
 ```
-PODNAME=`kubectl get pods --namespace=${NAMESPACE} --selector="app=tf-hub" --output=template --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`
+PODNAME=`kubectl get pods --namespace=${NAMESPACE} --selector="app=jupyterhub" --output=template --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`
 kubectl port-forward --namespace=${NAMESPACE} $PODNAME 8000:8000
 ```
 

--- a/content/docs/guides/components/jupyter.md
+++ b/content/docs/guides/components/jupyter.md
@@ -23,8 +23,8 @@ kubectl get svc -n=${NAMESPACE}
 
 NAME               TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
 ...
-jupyterhub-0           ClusterIP      None            <none>        8000/TCP       1m
-jupyterhub-lb          ClusterIP      10.11.245.94    <none>        80/TCP         1m
+jupyterhub-0       ClusterIP      None            <none>        8000/TCP       1m
+jupyterhub-lb      ClusterIP      10.11.245.94    <none>        80/TCP         1m
 ...
 ```
 

--- a/content/docs/started/getting-started-minikube.md
+++ b/content/docs/started/getting-started-minikube.md
@@ -193,8 +193,8 @@ ambassador         ClusterIP   10.97.168.31     <none>        80/TCP     1m
 ambassador-admin   ClusterIP   10.99.5.81       <none>        8877/TCP   1m
 centraldashboard   ClusterIP   10.111.104.142   <none>        80/TCP     1m
 k8s-dashboard      ClusterIP   10.102.65.244    <none>        443/TCP    1m
-tf-hub-0           ClusterIP   None             <none>        8000/TCP   1m
-tf-hub-lb          ClusterIP   10.101.15.28     <none>        80/TCP     1m
+jupyterhub-0           ClusterIP   None             <none>        8000/TCP   1m
+jupyterhub-lb          ClusterIP   10.101.15.28     <none>        80/TCP     1m
 tf-job-dashboard   ClusterIP   10.106.133.49    <none>        80/TCP     1m
 ```
 
@@ -202,7 +202,7 @@ Setup port forwarding for the central dashboard UI and Jupyter Hub
 ```
 $ POD=`kubectl -n kubeflow get pods --selector=service=ambassador | awk '{print $1}' | tail -1`
 $ kubectl -n kubeflow port-forward $POD 8080:80 2>&1 >/dev/null &
-$ POD=`kubectl -n kubeflow get pods --selector=app=tf-hub | awk '{print $1}' | tail -1`
+$ POD=`kubectl -n kubeflow get pods --selector=app=jupyterhub | awk '{print $1}' | tail -1`
 $ kubectl -n kubeflow port-forward $POD 8000:8000 2>&1 >/dev/null &
 ```
 Now you can access the Kubeflow dashboard at http://localhost:8080/ and JupyterHub at http://localhost:8000/.

--- a/content/docs/started/getting-started-minikube.md
+++ b/content/docs/started/getting-started-minikube.md
@@ -193,8 +193,8 @@ ambassador         ClusterIP   10.97.168.31     <none>        80/TCP     1m
 ambassador-admin   ClusterIP   10.99.5.81       <none>        8877/TCP   1m
 centraldashboard   ClusterIP   10.111.104.142   <none>        80/TCP     1m
 k8s-dashboard      ClusterIP   10.102.65.244    <none>        443/TCP    1m
-jupyterhub-0           ClusterIP   None             <none>        8000/TCP   1m
-jupyterhub-lb          ClusterIP   10.101.15.28     <none>        80/TCP     1m
+jupyterhub-0       ClusterIP   None             <none>        8000/TCP   1m
+jupyterhub-lb      ClusterIP   10.101.15.28     <none>        80/TCP     1m
 tf-job-dashboard   ClusterIP   10.106.133.49    <none>        80/TCP     1m
 ```
 


### PR DESCRIPTION
Follow up updates in regards to https://github.com/kubeflow/kubeflow/pull/1410, changing tf-hub to jupyterhub and tf-hub-lb to jupyterhub-lb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/243)
<!-- Reviewable:end -->
