### PR TITLE
Update install-sdk.md

### DIFF
--- a/content/docs/pipelines/sdk/install-sdk.md
+++ b/content/docs/pipelines/sdk/install-sdk.md
@@ -71,7 +71,7 @@ up Python using [Miniconda](https://conda.io/miniconda.html):
 Run the following command to install the Kubeflow Pipelines SDK:
 
 ```bash
-pip install https://storage.googleapis.com/ml-pipeline/release/{{% pipelines-sdk-version %}}/kfp.tar.gz --upgrade
+pip3 install https://storage.googleapis.com/ml-pipeline/release/{{% pipelines-sdk-version %}}/kfp.tar.gz --upgrade
 ```
 
 After successful installation, the command `dsl-compile` should be available.


### PR DESCRIPTION
As I understand it, pip3 is the Python3 version of pip. On systems with both Python 2 and 3, pip will use Python 2. This affects hosted notebook environments that have both Python 2 and 3 installed, such as Kubeflow notebooks or Google Cloud Notebooks. Since the SDK requires Python 3, I'd recommend changing this doc to use pip3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/559)
<!-- Reviewable:end -->
