### PR TITLE
Removed broken link from K8s version shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Kubernetes:
 - Usage in a document:
 
   ```
-  You need Kubernetes {{% kubernetes-min-version %}} or later.
+  You need Kubernetes version {{% kubernetes-min-version %}} or later.
   ```
 
 Useful Hugo docs:

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Kubernetes:
 - Content of the shortcode:
 
   ```
-  <a href="https://kubernetes.io/docs/imported/release/notes/">1.8</a>
+  1.8
   ```
 - Usage in a document:
 

--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -49,7 +49,7 @@ Requirements:
   * ksonnet version {{% ksonnet-min-version %}} or later. See the
     [ksonnet component guide](/docs/components/ksonnet) for help with
     installing ksonnet and understanding how Kubeflow uses ksonnet.
-  * Kubernetes {{% kubernetes-min-version %}} or later
+  * Kubernetes version {{% kubernetes-min-version %}} or later
   * kubectl
 
 Download, set up, and deploy. (If you prefer to work from source code, feel free to skip step 1):

--- a/content/docs/started/requirements.md
+++ b/content/docs/started/requirements.md
@@ -19,9 +19,8 @@ the following systems:
  * ksonnet version {{% ksonnet-min-version %}} or later. See the 
    [ksonnet component guide](/docs/components/ksonnet/) for details about
    installing ksonnet.
- * An existing Kubernetes cluster using Kubernetes {{% kubernetes-min-version %}} or later:
+ * An existing Kubernetes cluster using Kubernetes version 
+   {{% kubernetes-min-version %}} or later:
+
    * A minimum of 0.6 CPU in cluster (Reserved for 3 replicated ambassador pods and according to your need add additional CPUs)
    * Node with storage >= 10 GB (Due to the ML libraries and third party packages being bundled in Kubeflow Docker images)
-
-
-

--- a/layouts/shortcodes/kubernetes-min-version.html
+++ b/layouts/shortcodes/kubernetes-min-version.html
@@ -1,1 +1,1 @@
-<a href="https://kubernetes.io/docs/imported/release/notes/">1.8</a>
+1.8


### PR DESCRIPTION
Removed broken link from the shortcode for the Kubernetes version. I decided not to replace the link with another, as (a) we no longer use a link for the ksonnet version, which is used in the same places in the docs, and (b) any link we use may break again.

I also added the word "version" in the two docs that use this shortcode, for consistency with the usage for the ksonnet version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/526)
<!-- Reviewable:end -->
