### PR TITLE
KUBEFLOW_REPO should be full path

### DIFF
--- a/content/docs/started/getting-started-gke.md
+++ b/content/docs/started/getting-started-gke.md
@@ -84,8 +84,9 @@ Run the following steps to deploy Kubeflow:
     cd ${KUBEFLOW_REPO}
     export KUBEFLOW_TAG={{% kf-stable-tag %}}
     curl https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh | bash
+    cd ..
      ```
-   * **KUBEFLOW_REPO** directory where you want to download the source to
+   * **KUBEFLOW_REPO** full path to the directory where you want to download the source to
    * **KUBEFLOW_TAG** a tag corresponding to the version to checkout such as `master` for latest code.
    * **Note** you can also just clone the repository using git.
 1. Run the following scripts to set up and deploy Kubeflow:


### PR DESCRIPTION
Making it explicit that KUBEFLOW_REPO should be the full path not just a name. I also added `cd ..` so that the users can run the following commands to deploy Kubeflow into GKE:
```
mkdir ${KUBEFLOW_REPO}
    cd ${KUBEFLOW_REPO}
    export KUBEFLOW_TAG={{% kf-stable-tag %}}
    curl https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh | bash
    cd ..
    ${KUBEFLOW_REPO}/scripts/kfctl.sh init ${KFAPP} --platform gcp --project ${PROJECT}
    cd ${KFAPP}
    ${KUBEFLOW_REPO}/scripts/kfctl.sh generate platform
    ${KUBEFLOW_REPO}/scripts/kfctl.sh apply platform
    ${KUBEFLOW_REPO}/scripts/kfctl.sh generate k8s
    ${KUBEFLOW_REPO}/scripts/kfctl.sh apply k8s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/273)
<!-- Reviewable:end -->
