### PR TITLE
updateKubeflow Pipelines SDK version

### DIFF
--- a/content/docs/guides/pipelines/build-pipeline.md
+++ b/content/docs/guides/pipelines/build-pipeline.md
@@ -110,7 +110,7 @@ export PATH=MINICONDA_PATH/bin:$PATH
 Run the following to install the Kubeflow Pipelines SDK:
 
 ```bash
-pip3 install https://storage.googleapis.com/ml-pipeline/release/0.1.2/kfp.tar.gz --upgrade
+pip3 install https://storage.googleapis.com/ml-pipeline/release/0.1.7/kfp.tar.gz --upgrade
 ```
 
 After successful installation the command `dsl-compile` should be added to your 


### PR DESCRIPTION
As 0.1.2 version will met problem when compile sample in https://github.com/kubeflow/pipelines/tree/master/samples, update to latest version.