### PR TITLE
Update getting-started.md to fix the broken download script link

### DIFF
--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -60,7 +60,7 @@ Download, set up, and deploy. (If you prefer to work from source code, feel free
     mkdir ${KUBEFLOW_SRC}
     cd ${KUBEFLOW_SRC}
     export KUBEFLOW_TAG={{% kf-stable-tag %}}
-    curl https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh | bash
+    curl https://raw.githubusercontent.com/kubeflow/kubeflow/v${KUBEFLOW_TAG}/scripts/download.sh | bash
      ```
    * **KUBEFLOW_SRC** a directory where you want to download the source to
    * **KUBEFLOW_TAG** a tag corresponding to the version to check out, such as `master` for the latest code.


### PR DESCRIPTION
The link to get the kubeflow install script is incorrect: "v" is required before ${KUBEFLOW_TAG}.
Tested with KUBEFLOW_TAG = 0.3.5 and 0.4.1 - both give 404 not found with the given link
With this link, the file is found:
curl https://raw.githubusercontent.com/kubeflow/kubeflow/v${KUBEFLOW_TAG}/scripts/download.sh | bash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/486)
<!-- Reviewable:end -->
