### PR TITLE
 Sets Hugo prod environment in Netlify to trigger indexing of site.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,4 +8,3 @@
 [context.production.environment]
   HUGO_VERSION = "0.51"
   HUGO_ENV = "production"
-  

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,5 @@
 
 [context.production.environment]
   HUGO_VERSION = "0.51"
+  HUGO_ENV = "production"
+  


### PR DESCRIPTION
Our website has never been indexed. This may be one of the causes of our low SEO (issue https://github.com/kubeflow/website/issues/98). The lack of index also makes our upcoming search page (PR https://github.com/kubeflow/website/pull/471) empty.

By adding the production environment config to the Netlify build, this PR should result in the site index being built.

See info:
https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify

I'm submitting this change in a separate PR from the search box PR, because it may take a day or two before the index is built and search results start appearing.

The setting of the production environment may also trigger the creation of the `sitemap.xml` file, in which case I won't need to do that in PR https://github.com/kubeflow/website/pull/473.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/475)
<!-- Reviewable:end -->
