### PR TITLE
Add instructions for running API reference generation tool

### DIFF
--- a/content/docs/reference/tfjob/v1beta1/common.md
+++ b/content/docs/reference/tfjob/v1beta1/common.md
@@ -11,7 +11,7 @@ weight = 100
 </ul>
 <h2 id="kubeflow.org">kubeflow.org</h2>
 <p>
-<p>Package v1beta2 is the v1beta2 version of the API.</p>
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
 </p>
 Resource Types:
 <ul></ul>
@@ -153,7 +153,7 @@ Kubernetes meta/v1.Time
 <code>replicaStatuses</code></br>
 <em>
 <a href="#ReplicaStatus">
-map[github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2.ReplicaType]*github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2.ReplicaStatus
+map[github.com/kubeflow/tf-operator/pkg/apis/common/v1beta1.ReplicaType]*github.com/kubeflow/tf-operator/pkg/apis/common/v1beta1.ReplicaStatus
 </a>
 </em>
 </td>
@@ -339,5 +339,5 @@ is RestartPolicyAlways.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>20ef37df</code>.
+on git commit <code>a91cddc3</code>.
 </em></p>

--- a/content/docs/reference/tfjob/v1beta1/tensorflow.md
+++ b/content/docs/reference/tfjob/v1beta1/tensorflow.md
@@ -222,5 +222,5 @@ For example,
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>20ef37df</code>.
+on git commit <code>a91cddc3</code>.
 </em></p>

--- a/content/docs/reference/tfjob/v1beta1/tensorflow.md
+++ b/content/docs/reference/tfjob/v1beta1/tensorflow.md
@@ -81,7 +81,7 @@ TFJobSpec
 <code>cleanPodPolicy</code></br>
 <em>
 <a href="/docs/reference/tfjob/v1beta1/common/#CleanPodPolicy">
-github.com/kubeflow/tf-operator/pkg/apis/common/v1beta1.CleanPodPolicy
+common/v1beta1.CleanPodPolicy
 </a>
 </em>
 </td>
@@ -133,7 +133,7 @@ For example,
 <code>status</code></br>
 <em>
 <a href="/docs/reference/tfjob/v1beta1/common/#JobStatus">
-github.com/kubeflow/tf-operator/pkg/apis/common/v1beta1.JobStatus
+common/v1beta1.JobStatus
 </a>
 </em>
 </td>
@@ -168,7 +168,7 @@ Read-only.</p>
 <code>cleanPodPolicy</code></br>
 <em>
 <a href="/docs/reference/tfjob/v1beta1/common/#CleanPodPolicy">
-github.com/kubeflow/tf-operator/pkg/apis/common/v1beta1.CleanPodPolicy
+common/v1beta1.CleanPodPolicy
 </a>
 </em>
 </td>

--- a/content/docs/reference/tfjob/v1beta2/common.md
+++ b/content/docs/reference/tfjob/v1beta2/common.md
@@ -339,5 +339,5 @@ is RestartPolicyAlways.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>20ef37df</code>.
+on git commit <code>a91cddc3</code>.
 </em></p>

--- a/content/docs/reference/tfjob/v1beta2/tensorflow.md
+++ b/content/docs/reference/tfjob/v1beta2/tensorflow.md
@@ -222,5 +222,5 @@ For example,
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>20ef37df</code>.
+on git commit <code>a91cddc3</code>.
 </em></p>

--- a/content/docs/reference/tfjob/v1beta2/tensorflow.md
+++ b/content/docs/reference/tfjob/v1beta2/tensorflow.md
@@ -81,7 +81,7 @@ TFJobSpec
 <code>cleanPodPolicy</code></br>
 <em>
 <a href="/docs/reference/tfjob/v1beta2/common/#CleanPodPolicy">
-github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2.CleanPodPolicy
+common/v1beta2.CleanPodPolicy
 </a>
 </em>
 </td>
@@ -133,7 +133,7 @@ For example,
 <code>status</code></br>
 <em>
 <a href="/docs/reference/tfjob/v1beta2/common/#JobStatus">
-github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2.JobStatus
+common/v1beta2.JobStatus
 </a>
 </em>
 </td>
