### PR TITLE
Fixing Blog title and menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,7 +43,7 @@ Paginate = 20
     weight = -101
     url = "/docs/about/kubeflow/"
 [[menu.main]]
-    name = "Additional Resources"
+    name = "Blog"
     weight = -100
     url = "/blog/"
 [[menu.main]]

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,4 +1,4 @@
 +++
-title = "Blog, Talks & Videos"
+title = "The Kubeflow Blog"
 description = ""
 +++


### PR DESCRIPTION
Flixing blog menu item and the title on the blog page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/281)
<!-- Reviewable:end -->
