### PR TITLE
Adds gcp-kubeflow-notebook.md to Fairing docs.

### DIFF
--- a/content/docs/fairing/gcp-kubeflow-notebook.md
+++ b/content/docs/fairing/gcp-kubeflow-notebook.md
@@ -20,7 +20,7 @@ demonstrate how to:
 1.  Use the Kubeflow user interface to open your hosted notebook environment
     in Kubeflow.
 
-1.  In your hosted noteboo environment, click **New** and select **Terminal**
+1.  In your hosted notebook environment, click **New** and select **Terminal**
     to start a new terminal session in your notebook environment. Use the
     terminal session to configure your notebook environment to run the XGBoost
     quickstart notebook:

--- a/content/docs/fairing/gcp-kubeflow-notebook.md
+++ b/content/docs/fairing/gcp-kubeflow-notebook.md
@@ -1,13 +1,13 @@
 +++
 title = "Train and Deploy on GCP from a Kubeflow Notebook"
-description = "Use Kubeflow Fairing to train and deploy a model on Google Cloud Platform (GCP) from a notebook that is hosted on Kubeflow."
+description = "Use Kubeflow Fairing to train and deploy a model on Google Cloud Platform (GCP) from a notebook that is hosted on Kubeflow"
 weight = 35
 +++
 
-This guide introduces you to using Kubeflow Fairing to train and deploy a
-model to Kubeflow on Google Kubernetes Engine (GKE), and Google Cloud ML Engine.
-As an example, this guide uses a notebook that is hosted on Kubeflow to
-demonstrate how to:
+This guide introduces you to using [Kubeflow Fairing][fairing-repo] to train and
+deploy a model to Kubeflow on Google Kubernetes Engine (GKE) and Google Cloud
+ML Engine. As an example, this guide uses a notebook that is hosted on Kubeflow
+to demonstrate how to:
 
 *  Train an XGBoost model in a notebook,
 *  Use Kubeflow Fairing to train an XGBoost model remotely on Kubeflow,
@@ -15,15 +15,24 @@ demonstrate how to:
 *  Use Kubeflow Fairing to deploy a trained model to Kubeflow, and
 *  Call the deployed endpoint for predictions.
 
-## Use Kubeflow Fairing to train a model in a notebook, on Kubeflow, and on GCP
+1.  If you do not have a Kubeflow environment, follow the guide to [deploying
+    Kubeflow on GKE][kubeflow-install-gke] to set up your Kubeflow environment.
+    The guide provides two options for setting up your environment:
+
+    *  The [Kubeflow deployment user interface][kubeflow-deploy] is an easy
+       way for you to set up a GKE cluster with Kubeflow
+       installed, or
+    *  You can deploy Kubeflow using the [command line][kubeflow-install].
 
 1.  Use the Kubeflow user interface to open your hosted notebook environment
-    in Kubeflow.
+    in Kubeflow. 
 
-1.  In your hosted notebook environment, click **New** and select **Terminal**
-    to start a new terminal session in your notebook environment. Use the
-    terminal session to configure your notebook environment to run the XGBoost
-    quickstart notebook:
+1.  Download the files used in this example and install the packages that the
+    XGBoost quickstart notebook depends on.
+
+    1.  In your hosted notebook environment, click **New** and select **Terminal**
+        to start a new terminal session in your notebook environment. Use the
+        terminal session to set up your notebook environment to run this example.
 
     1.  Clone the Kubeflow Fairing repository to download the files used in
         this example.
