### PR TITLE
Add --zone option to kfctl generate step

### DIFF
--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -61,6 +61,7 @@ Follow these steps to deploy Kubeflow:
     ```bash
     # The following command is optional, to make kfctl binary easier to use.
     export PATH=$PATH:<path to kfctl in your kubeflow installation>
+    export ZONE=<your target zone> #where the deployment will be created
 
     export PROJECT=<your GCP project>
     export KFAPP=<your choice of application directory name>
@@ -70,7 +71,7 @@ Follow these steps to deploy Kubeflow:
     kfctl init ${KFAPP} --platform gcp --project ${PROJECT} --use_basic_auth -V
 
     cd ${KFAPP}
-    kfctl generate all -V
+    kfctl generate all -V --zone ${ZONE}
     kfctl apply all -V
     ```
    * **${KFAPP}** - the _name_ of a directory where you want Kubeflow 


### PR DESCRIPTION
It's a critical option to set at generate step.
The default value is us-east1-b.
If it's not specified at the generate step.  generated config files have the default zone hardcoded in multiple places.
Manually changing it in cluster*.yaml and doing the apply doesn't seem to work.
Even if it did, it's better that the users are aware of this option when they are creating the deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/618)
<!-- Reviewable:end -->
