### PR TITLE
Clarified notebook setup in Fairing guide

### DIFF
--- a/content/docs/fairing/gcp-kubeflow-notebook.md
+++ b/content/docs/fairing/gcp-kubeflow-notebook.md
@@ -6,7 +6,24 @@ weight = 35
 
 This guide introduces you to using [Kubeflow Fairing][fairing-repo] to train and
 deploy a model to Kubeflow on Google Kubernetes Engine (GKE) and Google Cloud
-ML Engine. As an example, this guide uses a notebook that is hosted on Kubeflow
+ML Engine.
+
+Your Kubeflow deployment includes services for spawning and managing Jupyter
+notebooks. Kubeflow Fairing is preinstalled in the Kubeflow notebooks, along
+with a number of machine learning (ML) libraries.
+
+## Set up Kubeflow and access the Kubeflow notebook environment
+
+Follow the [Kubeflow notebook setup guide](/docs/notebooks/setup/)
+to install Kubeflow, access your Kubeflow hosted notebook environment, and 
+create a new notebook server.
+
+When selecting a Docker image and other settings for the baseline deployment
+of your notebook server, you can leave all the settings at the default value.
+
+## Run the example notebook
+
+As an example, this guide uses a notebook that is hosted on Kubeflow
 to demonstrate how to:
 
 *  Train an XGBoost model in a notebook,
@@ -15,27 +32,15 @@ to demonstrate how to:
 *  Use Kubeflow Fairing to deploy a trained model to Kubeflow, and
 *  Call the deployed endpoint for predictions.
 
-Follow these instructions to set up your environment and run the XGBoost
-quickstart notebook:
-
-1.  If you do not have a Kubeflow environment, follow the guide to [deploying
-    Kubeflow on GKE][kubeflow-install-gke] to set up your Kubeflow environment.
-    The guide provides two options for setting up your environment:
-
-    *  The [Kubeflow deployment user interface][kubeflow-deploy] is an easy
-       way for you to set up a GKE cluster with Kubeflow
-       installed, or
-    *  You can deploy Kubeflow using the [command line][kubeflow-install].
-
-1.  Use the Kubeflow user interface to open your hosted notebook environment
-    in Kubeflow. 
+Follow these instructions to run the XGBoost quickstart notebook:
 
 1.  Download the files used in this example and install the packages that the
     XGBoost quickstart notebook depends on.
 
-    1.  In your hosted notebook environment, click **New** and select **Terminal**
-        to start a new terminal session in your notebook environment. Use the
-        terminal session to set up your notebook environment to run this example.
+    1.  On the **Jupyter dashboard** for your notebook server, click **New** and
+        select **Terminal** to start a new terminal session in your notebook
+        environment. Use the terminal session to set up your notebook
+        environment to run this example.
 
     1.  Clone the Kubeflow Fairing repository to download the files used in
         this example.

--- a/content/docs/fairing/gcp-kubeflow-notebook.md
+++ b/content/docs/fairing/gcp-kubeflow-notebook.md
@@ -63,7 +63,7 @@ Follow these instructions to run the XGBoost quickstart notebook:
 
     1.  Train an XGBoost model in a notebook,
     1.  Use Kubeflow Fairing to train an XGBoost model remotely on Kubeflow,
-    1.  Use Kubeflow Fairing to train an XGBoost model remotely on Cloud ML Engine, 
+    1.  Use Kubeflow Fairing to train an XGBoost model remotely on AI Platform Training, 
     1.  Use Kubeflow Fairing to deploy a trained model to Kubeflow, and
     1.  Call the deployed endpoint for predictions.
 

--- a/content/docs/fairing/gcp-kubeflow-notebook.md
+++ b/content/docs/fairing/gcp-kubeflow-notebook.md
@@ -5,8 +5,8 @@ weight = 35
 +++
 
 This guide introduces you to using [Kubeflow Fairing][fairing-repo] to train and
-deploy a model to Kubeflow on Google Kubernetes Engine (GKE) and Google Cloud
-ML Engine.
+deploy a model to Kubeflow on Google Kubernetes Engine (GKE) and 
+Google AI Platform Training.
 
 Your Kubeflow deployment includes services for spawning and managing Jupyter
 notebooks. Kubeflow Fairing is preinstalled in the Kubeflow notebooks, along
@@ -28,7 +28,8 @@ to demonstrate how to:
 
 *  Train an XGBoost model in a notebook,
 *  Use Kubeflow Fairing to train an XGBoost model remotely on Kubeflow,
-*  Use Kubeflow Fairing to train an XGBoost model remotely on Cloud ML Engine, 
+*  Use Kubeflow Fairing to train an XGBoost model remotely on 
+   AI Platform Training, 
 *  Use Kubeflow Fairing to deploy a trained model to Kubeflow, and
 *  Call the deployed endpoint for predictions.
 


### PR DESCRIPTION
In the Fairing guide to training/deploying from a Kubeflow notebook, this PR makes it clear that the Kubeflow notebook already includes Fairing as well as other ML libraries. This PR also links to our new guide to setting up notebooks.

fixes https://github.com/kubeflow/website/issues/644

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/645)
<!-- Reviewable:end -->