@@ -39,9 +48,17 @@ demonstrate how to:
         ```
 
 1.  Use the notebook user interface to open the XGBoost quickstart notebook
-    at fairing/examples/prediction/xgboost-high-level-apis.ipynb.
+    at `[path-to-cloned-fairing-repo]fairing/examples/prediction/xgboost-high-level-apis.ipynb`.
 
-1.  Follow the instructions in the notebook to train a model in the
-    notebook, on Kubeflow, and on Cloud ML Engine. Then deploy the
-    trained model to Kubeflow for predictions and send requests to
-    the prediction endpoint.
+1.  Follow the instructions in the notebook to:
+
+    1.  Train an XGBoost model in a notebook,
+    1.  Use Kubeflow Fairing to train an XGBoost model remotely on Kubeflow,
+    1.  Use Kubeflow Fairing to train an XGBoost model remotely on Cloud ML Engine, 
+    1.  Use Kubeflow Fairing to deploy a trained model to Kubeflow, and
+    1.  Call the deployed endpoint for predictions.
+
+[fairing-repo]: https://github.com/kubeflow/fairing
+[kubeflow-install-gke]: /docs/gke/deploy/
+[kubeflow-install]: /docs/gke/deploy/deploy-cli/
+[kubeflow-deploy]: https://deploy.kubeflow.cloud

--- a/content/docs/fairing/gcp-kubeflow-notebook.md
+++ b/content/docs/fairing/gcp-kubeflow-notebook.md
@@ -15,6 +15,9 @@ to demonstrate how to:
 *  Use Kubeflow Fairing to deploy a trained model to Kubeflow, and
 *  Call the deployed endpoint for predictions.
 
+Follow these instructions to set up your environment and run the XGBoost
+quickstart notebook:
+
 1.  If you do not have a Kubeflow environment, follow the guide to [deploying
     Kubeflow on GKE][kubeflow-install-gke] to set up your Kubeflow environment.
     The guide provides two options for setting up your environment:

--- a/content/docs/fairing/gcp-kubeflow-notebook.md
+++ b/content/docs/fairing/gcp-kubeflow-notebook.md
@@ -1,0 +1,47 @@
++++
+title = "Train and Deploy on GCP from a Kubeflow Notebook"
+description = "Use Kubeflow Fairing to train and deploy a model on Google Cloud Platform (GCP) from a notebook that is hosted on Kubeflow."
+weight = 35
++++
+
+This guide introduces you to using Kubeflow Fairing to train and deploy a
+model to Kubeflow on Google Kubernetes Engine (GKE), and Google Cloud ML Engine.
+As an example, this guide uses a notebook that is hosted on Kubeflow to
+demonstrate how to:
+
+*  Train an XGBoost model in a notebook,
+*  Use Kubeflow Fairing to train an XGBoost model remotely on Kubeflow,
+*  Use Kubeflow Fairing to train an XGBoost model remotely on Cloud ML Engine, 
+*  Use Kubeflow Fairing to deploy a trained model to Kubeflow, and
+*  Call the deployed endpoint for predictions.
+
+## Use Kubeflow Fairing to train a model in a notebook, on Kubeflow, and on GCP
+
+1.  Use the Kubeflow user interface to open your hosted notebook environment
+    in Kubeflow.
+
+1.  In your hosted noteboo environment, click **New** and select **Terminal**
+    to start a new terminal session in your notebook environment. Use the
+    terminal session to configure your notebook environment to run the XGBoost
+    quickstart notebook:
+
+    1.  Clone the Kubeflow Fairing repository to download the files used in
+        this example.
+
+        ```bash
+        git clone https://github.com/kubeflow/fairing 
+        ```
+
+    1.  Install the Python dependencies for the XGBoost quickstart notebook.
+
+        ```bash
+        pip3 install -r fairing/examples/prediction/requirements.txt
+        ```
+
+1.  Use the notebook user interface to open the XGBoost quickstart notebook
+    at fairing/examples/prediction/xgboost-high-level-apis.ipynb.
+
+1.  Follow the instructions in the notebook to train a model in the
+    notebook, on Kubeflow, and on Cloud ML Engine. Then deploy the
+    trained model to Kubeflow for predictions and send requests to
+    the prediction endpoint.


### PR DESCRIPTION
Adds documentation for using the Fairing XGBoost quickstart in a Kubeflow hosted notebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/620)
<!-- Reviewable:end -->
