### PR TITLE
Added the framework for API references.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -132,7 +132,7 @@ githubbranch = "master"
 # Docsy: User interface configuration
 [params.ui]
 # Docsy: Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 #  Docsy: Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 

--- a/content/docs/components/tftraining.md
+++ b/content/docs/components/tftraining.md
@@ -729,4 +729,6 @@ Events:
    in the previous section.
 
 ## More information
+
+* Explore the [TFJob reference documentation](/docs/reference#tfjob).
 * See how to [run a job with gang-scheduling](/docs/other-guides/job-scheduling).

--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Reference"
-description = "Reference documentation for Kubeflow APIs and services."
-weight = 20
+description = "Reference documentation for Kubeflow."
+weight = 900
 +++
 
 <a id="tfjob">
@@ -14,4 +14,5 @@ using TFJob with Kubeflow, see the [user guide](/docs/components/tftraining/).
 
 API references:
 
+  * [v1beta1](/docs/reference/tfjob/v1beta1/tensorflow/)
   * [v1beta2](/docs/reference/tfjob/v1beta2/tensorflow/)

--- a/content/docs/reference/index.md
+++ b/content/docs/reference/index.md
@@ -1,0 +1,17 @@
++++
+title = "Reference"
+description = "Reference documentation for Kubeflow APIs and services."
+weight = 20
++++
+
+<a id="tfjob">
+## TFJob
+
+TFJob is a Kubernetes 
+[custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+that you can use to run TensorFlow training jobs on Kubernetes. For help with
+using TFJob with Kubeflow, see the [user guide](/docs/components/tftraining/).
+
+API references:
+
+  * [v1beta2](/docs/reference/tfjob/v1beta2/tensorflow/)

--- a/content/docs/reference/overview.md
+++ b/content/docs/reference/overview.md
@@ -1,0 +1,19 @@
++++
+title = "Reference Overview"
+description = "Reference documentation for Kubeflow APIs and services."
+weight = 1
+
++++
+
+<a id="tfjob">
+## TFJob
+
+TFJob is a Kubernetes 
+[custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+that you can use to run TensorFlow training jobs on Kubernetes. For help with
+using TFJob with Kubeflow, see the [user guide](/docs/components/tftraining/).
+
+API references:
+
+  * [v1beta1](/docs/reference/tfjob/v1beta1/tensorflow/)
+  * [v1beta2](/docs/reference/tfjob/v1beta2/tensorflow/)

--- a/content/docs/reference/tfjob/_index.md
+++ b/content/docs/reference/tfjob/_index.md
@@ -1,0 +1,5 @@
++++
+title = "TFJob Reference"
+description = "Reference documentation for the TFJob custom resource."
+weight = 10
++++

--- a/content/docs/reference/tfjob/v1beta1/_index.md
+++ b/content/docs/reference/tfjob/v1beta1/_index.md
@@ -1,0 +1,5 @@
++++
+title = "TFJob v1beta1"
+description = "Reference documentation for version v1beta1 of the TFJob custom resource."
+weight = 10
++++

--- a/content/docs/reference/tfjob/v1beta2/_index.md
+++ b/content/docs/reference/tfjob/v1beta2/_index.md
@@ -1,0 +1,5 @@
++++
+title = "TFJob v1beta2"
+description = "Reference documentation for version v1beta2 of the TFJob custom resource."
+weight = 10
++++


### PR DESCRIPTION
I've added an index page for API references, in preparation for the TFJob reference described in issue https://github.com/kubeflow/tf-operator/issues/731

I've also added a link from the TFJob user guide to the (upcoming) reference, and configured a compact left-hand nav to make it easier to see all the doc sections.

Note that this PR isn't ready to submit, as it assumes the existence of the v1beta2 API reference for TFJob.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/514)
<!-- Reviewable:end -->
