### PR TITLE
Update Getting started guide for 0.5;

### DIFF
--- a/content/docs/started/getting-started-k8s.md
+++ b/content/docs/started/getting-started-k8s.md
@@ -1,6 +1,6 @@
 +++
 title = "Kubeflow on Kubernetes"
-description = "Instructions for installing Kubeflow on your existing Kubernetes platform"
+description = "Instructions for installing Kubeflow on your existing Kubernetes cluster"
 weight = 4
 +++
 
@@ -9,30 +9,19 @@ cluster.
 
 If you are using a Kubernetes distribution or Cloud Provider which has specific
 instructions for installing Kubeflow we recommend following those instructions.
-
-The insturctions specific to particular platforms/Clouds do additional setup
-to create a really great Kubeflow experience.
+Those instuctions do additional Cloud specific setup to create a really great 
+Kubeflow experience.
 
 Before installing Kubeflow on the command line:
 
   * Ensure you have installed the following tools:
     
      * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-     * [gcloud](https://cloud.google.com/sdk/)
 
-  * If you're using
-    [Cloud Shell](https://cloud.google.com/shell/), enable 
-    [boost mode](https://cloud.google.com/shell/docs/features#boost_mode).
 
 ## Deploy Kubeflow
 
 Follow these steps to deploy Kubeflow:
-
-1. Create user credentials. You only need to run this command once:
-   
-   ```
-   gcloud auth application-default login
-   ```
 
 1. Download a `kfctl` release from the 
   [Kubeflow releases page](https://github.com/kubeflow/kubeflow/releases/).
@@ -66,15 +55,6 @@ Follow these steps to deploy Kubeflow:
      The value of this variable cannot be greater than 25 characters. It must
      contain just the directory name, not the full path to the directory.
      The content of this directory is described in the next section.
-   * **${PROJECT}** - the _name_ of the GCP project where you want Kubeflow 
-     deployed.
-   * When you run `kfctl init` you need to choose to use either IAP or basic 
-     authentication, as described below.
-   * `kfctl generate all` attempts to fetch your email address from your 
-     credential. If it can't find a valid email address, you need to pass a
-     valid email address with flag `--email <your email address>`. This email 
-     address becomes an administrator in the configuration of your Kubeflow 
-     deployment.
 
 1. Check the resources deployed in namespace `kubeflow`:
 

--- a/content/docs/started/getting-started-k8s.md
+++ b/content/docs/started/getting-started-k8s.md
@@ -1,0 +1,134 @@
++++
+title = "Kubeflow on Kubernetes"
+description = "Instructions for installing Kubeflow on your existing Kubernetes platform"
+weight = 4
++++
+
+Follow these instructions if you want to install Kubeflow on an existing Kubernetes
+cluster.
+
+If you are using a Kubernetes distribution or Cloud Provider which has specific
+instructions for installing Kubeflow we recommend following those instructions.
+
+The insturctions specific to particular platforms/Clouds do additional setup
+to create a really great Kubeflow experience.
+
+Before installing Kubeflow on the command line:
+
+  * Ensure you have installed the following tools:
+    
+     * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+     * [gcloud](https://cloud.google.com/sdk/)
+
+  * If you're using
+    [Cloud Shell](https://cloud.google.com/shell/), enable 
+    [boost mode](https://cloud.google.com/shell/docs/features#boost_mode).
+
+## Deploy Kubeflow
+
+Follow these steps to deploy Kubeflow:
+
+1. Create user credentials. You only need to run this command once:
+   
+   ```
+   gcloud auth application-default login
+   ```
+
+1. Download a `kfctl` release from the 
+  [Kubeflow releases page](https://github.com/kubeflow/kubeflow/releases/).
+
+1. Unpack the tar ball:
+
+    ```
+    tar -xvf kfctl_<release tag>_<platform>.tar.gz
+    ```
+
+1. Run the following commands to set up and deploy Kubeflow. The code below
+  includes an option command to add the binary `kfctl` to your path. If you 
+  don't add the binary to your path, you must use the full path to the `kfctl` 
+  binary each time you run it.
+
+    ```bash
+    # The following command is optional, to make kfctl binary easier to use.
+    export PATH=$PATH:<path to kfctl in your kubeflow installation>
+
+    export KFAPP=<your choice of application directory name>
+    # Default uses IAP.
+    kfctl init ${KFAPP}
+    cd ${KFAPP}
+    kfctl generate all -V
+    kfctl apply all -V
+    ```
+   * **${KFAPP}** - the _name_ of a directory where you want Kubeflow 
+     configurations to be stored. This directory is created when you run
+     `kfctl init`. If you want a custom deployment name, specify that name here.
+     The value of this variable becomes the name of your deployment.
+     The value of this variable cannot be greater than 25 characters. It must
+     contain just the directory name, not the full path to the directory.
+     The content of this directory is described in the next section.
+   * **${PROJECT}** - the _name_ of the GCP project where you want Kubeflow 
+     deployed.
+   * When you run `kfctl init` you need to choose to use either IAP or basic 
+     authentication, as described below.
+   * `kfctl generate all` attempts to fetch your email address from your 
+     credential. If it can't find a valid email address, you need to pass a
+     valid email address with flag `--email <your email address>`. This email 
+     address becomes an administrator in the configuration of your Kubeflow 
+     deployment.
+
+1. Check the resources deployed in namespace `kubeflow`:
+
+    ```
+    kubectl -n kubeflow get  all
+    ```
+
+## Delete Kubeflow
+
+Run the following commands to delete your deployment and reclaim all resources:
+
+```
+cd ${KFAPP}
+# If you want to delete all the resources, including storage.
+kfctl delete all --delete_storage
+# If you want to preserve storage, which contains metadata and information
+# from mlpipeline.
+kfctl delete all
+```
+
+## Understanding the deployment process
+
+The deployment process is controlled by 4 different commands:
+
+* **init** - one time set up.
+* **generate** - creates config files defining the various resources.
+* **apply** - creates or updates the resources.
+* **delete** - deletes the resources.
+
+With the exception of `init`, all commands take an argument which describes the
+set of resources to apply the command to; this argument can be one of the
+following:
+
+* **k8s** - all resources that run on Kubernetes.
+* **all** - GCP and Kubernetes resources.
+
+### App layout
+
+Your Kubeflow app directory contains the following files and directories:
+
+* **app.yaml** defines configurations related to your Kubeflow deployment.
+
+  * The values are set when you run `kfctl init`.
+  * The values are snapshotted inside **app.yaml** to make your app 
+    self contained.
+
+  * The directory is created when you run `kfctl generate platform`.
+  * You can modify these configurations to customize your GCP infrastructure.
+
+* **${KFAPP}/k8s_specs** is a directory that contains YAML specifications
+  for some daemons deployed on your Kubernetes Engine cluster.
+
+* **${KFAPP}/ks_app** is a directory that contains the 
+  [ksonnet](https://ksonnet.io) application for Kubeflow.
+
+  * The directory is created when you run `kfctl generate`.
+  * You can use ksonnet to customize Kubeflow.

--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -7,7 +7,7 @@ weight = 1
 There are a variety of ways to install Kubeflow
 
 * GCP users should follow the [guide for deploying on GCP](/docs/gke/deploy/)
-* On prem users or users with an existing Kubernetes cluster should follow the [guide for deploying on kubernetes](/docs/started/getting-started-k8s.md)
+* On prem users or users with an existing Kubernetes cluster should follow the [guide for deploying on kubernetes](/docs/started/getting-started-k8s/)
 * Users who want to run Kubernetes locally in a virtual machine can select one of the following options
 
    * [MiniKF setup](/docs/started/getting-started-minikf/)

--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -4,34 +4,11 @@ description = "Quickly get running with your ML Workflow"
 weight = 1
 +++
 
-## Who should consider using Kubeflow?
+There are a variety of ways to instal Kubeflow
 
-Based on the current functionality you should consider using Kubeflow if:
-
-  * You want to train/serve TensorFlow models in different environments (e.g.
-    local, on prem, and cloud)
-  * You want to use Jupyter notebooks to manage TensorFlow training jobs
-  * You want to launch training jobs that use resources -- such as additional
-    CPUs or GPUs -- that aren't available on your personal computer
-  * You want to combine TensorFlow with other processes
-       * For example, you may want to use
-	 [tensorflow/agents](https://github.com/tensorflow/agents) to run
-	 simulations to generate data for training reinforcement learning
-	 models.
-
-This list is based ONLY on current capabilities. We are investing significant
-resources to expand the functionality and actively soliciting help from
-companies and individuals interested in contributing (see
-[Contributing](/docs/contributing/)).
-
-## Installation without pre-existing Kubernetes
-
-Here is how you can get Kubeflow up and running if you don't have a K8s cluster
-running already.
-
-### Local
-
-There are several options:
+* GCP users should follow [guide for deploying on GCP](/docs/gke/deploy/)
+* On prem users or users with an existing Kubernetes cluster should follow the [guide for deploying on kubernetes](/docs/started/getting-started-k8s.md)
+ * Users who want to run Kubernetes locally in a virtual machine can select one of the following options
 
    * [MiniKF setup](/docs/started/getting-started-minikf/)
       * MiniKF is a fast and easy way to get started with Kubeflow.
@@ -72,79 +49,6 @@ There are several options:
 	   - Eliminates the need to install a separate virtualization
 	     application.
 	   - You can use cloud-init to customize the VM (as you might in a cloud)
-
-### Cloud
-
-To get started with Kubeflow on the cloud please follow the the 
-guide to [deploying Kubeflow on GCP](/docs/gke/deploy/).
-
-For more general information on setting up a Kubernetes cluster please refer to
-[Kubernetes Setup](https://kubernetes.io/docs/setup/). If you want to use GPUs,
-be sure to follow the Kubernetes [instructions for enabling
-GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/).
-
-## Installation on existing Kubernetes
-
-Use these instructions if you are already running a Κ8s cluster on prem.
-
-### Install Kubeflow
-
-Requirements:
-
-  * ksonnet version {{% ksonnet-min-version %}} or later. See the
-    [ksonnet component guide](/docs/components/ksonnet) for help with installing
-    ksonnet and understanding how Kubeflow uses ksonnet.
-  * Kubernetes version {{% kubernetes-min-version %}} or later
-  * kubectl
-
-Download, set up, and deploy. (If you prefer to work from source code, feel free
-to skip step 1):
-
-1. Run the following commands to download `kfctl.sh`
-
-    ```
-    mkdir ${KUBEFLOW_SRC}
-    cd ${KUBEFLOW_SRC}
-    export KUBEFLOW_TAG={{% kf-stable-tag %}}
-    curl
-    https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh | bash
-     ```
-   * **KUBEFLOW_SRC** a directory where you want to download the source to
-   * **KUBEFLOW_TAG** a tag corresponding to the version to check out, such as
-     `master` for the latest code.
-   * **Note** you can also just clone the repository using git.
-
-2. Run the following commands to setup and deploy Kubeflow:
-
-    ```
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform none
-    cd ${KFAPP}
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh generate k8s
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
-    ```
-   * **${KFAPP}** the name for the kubeflow deployment (shouldn't be a path). A
-     directory with the name will be created under `pwd` when you run init, and
-     that is where kubeflow configurations will be stored.
-      * The ksonnet app will be created in the directory **${KFAPP}/ks_app**
-   * (optional) For GPU support, make sure your cluster is in a
-     [zone that has GPUs](https://cloud.google.com/compute/docs/regions-zones/).
-     To set the zone explicitly, append `--zone ${ZONE}` to the `init` command.
-
-**Important**: The commands above will enable collection of **anonymous** user
-data to help us improve Kubeflow; for more information including instructions
-for explicitly disabling it please refer to the [usage reporting
-guide](/docs/other-guides/usage-reporting/).
-
-### Remove KubeFlow
-
-To remove your Kubeflow deployment, you can use the same `kfkctl` script as
-above. Note, that it will delete the namespace kubeflow along with everything
-you have deployed in it!
-
-    
-    cd ${KUBEFLOW_SRC}/${KFAPP}
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh delete k8s
-    
     
 ## Troubleshooting
 

--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -4,11 +4,11 @@ description = "Quickly get running with your ML Workflow"
 weight = 1
 +++
 
-There are a variety of ways to instal Kubeflow
+There are a variety of ways to install Kubeflow
 
-* GCP users should follow [guide for deploying on GCP](/docs/gke/deploy/)
+* GCP users should follow the [guide for deploying on GCP](/docs/gke/deploy/)
 * On prem users or users with an existing Kubernetes cluster should follow the [guide for deploying on kubernetes](/docs/started/getting-started-k8s.md)
- * Users who want to run Kubernetes locally in a virtual machine can select one of the following options
+* Users who want to run Kubernetes locally in a virtual machine can select one of the following options
 
    * [MiniKF setup](/docs/started/getting-started-minikf/)
       * MiniKF is a fast and easy way to get started with Kubeflow.


### PR DESCRIPTION
* Add a getting started page for on prem users and users with an existing K8s
  cluster. This guide should explain how to use kfctl go binary rather
  than kfctl.sh

* The main getting started page should link to individual getting started pages.

Fix #630 - remove who should consider using Kubeflw.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/642)
<!-- Reviewable:end -->
