### PR TITLE
Change in kube-batch name to volcano

### DIFF
--- a/content/docs/other-guides/job-scheduling.md
+++ b/content/docs/other-guides/job-scheduling.md
@@ -4,18 +4,18 @@ description = "How to schedule a job with gang-scheduling"
 weight = 30
 +++
 
-This guide describes how to use kube-batch to support gang-scheduling in 
+This guide describes how to use Volcano to support gang-scheduling in 
 Kubeflow, to allow jobs to run multiple pods at the same time.
 
 ## Running jobs with gang-scheduling
-To use gang-scheduling, you have to install kube-batch in your cluster first as a secondary scheduler of Kubernetes and configure operator to enable gang-scheduling. 
+To use gang-scheduling, you have to install volcano scheduler in your cluster first as a secondary scheduler of Kubernetes and configure operator to enable gang-scheduling. 
 
-* Kube-batch's introduction is [here](https://github.com/kubernetes-sigs/kube-batch), and also check how to install it [here](https://github.com/kubernetes-sigs/kube-batch/blob/master/doc/usage/tutorial.md).
+* Volcano's introduction is [here](https://github.com/kubernetes-sigs/volcano), and also check how to install it [here](https://github.com/kubernetes-sigs/volcano/blob/master/doc/usage/tutorial.md).
 * Take tf-operator for example, enable gang-scheduling in tf-operator by setting true to `--enable-gang-scheduling` flag.
 
-**Note:** Kube-batch and operator in Kubeflow achieve gang-scheduling by using pdb. operator will create the pdb of the job automatically. You can know more about pdb [here](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
+**Note:** Volcano and operator in Kubeflow achieve gang-scheduling by using pdb. operator will create the pdb of the job automatically. You can know more about pdb [here](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
 
-To use kube-batch to schedule your job as a gang, you have to specify the schedulerName in each replica; for example.
+To use Volcano scheduler to schedule your job as a gang, you have to specify the schedulerName in each replica; for example.
 
 ```yaml
 apiVersion: "kubeflow.org/v1beta1"
@@ -74,16 +74,16 @@ spec:
           restartPolicy: OnFailure
 ```
 
-## About kube-batch and gang-scheduling
-With using kube-batch to apply gang-scheduling, a job can run only if there are enough resources for all the pods of the job. Otherwise, all the pods will be in pending state waiting for enough resources. For example, if a job requiring N pods is created and there are only enough resources to schedule N-2 pods, then N pods of the job will stay pending.
+## About Volcano and gang-scheduling
+With using Volcano to apply gang-scheduling, a job can run only if there are enough resources for all the pods of the job. Otherwise, all the pods will be in pending state waiting for enough resources. For example, if a job requiring N pods is created and there are only enough resources to schedule N-2 pods, then N pods of the job will stay pending.
 
 **Note:** when in a high workload, if a pod of the job dies when the job is still running, it might give other pods chance to occupied the resources and cause deadlock. 
 
 ## Troubleshooting 
 
-If you keep getting problems related to RBAC in your kube-batch.
+If you keep getting problems related to RBAC in your volcano.
 
-You can try to add the following rules into your clusterrole of scheduler used by kube-batch.
+You can try to add the following rules into your clusterrole of scheduler used by volcano.
 ```
 - apiGroups:
   - '*'


### PR DESCRIPTION
Kube-Batch has been renamed to Volcano, so Doc changes has been made in this PR
https://github.com/kubernetes-sigs/volcano/issues/761
Preview: https://github.com/thandayuthapani/website/blob/master/content/docs/other-guides/job-scheduling.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/634)
<!-- Reviewable:end -->
