### PR TITLE
clarify that KFAPP should not be a path

### DIFF
--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -71,7 +71,7 @@ Download, set up, and deploy (If you prefer to work from source code, feel free 
     ${KUBEFLOW_SRC}/scripts/kfctl.sh generate k8s
     ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
     ```
-   * **${KFAPP}** the _name_ of a directory where you want kubeflow configurations to be stored. This directory will be created when you run init.
+   * **${KFAPP}** the name for the kubeflow deployment (shouldn't be a path). A directory with the name will be created under `pwd` when you run init, and that is where kubeflow configurations will be stored.
       * The ksonnet app will be created in the directory **${KFAPP}/ks_app**
    * (optional) For GPU support, make sure your cluster is in a [zone that has GPUs](https://cloud.google.com/compute/docs/regions-zones/). To set the zone explicitly, append `--zone ${ZONE}` to the `init` command.
 


### PR DESCRIPTION
KFAPP cannot be a path based on [kfctl.sh](https://github.com/kubeflow/kubeflow/blob/master/scripts/kfctl.sh#L325-L354). `cd ${KFAPP}` may mislead user to name it as a path. We should clarify what it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/431)
<!-- Reviewable:end -->
