### PR TITLE
update kube-arbitrator to kube-batch in the doc

### DIFF
--- a/content/docs/guides/job-scheduling.md
+++ b/content/docs/guides/job-scheduling.md
@@ -3,7 +3,7 @@ title = "Job Scheduling"
 description = "Schedule job with gang-scheduling"
 weight = 10
 toc = true
-bref = "This guide describes how to use kube-arbitrator to support gang-scheduling in Kubeflow, to allow jobs to run multiple pods at the same time."
+bref = "This guide describes how to use kube-batch to support gang-scheduling in Kubeflow, to allow jobs to run multiple pods at the same time."
 
 [menu.docs]
   parent = "guides"
@@ -11,14 +11,14 @@ bref = "This guide describes how to use kube-arbitrator to support gang-scheduli
 +++
 
 ## Running jobs with gang-scheduling
-To use gang-scheduling, you have to install kube-arbitrator in your cluster first as a secondary scheduler of Kubernetes and configure operator to enable gang-scheduling. 
+To use gang-scheduling, you have to install kube-batch in your cluster first as a secondary scheduler of Kubernetes and configure operator to enable gang-scheduling. 
 
-* Kube-arbitrator's introduction is [here](https://github.com/kubernetes-incubator/kube-arbitrator), and also check how to install it [here](https://github.com/kubernetes-incubator/kube-arbitrator/blob/master/doc/usage/tutorial.md).
+* Kube-batch's introduction is [here](https://github.com/kubernetes-sigs/kube-batch), and also check how to install it [here](https://github.com/kubernetes-sigs/kube-batch/blob/master/doc/usage/tutorial.md).
 * Take tf-operator for example, enable gang-scheduling in tf-operator by setting true to `--enable-gang-scheduling` flag.
 
-**Note:** Kube-arbitrator and operator in Kubeflow achieve gang-scheduling by using pdb. operator will create the pdb of the job automatically. You can know more about pdb [here](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
+**Note:** Kube-batch and operator in Kubeflow achieve gang-scheduling by using pdb. operator will create the pdb of the job automatically. You can know more about pdb [here](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
 
-To use kube-arbitrator to schedule your job as a gang, you have to specify the schedulerName in each replica; for example.
+To use kube-batch to schedule your job as a gang, you have to specify the schedulerName in each replica; for example.
 
 ```yaml
 apiVersion: "kubeflow.org/v1alpha2"
@@ -77,22 +77,16 @@ spec:
           restartPolicy: OnFailure
 ```
 
-## About kube-arbitrator and gang-scheduling
-With using kube-arbitrator to apply gang-scheduling, a job can run only if there are enough resources for all the pods of the job. Otherwise, all the pods will be in pending state waiting for enough resources. For example, if a job requiring N pods is created and there are only enough resources to schedule N-2 pods, then N pods of the job will stay pending.
+## About kube-batch and gang-scheduling
+With using kube-batch to apply gang-scheduling, a job can run only if there are enough resources for all the pods of the job. Otherwise, all the pods will be in pending state waiting for enough resources. For example, if a job requiring N pods is created and there are only enough resources to schedule N-2 pods, then N pods of the job will stay pending.
 
 **Note:** when in a high workload, if a pod of the job dies when the job is still running, it might give other pods chance to occupied the resources and cause deadlock. 
 
 ## Troubleshooting 
 
-If you keep getting logs like below in your kube-arbitrator.
-```
-I0910 10:27:16.745314       1 reflector.go:240] Listing and watching *v1alpha1.PodGroup from github.com/kubernetes-incubator/kube-arbitrator/pkg/scheduler/cache/cache.go:243
-E0910 10:27:16.747168       1 reflector.go:205] github.com/kubernetes-incubator/kube-arbitrator/pkg/scheduler/cache/cache.go:243: Failed to list *v1alpha1.PodGroup: podgroups.scheduling.incubator.k8s.io is forbidden: User "system:serviceaccount:kube-system:my-scheduler" cannot list podgroups.scheduling.incubator.k8s.io at the cluster scope
-I0910 10:27:17.747374       1 reflector.go:240] Listing and watching *v1alpha1.PodGroup from github.com/kubernetes-incubator/kube-arbitrator/pkg/scheduler/cache/cache.go:243
-E0910 10:27:17.748986       1 reflector.go:205] github.com/kubernetes-incubator/kube-arbitrator/pkg/scheduler/cache/cache.go:243: Failed to list *v1alpha1.PodGroup: podgroups.scheduling.incubator.k8s.io is forbidden: User "system:serviceaccount:kube-system:my-scheduler" cannot list podgroups.scheduling.incubator.k8s.io at the cluster scope
-```
+If you keep getting problems related to RBAC in your kube-batch.
 
-You can just add the following rules into your clusterrole of scheduler used by kube-arbitrator.
+You can try to add the following rules into your clusterrole of scheduler used by kube-batch.
 ```
 - apiGroups:
   - '*'

--- a/content/docs/guides/job-scheduling.md
+++ b/content/docs/guides/job-scheduling.md
@@ -31,7 +31,7 @@ spec:
       replicas: 1
       template:
         spec:
-          schedulerName: kube-batchd
+          schedulerName: kube-batch
           containers:
           - args:
             - python
@@ -55,7 +55,7 @@ spec:
       replicas: 1
       template:
         spec:
-          schedulerName: kube-batchd
+          schedulerName: kube-batch
           containers:
           - args:
             - python


### PR DESCRIPTION
According to the discussion in [kubernetes/org#112](https://github.com/kubernetes/org/issues/112), we changed the name from kube-arbitrator to kube-batch. So this PR update the doc to keep consistency.

Fix the issue [kubeflow/tf-operator#837](https://github.com/kubeflow/tf-operator/issues/837)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/253)
<!-- Reviewable:end -->
