### PR TITLE
Update tftraining.md

### DIFF
--- a/content/docs/components/tftraining.md
+++ b/content/docs/components/tftraining.md
@@ -171,7 +171,7 @@ Choose a tf-job prototype from the following list of available prototypes, to ma
 
 Run the `generate` command:
 ```
-ks generate tf-job-simple-v1beta1 ${CNN_JOB_NAME} --name=${CNN_JOB_NAME}
+ks generate tf-job-simple ${CNN_JOB_NAME} --name=${CNN_JOB_NAME}
 ```
 
 Submit it
@@ -183,7 +183,7 @@ ks apply ${KF_ENV} -c ${CNN_JOB_NAME}
 Monitor it (Please refer to the [TfJob docs](https://github.com/kubeflow/tf-operator#monitoring-your-job))
 
 ```
-kubectl get -o yaml tfjobs ${CNN_JOB_NAME}
+kubectl get -o yaml tfjobs ${CNN_JOB_NAME} -n kubeflow
 ```
 
 Delete it

--- a/content/docs/components/tftraining.md
+++ b/content/docs/components/tftraining.md
@@ -183,7 +183,7 @@ ks apply ${KF_ENV} -c ${CNN_JOB_NAME}
 Monitor it (Please refer to the [TfJob docs](https://github.com/kubeflow/tf-operator#monitoring-your-job))
 
 ```
-kubectl get -o yaml tfjobs ${CNN_JOB_NAME} -n kubeflow
+kubectl get -n kubeflow -o yaml tfjobs ${CNN_JOB_NAME}
 ```
 
 Delete it


### PR DESCRIPTION
1.  `ks generate tf-job-simple-v1beta1 ${CNN_JOB_NAME} --name=${CNN_JOB_NAME}` will cause error:

```
ERROR handle object: patching object from cluster: merging object with existing state: unable to recognize "/tmp/ksonnet-mergepatch596037217": no matches for kind "TFJob" in version "kubeflow.org/v1beta1"
```

And tfjobs that created is with namespace 'kubeflow'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/453)
<!-- Reviewable:end -->
