### PR TITLE
update doc to point reasonable line

### DIFF
--- a/content/docs/pipelines/pipelines-metrics.md
+++ b/content/docs/pipelines/pipelines-metrics.md
@@ -24,7 +24,7 @@ To enable metrics, you need to write a file `/mlpipeline-metrics.json`. For exam
   with file_io.FileIO('/mlpipeline-metrics.json', 'w') as f:
     json.dump(metrics, f)
 ```
-See the [full example](https://github.com/kubeflow/pipelines/blob/master/components/local/confusion_matrix/src/confusion_matrix.py#L78).
+See the [full example](https://github.com/kubeflow/pipelines/blob/master/components/local/confusion_matrix/src/confusion_matrix.py#L90).
 
 There are several conventions on the metrics file:
 


### PR DESCRIPTION
In [Pipeline metrics](https://www.kubeflow.org/docs/pipelines/pipelines-metrics/) guide, there is a link issue which is point to unreasonable line. Correct that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/478)
<!-- Reviewable:end -->
