### PR TITLE
correct link for viewers in pipelines-ui page

### DIFF
--- a/content/docs/guides/pipelines/pipelines-ui.md
+++ b/content/docs/guides/pipelines/pipelines-ui.md
@@ -122,7 +122,7 @@ the page displaying the name of the run and containing its own three tabs:
 ### Artifacts
 
 Artifacts are any 
-[viewers](docs/guides/pipelines/output-viewers) associated with a given 
+[viewers](/docs/guides/pipelines/output-viewer) associated with a given 
 component. There are many kinds of viewers including: 
 
 * TensorBoard instances (accessible via link)


### PR DESCRIPTION
The viewer link is not right, link to unknown page. 
The PR to correct the link to reasonable page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/356)
<!-- Reviewable:end -->
