### PR TITLE
Added base URL to sitemap.

### DIFF
--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,7 +2,7 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
   <url>
-    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>https://www.kubeflow.org{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}


### PR DESCRIPTION
Google Search Console does not recognise the format of the URLs in our sitemap. Error given:

```
This is not a valid URL. Please correct it and resubmit.
Examples

URL:
/docs/about/
Line 6
Parent tag:
url
Tag:
loc

URL:
/docs/gke/customizing-gke/
Line 11
Parent tag:
url
Tag:
loc

URL:
/docs/started/getting-started/
Line 16
Parent tag:
url
Tag:
loc
```

To fix this, I'm inserting the URL directly into the sitemap template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/508)
<!-- Reviewable:end -->
