### PR TITLE
Added optional instructions on how to change the service type

### DIFF
--- a/content/docs/components/tfserving_new.md
+++ b/content/docs/components/tfserving_new.md
@@ -16,6 +16,7 @@ Generate the service(model) component
 ks generate tf-serving-service mnist-service
 ks param set mnist-service modelName mnist    // match your deployment mode name
 ks param set mnist-service trafficRule v1:100    // optional, it's the default value
+ks param set mnist-service serviceType LoadBalancer    // optional, change type to LoadBalancer to expose external IP
 ```
 
 Generate the deployment(version) component


### PR DESCRIPTION
Added additional optional instructions on how to change the service type of the model service, should give some users a hint on how to expose the external IP. Per default this param seems to be set to ClusterIP, which only exposes internal IP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/440)
<!-- Reviewable:end -->