@@ -168,7 +168,7 @@ Read-only.</p>
 <code>cleanPodPolicy</code></br>
 <em>
 <a href="/docs/reference/tfjob/v1beta2/common/#CleanPodPolicy">
-github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2.CleanPodPolicy
+common/v1beta2.CleanPodPolicy
 </a>
 </em>
 </td>

--- a/gen-api-reference/README.md
+++ b/gen-api-reference/README.md
@@ -27,7 +27,6 @@ at the root of the repo, and that your GOPATH is set properly. For example:
 ```
 cd $GOPATH/src/github.com/kubeflow/tf-operator/
 ```
-
 1. Run the `gen-tfjob-api.sh` script.
 
 1. Run `git diff` to verify the changes.

--- a/gen-api-reference/README.md
+++ b/gen-api-reference/README.md
@@ -1,0 +1,35 @@
+This folder contains scripts that automatically generate API reference pages for Kubeflow.
+The tool used here can be found at https://github.com/ahmetb/gen-crd-api-reference-docs.
+
+## Prerequisites
+* Clone this repository
+* Clone of the repository for which you are generating reference (e.g. kubeflow/tf-operator).
+
+## Installation
+
+1. Download the tool from https://github.com/ahmetb/gen-crd-api-reference-docs/releases.
+
+1. Extract the tool to a local directory, for example:
+```
+tar -xvf gen-crd-api-reference-docs_linux_amd64.tar.gz -C gen-crd-api-reference-docs
+```
+
+## Usage
+
+1. Open up `gen-tfjob-api.sh` script.
+
+1. Set the `GEN_DOCS` variable to where you have gen-crd-api-reference extracted.
+
+1. Make sure that your `$GOPATH` is set up correctly.
+
+1. Go to the directory where your API repository is cloned. The tool assumes that you are
+at the root of the repo, and that your GOPATH is set properly. For example:
+```
+cd $GOPATH/src/github.com/kubeflow/tf-operator/
+```
+
+1. Run the `gen-tfjob-api.sh` script.
+
+1. Run `git diff` to verify the changes.
+
+1. Create a PR to merge your changes.

--- a/gen-api-reference/README.md
+++ b/gen-api-reference/README.md
@@ -1,9 +1,12 @@
 This folder contains scripts that automatically generate API reference pages for Kubeflow.
+
+# Generating API References for Custom Resources
+
 The tool used here can be found at https://github.com/ahmetb/gen-crd-api-reference-docs.
 
 ## Prerequisites
-* Clone this repository
-* Clone of the repository for which you are generating reference (e.g. kubeflow/tf-operator).
+* Clone this repository (website)
+* Clone the repository for which you are generating reference (e.g. kubeflow/tf-operator).
 
 ## Installation
 
@@ -18,15 +21,18 @@ tar -xvf gen-crd-api-reference-docs_linux_amd64.tar.gz -C gen-crd-api-reference-
 
 1. Open up `gen-tfjob-api.sh` script.
 
-1. Set the `GEN_DOCS` variable to where you have gen-crd-api-reference extracted.
+1. Set the `GEN_DOCS` variable to where you have `gen-crd-api-reference-docs` extracted.
 
-1. Set the `WEBSITE_ROOT` variable to where your website repository is cloned.
+1. Set the `WEBSITE_ROOT` variable to where your website repository is cloned. For example:
+	```
+	WEBSITE_ROOT=$GOPATH/src/github.com/kubeflow/website
+	```
 
 1. Go to the directory where your **API repository** is cloned. The tool assumes that you are
 at the root of the repo, and that your GOPATH is set properly. For example:
-```
-cd $GOPATH/src/github.com/kubeflow/tf-operator/
-```
+	```
+	cd $GOPATH/src/github.com/kubeflow/tf-operator/
+	```
 1. Run the `gen-tfjob-api.sh` script.
 
 1. Run `git diff` to verify the changes.

--- a/gen-api-reference/README.md
+++ b/gen-api-reference/README.md
@@ -20,9 +20,9 @@ tar -xvf gen-crd-api-reference-docs_linux_amd64.tar.gz -C gen-crd-api-reference-
 
 1. Set the `GEN_DOCS` variable to where you have gen-crd-api-reference extracted.
 
