### PR TITLE
Fix version in download.sh

### DIFF
--- a/content/docs/started/getting-started-gke.md
+++ b/content/docs/started/getting-started-gke.md
@@ -83,7 +83,7 @@ Run the following steps to deploy Kubeflow:
     mkdir ${KUBEFLOW_SRC}
     cd ${KUBEFLOW_SRC}
     export KUBEFLOW_TAG={{% kf-stable-tag %}}
-    curl https://raw.githubusercontent.com/kubeflow/kubeflow/{{< params "githubbranch" >}}/scripts/download.sh | bash
+    curl https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh | bash
      ```
    * **KUBEFLOW_SRC** directory where you want to download the source to
    * **KUBEFLOW_TAG** a tag corresponding to the version to checkout such as `master` for latest code.

--- a/content/docs/started/getting-started-minikube.md
+++ b/content/docs/started/getting-started-minikube.md
@@ -216,7 +216,7 @@ The following steps will deploy Kubeflow components and start them on the Miniku
     mkdir ${KUBEFLOW_SRC}
     cd ${KUBEFLOW_SRC}
     export KUBEFLOW_TAG=v0.3.0
-    curl https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_VERSION}/scripts/download.sh | bash
+    curl https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh | bash
     ```
     - **KUBEFLOW_SRC** is the directory where you want to download the source
     - **KUBEFLOW_TAG** is a tag corresponding to the version to checkout such as `v0.3.0`


### PR DESCRIPTION
* We want to use KUBEFLOW_TAG in the URL so we use the download.sh script
  on the release branch.

Fix kubeflow/kubeflow#1738
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/257)
<!-- Reviewable:end -->
