### PR TITLE
Add description PROJECT variable

### DIFF
--- a/content/docs/started/getting-started-gke.md
+++ b/content/docs/started/getting-started-gke.md
@@ -216,6 +216,7 @@ Follow these steps to deploy Kubeflow:
      contain just the directory name, not the full path to the directory.
      The value of this variable becomes the name of your deployment.
      The contents of this directory are described in the next section.
+   * **${PROJECT}** - the _name_ of the GCP project where you want kubeflow deployed to.
 
 1. Check the resources deployed in namespace `kubeflow`:
 


### PR DESCRIPTION
## What
* Added description for `${PROJECT}` variable

## Why
* `${PROJECT}` was not defined in step 2 of the `Deploy Kubeflow on GKE using the command line` section. 
* While it is pretty intuitive for those that use GCP, without a description it can be easy to forget to set it when running the command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/541)
<!-- Reviewable:end -->