-1. Make sure that your `$GOPATH` is set up correctly.
+1. Set the `WEBSITE_ROOT` variable to where your website repository is cloned.
 
-1. Go to the directory where your API repository is cloned. The tool assumes that you are
+1. Go to the directory where your **API repository** is cloned. The tool assumes that you are
 at the root of the repo, and that your GOPATH is set properly. For example:
 ```
 cd $GOPATH/src/github.com/kubeflow/tf-operator/

--- a/gen-api-reference/gen-tfjob-api.sh
+++ b/gen-api-reference/gen-tfjob-api.sh
@@ -1,0 +1,48 @@
+# Change this to where gen-crd-api-reference-docs is extracted
+GEN_DOCS=$HOME/gen-crd-api-reference-docs
+
+# V1beta1
+CONTENT_DIR=$GOPATH/src/github.com/kubeflow/website/content/docs/reference/tfjob/v1beta1
+
+echo "+++
+title = \"TFJob Common\"
+description = \"Reference documentation for TFJob\"
+weight = 100
++++" > $CONTENT_DIR/common.md
+
+$GEN_DOCS/gen-crd-api-reference-docs -config $GEN_DOCS/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/common/v1beta1" -out-file temp_common.md
+cat temp_common.md >> $CONTENT_DIR/common.md
+rm temp_common.md
+
+echo "+++
+title = \"TFJob TensorFlow\"
+description = \"Reference documentation for TFJob\"
+weight = 100
++++" > $CONTENT_DIR/tensorflow.md
+
+$GEN_DOCS/gen-crd-api-reference-docs -config $GEN_DOCS/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1beta1" -out-file temp_tensorflow.md
+cat temp_tensorflow.md >> $CONTENT_DIR/tensorflow.md
+rm temp_tensorflow.md
+
+# V1beta2
+CONTENT_DIR=$GOPATH/src/github.com/kubeflow/website/content/docs/reference/tfjob/v1beta2
+
+echo "+++
+title = \"TFJob Common (in development)\"
+description = \"Reference documentation for TFJob\"
+weight = 100
++++" > $CONTENT_DIR/common.md
+
+$GEN_DOCS/gen-crd-api-reference-docs -config $GEN_DOCS/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2" -out-file temp_common.md
+cat temp_common.md >> $CONTENT_DIR/common.md
+rm temp_common.md
+
+echo "+++
+title = \"TFJob TensorFlow (in development)\"
+description = \"Reference documentation for TFJob\"
+weight = 100
++++" > $CONTENT_DIR/tensorflow.md
+
+$GEN_DOCS/gen-crd-api-reference-docs -config $GEN_DOCS/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1beta2" -out-file temp_tensorflow.md
+cat temp_tensorflow.md >> $CONTENT_DIR/tensorflow.md
+rm temp_tensorflow.md

--- a/gen-api-reference/gen-tfjob-api.sh
+++ b/gen-api-reference/gen-tfjob-api.sh
@@ -1,8 +1,11 @@
 # Change this to where gen-crd-api-reference-docs is extracted
 GEN_DOCS=$HOME/gen-crd-api-reference-docs
 
+# Change this to where the website repository is cloned.
+WEBSITE_ROOT=$GOPATH/src/github.com/kubeflow/website
+
 # V1beta1
-CONTENT_DIR=$GOPATH/src/github.com/kubeflow/website/content/docs/reference/tfjob/v1beta1
+CONTENT_DIR=$WEBSITE_ROOT/content/docs/reference/tfjob/v1beta1
 
 echo "+++
 title = \"TFJob Common\"
@@ -10,7 +13,7 @@ description = \"Reference documentation for TFJob\"
 weight = 100
 +++" > $CONTENT_DIR/common.md
 
-$GEN_DOCS/gen-crd-api-reference-docs -config $GEN_DOCS/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/common/v1beta1" -out-file temp_common.md
+$GEN_DOCS/gen-crd-api-reference-docs -config $WEBSITE_ROOT/gen-api-reference/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/common/v1beta1" -out-file temp_common.md
 cat temp_common.md >> $CONTENT_DIR/common.md
 rm temp_common.md
 
@@ -20,12 +23,12 @@ description = \"Reference documentation for TFJob\"
 weight = 100
 +++" > $CONTENT_DIR/tensorflow.md
 
-$GEN_DOCS/gen-crd-api-reference-docs -config $GEN_DOCS/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1beta1" -out-file temp_tensorflow.md
+$GEN_DOCS/gen-crd-api-reference-docs -config $WEBSITE_ROOT/gen-api-reference/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1beta1" -out-file temp_tensorflow.md
 cat temp_tensorflow.md >> $CONTENT_DIR/tensorflow.md
 rm temp_tensorflow.md
 
 # V1beta2
-CONTENT_DIR=$GOPATH/src/github.com/kubeflow/website/content/docs/reference/tfjob/v1beta2
+CONTENT_DIR=$WEBSITE_ROOT/content/docs/reference/tfjob/v1beta2
 
 echo "+++
 title = \"TFJob Common (in development)\"
@@ -33,7 +36,7 @@ description = \"Reference documentation for TFJob\"
 weight = 100
 +++" > $CONTENT_DIR/common.md
 
-$GEN_DOCS/gen-crd-api-reference-docs -config $GEN_DOCS/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2" -out-file temp_common.md
+$GEN_DOCS/gen-crd-api-reference-docs -config $WEBSITE_ROOT/gen-api-reference/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/common/v1beta2" -out-file temp_common.md
 cat temp_common.md >> $CONTENT_DIR/common.md
 rm temp_common.md
 
@@ -43,6 +46,6 @@ description = \"Reference documentation for TFJob\"
 weight = 100
 +++" > $CONTENT_DIR/tensorflow.md
 
-$GEN_DOCS/gen-crd-api-reference-docs -config $GEN_DOCS/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1beta2" -out-file temp_tensorflow.md
+$GEN_DOCS/gen-crd-api-reference-docs -config $WEBSITE_ROOT/gen-api-reference/kubeflow-config.json -template-dir $GEN_DOCS/template -api-dir "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1beta2" -out-file temp_tensorflow.md
 cat temp_tensorflow.md >> $CONTENT_DIR/tensorflow.md
 rm temp_tensorflow.md

--- a/gen-api-reference/kubeflow-config.json
+++ b/gen-api-reference/kubeflow-config.json
@@ -1,0 +1,36 @@
+{
+    "hideMemberFields": [
+        "TypeMeta"
+    ],
+    "hideTypePatterns": [
+        "ParseError$",
+        "List$"
+    ],
+    "externalPackages": [
+        {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/apis/meta/v1\\.Duration$",
+            "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
+        },
+        {
+            "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",
+            "docsURLTemplate": "https://godoc.org/github.com/knative/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/kubeflow/tf-operator/pkg/apis/common/v1beta1",
+            "docsURLTemplate": "/docs/reference/tfjob/v1beta1/common/#{{.TypeIdentifier}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/kubeflow/tf-operator/pkg/apis/common/v1beta2",
+            "docsURLTemplate": "/docs/reference/tfjob/v1beta2/common/#{{.TypeIdentifier}}"
+        }	
+    ],
+    "typeDisplayNamePrefixOverrides": {
+        "k8s.io/api/": "Kubernetes ",
+        "k8s.io/apimachinery/pkg/apis/": "Kubernetes "
+    },
+    "markdownDisabled": false
+}

--- a/gen-api-reference/kubeflow-config.json
+++ b/gen-api-reference/kubeflow-config.json
@@ -30,7 +30,8 @@
     ],
     "typeDisplayNamePrefixOverrides": {
         "k8s.io/api/": "Kubernetes ",
-        "k8s.io/apimachinery/pkg/apis/": "Kubernetes "
+        "k8s.io/apimachinery/pkg/apis/": "Kubernetes ",
+        "github.com/kubeflow/tf-operator/pkg/apis/common": "common"
     },
     "markdownDisabled": false
 }


### PR DESCRIPTION
Also fixed an incorrect version name in the docs.

Fixes https://github.com/kubeflow/tf-operator/issues/731.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/521)
<!-- Reviewable:end -->
