### PR TITLE
Use right S3 API Endpoint to avoid hostname can not resolve issue

### DIFF
--- a/content/docs/guides/components/tfserving_new.md
+++ b/content/docs/guides/components/tfserving_new.md
@@ -95,7 +95,7 @@ ks param set ${MODEL_COMPONENT} s3UseHttps true
 ks param set ${MODEL_COMPONENT} s3VerifySsl true
 
 # URL for your s3-compatible endpoint.
-ks param set ${MODEL_COMPONENT} s3Endpoint http://s3.us-west-1.amazonaws.com
+ks param set ${MODEL_COMPONENT} s3Endpoint s3.us-west-1.amazonaws.com
 ```
 
 ### Using GPU


### PR DESCRIPTION
`http://` protocol is not helpful here and leads TF-Serving fail to downloads model bits. 

Logs:

```
2018-12-10 05:52:56.685207: I external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:54] Found secret key
2018-12-10 05:52:56.685308: I external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:54] Pool grown by 2
2018-12-10 05:52:56.685333: I external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:54] Connection has been released. Continuing.
2018-12-10 05:52:56.744106: E external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:60] Curl returned error code 6
2018-12-10 05:52:56.744211: W external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:57] If the signature check failed. This could be because of a time skew. Attempting to adjust the signer.
2018-12-10 05:52:56.744261: W external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:57] Request failed, now waiting 0 ms before attempting again.
2018-12-10 05:52:56.744652: I external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:54] Found secret key
2018-12-10 05:52:56.744810: I external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:54] Connection has been released. Continuing.
2018-12-10 05:52:56.753441: E external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:60] Curl returned error code 6
2018-12-10 05:52:56.753555: W external/org_tensorflow/tensorflow/core/platform/s3/aws_logging.cc:57] If the signature check failed. This could be because of a time skew. Attempting to adjust the signer.

```

Curl returned error code 6 - CURLE_COULDNT_RESOLVE_HOST (6) means `Couldn't resolve host. The given remote host was not resolved.`


Based on official documentation [here](https://www.tensorflow.org/deploy/s3) . We should delete `http://` header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/346)
<!-- Reviewable:end -->
