### PR TITLE
Fix Broken Link

### DIFF
--- a/content/docs/guides/gke/customizing-gke.md
+++ b/content/docs/guides/gke/customizing-gke.md
@@ -93,10 +93,10 @@ To use VMs with more CPUs or RAM:
 
 To grant additional users IAM permissions to access Kubeflow:
 
-  * Add the users by editing [cluster-kubeflow.yaml](https://github.com/kubeflow/kubeflow/blob/{{< params "githubbranch" >}}/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml#L74).
+  * Add users by editing [cluster-kubeflow.yaml](https://github.com/kubeflow/kubeflow/blob/{{< params "githubbranch" >}}/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml#L74).
 
 
-By default, this file can be found at `${KUBEFLOW_REPO}/kubeflow/gcp_config/cluster-kubeflow.yaml` after your first deployment. After making changes to the file, you'll need to apply them:
+By default, this file will be located at `${KUBEFLOW_REPO}/kubeflow/gcp_config/cluster-kubeflow.yaml` after your first deployment. After making changes to the file, you'll need to apply them:
 
 ```
 cd ${KFAPP}

--- a/content/docs/guides/gke/customizing-gke.md
+++ b/content/docs/guides/gke/customizing-gke.md
@@ -93,10 +93,10 @@ To use VMs with more CPUs or RAM:
 
 To grant additional users IAM permissions to access Kubeflow:
 
-  * Add the users [here](https://github.com/kubeflow/kubeflow/blob/{{< params "githubbranch" >}}/scripts/gke/deployment_manager_configs/cluster-kubeflow.yaml#L61).
+  * Add the users by editing [cluster-kubeflow.yaml](https://github.com/kubeflow/kubeflow/blob/{{< params "githubbranch" >}}/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml#L74).
 
 
-After making the changes you need to recreate your deployment:
+By default, this file can be found at `${KUBEFLOW_REPO}/kubeflow/gcp_config/cluster-kubeflow.yaml` after your first deployment. After making changes to the file, you'll need to apply them:
 
 ```
 cd ${KFAPP}

--- a/content/docs/guides/gke/troubleshooting-gke.md
+++ b/content/docs/guides/gke/troubleshooting-gke.md
@@ -43,7 +43,7 @@ This section provides troubleshooting information for 404s, page not found, bein
    envoy-76774f8d5c-sg555   2/2       Running   2          4m
    ```
 
-* Try other services to see if their accessible e.g
+* Try other services to see if they're accessible e.g
 
    ```
    https://${KUBEFLOW_FQDN}/whoami


### PR DESCRIPTION
The link to cluster-kubeflow.yaml is broken for 0.3.  I think this section should be more emphasized in the docs at some point, but I wanted to make sure the link was at least up to date for now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/287)
<!-- Reviewable:end -->
