### PR TITLE
Fix typo(s) in installation of kfp package via conda

### DIFF
--- a/content/docs/pipelines/sdk/install-sdk.md
+++ b/content/docs/pipelines/sdk/install-sdk.md
@@ -71,7 +71,7 @@ up Python using [Miniconda](https://conda.io/miniconda.html):
 Run the following command to install the Kubeflow Pipelines SDK:
 
 ```bash
-pip3 install https://storage.googleapis.com/ml-pipeline/release/{{% pipelines-sdk-version %}}/kfp.tar.gz --upgrade
+pip install https://storage.googleapis.com/ml-pipeline/release/{{% pipelines-sdk-version %}}/kfp.tar.gz --upgrade
 ```
 
 After successful installation, the command `dsl-compile` should be available.
@@ -84,7 +84,7 @@ which dsl-compile
 The response should be something like this:
 
 ```
-/<PATH_TO_YOUR_USER_BIN>/miniconda2/envs/mlpipeline/bin/dsl-compile
+/<PATH_TO_YOUR_USER_BIN>/miniconda3/envs/mlpipeline/bin/dsl-compile
 ```
 
 ## Next steps


### PR DESCRIPTION
Most recent version of miniconda installs pip, not pip3 with Python 3.7.  When using GCP Cloud Shell, pip3 is in /usr/bin and will cause kfp package to end up in the users site packages directory and not in the mlpipelines env.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/589)
<!-- Reviewable:end -->
