### PR TITLE
Update docs for enabling private clusters for 0.5.

### DIFF
--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -33,20 +33,20 @@ Before installing Kubeflow ensure you have installed the following tools:
     ```
 1. Copy non-GCR hosted images to your GCR registry
 
-   1. Clone the Kubeflow source 
+    1. Clone the Kubeflow source 
 
-       ```
-       git clone https://github.com/kubeflow/kubeflow.git git_kubeflow      
-       ```
-   1. Use [Google Cloud Builder(GCB)](https://cloud.google.com/cloud-build/docs/) to replicate the images
+        ```
+        git clone https://github.com/kubeflow/kubeflow.git git_kubeflow      
+        ```
+    1. Use [Google Cloud Builder(GCB)](https://cloud.google.com/cloud-build/docs/) to replicate the images
 
-       ```
-       cd ~/git_kubeflow/scripts/gke
-       PROJECT=<PROJECT> make copy-gcb
-       ```
+        ```
+        cd ~/git_kubeflow/scripts/gke
+        PROJECT=<PROJECT> make copy-gcb
+        ```
 
-   * This is needed because your GKE nodes won't be able to pull images from non GCR
-     registries because they don't have public internet addresses
+    * This is needed because your GKE nodes won't be able to pull images from non GCR
+      registries because they don't have public internet addresses
 
 1. Follow the [instructions](https://www.kubeflow.org/docs/gke/deploy/oauth-setup/) for creating an OAuth client
 

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -28,10 +28,9 @@ Before installing Kubeflow ensure you have installed the following tools:
 
 1. Set user credentials. You only need to run this command once:
    
-   ```
-   gcloud auth application-default login
-   ```
-
+    ```
+    gcloud auth application-default login
+    ```
 1. Copy non-GCR hosted images to your GCR registry
 
    1. Clone the Kubeflow source 

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -7,23 +7,104 @@ weight = 5
 This guide describes how to create private clusters with Kubeflow on Google 
 Kubernetes Engine (GKE).
 
-## Before you start
-
-This guide assumes you have already set up Kubeflow with GKE. If you haven't done
-so, follow the guide to [deploying Kubeflow on GCP](/docs/gke/deploy/).
-
-## Private clusters
-
 Creating a [private Kubernetes Engine cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters)
 means the Kubernetes Engine nodes won't have public IP addresses. This can improve security by blocking unwanted outbound/inbound
 access to nodes. Removing IP addresses means external services (including GitHub, PyPi, DockerHub etc...) won't be accessible
 from the nodes. Google services (for example, Container Registry) are still accessible.
 
-1. Enable private clusters in `${KFAPP}/gcp_configs/cluster-kubeflow.yaml` by updating the following two parameters:
+## Before you start
+
+Before installing Kubeflow ensure you have installed the following tools:
+    
+  * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+  * [gcloud](https://cloud.google.com/sdk/)
+  * [jsonnet](https://github.com/google/jsonnet/releases)
+
+## Deploy Kubeflow with Private GKE
+
+1. Set user credentials. You only need to run this command once:
+   
+   ```
+   gcloud auth application-default login
+   ```
+
+1. Copy non-GCR hosted images to your GCR registry
+
+   1. Clone the Kubeflow source 
+
+      ```
+      git clone https://github.com/kubeflow/kubeflow.git git_kubeflow      
+      ```
+
+   1. Use GCB to replicate the images
+
+      ```
+      cd ~/git_kubeflow/scripts/gke
+      PROJECT=<PROJECT> make copy-gcb
+      ```
+
+   * This is needed because your GKE nodes won't be able to pull images from non GCR
+     registries because they don't have public internet addresses
+
+1. Create environment variables for IAP OAuth acces
+
+    ```bash
+    export CLIENT_ID=<CLIENT_ID from OAuth page>
+    export CLIENT_SECRET=<CLIENT_SECRET from OAuth page>
+    ```
+
+1. Download a `kfctl` release from the 
+  [Kubeflow releases page](https://github.com/kubeflow/kubeflow/releases/).
+
+1. Unpack the tar ball:
+
+    ```
+    tar -xvf kfctl_<release tag>_<platform>.tar.gz
+    ```
+   
+   * **Optional** Add the kfctl binary to your path. 
+   * If you don't add the kfctl binary to your path then in all subsequent
+     steps you will need to replace `kfctl` with the full path to the binary.
+
+1. Initialize the directory containing your Kubeflow deployment config files
+    
+    ```bash
+    export PROJECT=<your GCP project>
+    export KFAPP=<your choice of application directory name>
+    # Default uses IAP.
+    kfctl init ${KFAPP} --platform gcp --project ${PROJECT}
+
+    cd ${KFAPP}
+    kfctl generate all -V
+    ```
+   * **${KFAPP}** - the _name_ of a directory where you want Kubeflow 
+     configurations to be stored. This directory is created when you run
+     `kfctl init`. If you want a custom deployment name, specify that name here.
+     The value of this variable becomes the name of your deployment.
+     The value of this variable cannot be greater than 25 characters. It must
+     contain just the directory name, not the full path to the directory.
+     The content of this directory is described in the next section.
+   * **${PROJECT}** - the _name_ of the GCP project where you want Kubeflow 
+     deployed.
+   * When you run `kfctl init` you need to choose to use either IAP or basic 
+     authentication, as described below.
+   * `kfctl generate all` attempts to fetch your email address from your 
+     credential. If it can't find a valid email address, you need to pass a
+     valid email address with flag `--email <your email address>`. This email 
+     address becomes an administrator in the configuration of your Kubeflow 
+     deployment.
+
+1. Enable private clusters by editing `${KFAPP}/gcp_configs/cluster-kubeflow.yaml` and updating the following two parameters:
 
     ```
     privatecluster: true
     gkeApiVersion: v1beta1
+    ```
+1. Remove components which are not useful in private clusters:
+
+    ```
+    cd ${KFAPP}/ks_app
+    ks component rm cert-manager
     ```
 1. Create the deployment:
 
@@ -32,21 +113,64 @@ from the nodes. Google services (for example, Container Registry) are still acce
     kfctl apply platform
     ```
 
-1. To set up ingress to the cluster, it is recommended to use your custom domain instead of Cloud Endpoints. cert-manager cannot be used to create HTTPS certificates because cert-manager needs to talk to LetsEncrypt to get the certificate and that is not possible in a private cluster setting. Obtain the HTTPS certificates for your ${FQDN} and create a k8s secret with it. Assuming your cert and key are present in files named tls.crt and tls.key, create a secret using the following command:
+   * If you get an error **legacy networks not supported** Follow the 
+     [troubleshooting guide]( /docs/gke/troubleshooting-gke/#legacy-networks-are-not-supported) to create a new network.
 
-    ```
-    kubectl create secret generic --namespace=${NAMESPACE} envoy-ingress-tls --from-file=tls.crt=tls.crt --from-file=tls.key=tls.key
-    ```
+     * You will need to manually create the network as a work around for [kubeflow/kubeflow#3071](https://github.com/kubeflow/kubeflow/issues/3071)
+
+       ```
+       cd ${KFAPP}/gcp_configs
+       gcloud --project=${PROJECT} deployment-manager deployments create ${KFAPP}-network --config=network.yaml
+       ```
+
+     * Then edit **gcp_config/cluster.jinja** to add a field **network** in your cluster
+     
+       ```
+       cluster:
+          name: {{ CLUSTER_NAME }}
+          network: <name of the new network>
+       ```
+   
+     * To get the name of the new network run
+      
+       ```
+       gcloud --project=cloud-ml-dev compute networks list
+       ``` 
+
+       * The name will contain the value ${KFAPP}
 
 1. Update iap-ingress component parameters:
 
     ```
-    cd ${KFAPP}/ks_app
-    ks param set iap-ingress hostname ${FQDN}
+    cd ${KFAPP}/ks_app    
     ks param set iap-ingress privateGKECluster true
     ```
 
-1. Create an A record in your DNS management service to point ${FQDN} to the static IP address which was created by deployment manager. It can be found in `gcloud compute addresses list`.
+1. Obtain an HTTPS certificates for your ${FQDN} and create a k8s secret with it. 
+
+   * You can create a self signed cert using [kube-rsa](https://github.com/kelseyhightower/kube-rsa)
+
+      ```
+      go get github.com/kelseyhightower/kube-rsa
+      kube-rsa ${FQDN}
+      ```
+      * The fully qualified domain is the host field specified for your ingress; 
+        you can get it by running
+
+        ```
+        kubectl get ingress
+        ```
+
+    * Then create your K8s secret
+
+      ```
+      kubectl create secret tls --namespace=kubeflow envoy-ingress-tls --cert=ca.pem --key=ca-key.pem
+     ```
+
+   * An alternative option is to upgrade to GKE 1.12 or later and use 
+     [managed certificates](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs#migrating_to_google-managed_certificates_from_self-managed_certificates)
+
+     * See [kubeflow/kubeflow#3079](https://github.com/kubeflow/kubeflow/issues/3079)
 
 1. Update the various ksonnet components to use `gcr.io` images instead of dockerhub images:
 
@@ -55,17 +179,34 @@ from the nodes. Google services (for example, Container Registry) are still acce
     ${KUBEFLOW_SRC}/scripts/gke/use_gcr_for_all_images.sh
     ```
 
-1. Remove components which are not useful in private clusters:
-
-    ```
-    cd ${KFAPP}/ks_app
-    ks component rm cloud-endpoints
-    ks component rm cert-manager
-    ```
-
 1. Apply all the k8s resources:
 
     ```
     cd ${KFAPP}
     kfctl apply k8s
     ```
+1. Wait for Kubeflow to become accessible and then access it at
+
+   ```
+   https://${FQDN}/
+   ```
+
+   * ${FQDN} is the host associated with your ingress
+
+      * You can get it by running `kubectl get ingress`
+
+
+   * Follow the [instructions](/content/docs/gke/deploy/monitor-iap-setup/) to monitor the 
+     deployment
+
+   * It can take 10-20 minutes for the endpoint to become fully available
+
+## Next steps
+
+* Use [GKE Authorized Networks](https://cloud.google.com/kubernetes-engine/docs/how-to/authorized-networks) to restrict access to your GKE master
+*  Setup [VPC Service Controls](https://cloud.google.com/vpc-service-controls/docs/) to
+   restrict which GCP resources are accessible from your cluster
+* See how to [delete](/docs/gke/deploy/delete-cli) your Kubeflow deployment 
+  using the CLI.
+* [Troubleshoot](/docs/gke/troubleshooting-gke) any issues you may
+  find.

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -10,7 +10,11 @@ Kubernetes Engine (GKE).
 Creating a [private Kubernetes Engine cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters)
 means the Kubernetes Engine nodes won't have public IP addresses. This can improve security by blocking unwanted outbound/inbound
 access to nodes. Removing IP addresses means external services (including GitHub, PyPi, DockerHub etc...) won't be accessible
-from the nodes. Google services (for example, Container Registry) are still accessible.
+from the nodes. Google services (BigQuery, Cloud Storage, etc...) are still accessible.
+
+Importantly this means you can continue to use your [Google Container Registry (GCR)](https://cloud.google.com/container-registry/docs/) to host your Docker images. Other Docker registries (for example DockerHub) will not be accessible. If you need to use Docker images
+hosted outside Google Container Registry you can use the scripts provided by Kubeflow
+to mirror them to your GCR registry.
 
 ## Before you start
 
@@ -36,7 +40,7 @@ Before installing Kubeflow ensure you have installed the following tools:
       git clone https://github.com/kubeflow/kubeflow.git git_kubeflow      
       ```
 
-   1. Use GCB to replicate the images
+   1. Use [Google Cloud Builder(GCB)](https://cloud.google.com/cloud-build/docs/) to replicate the images
 
       ```
       cd ~/git_kubeflow/scripts/gke
@@ -46,7 +50,9 @@ Before installing Kubeflow ensure you have installed the following tools:
    * This is needed because your GKE nodes won't be able to pull images from non GCR
      registries because they don't have public internet addresses
 
-1. Create environment variables for IAP OAuth acces
+1. Follow the [instructions](https://www.kubeflow.org/docs/gke/deploy/oauth-setup/) for creating an OAuth client
+
+1. Create environment variables for IAP OAuth access
 
     ```bash
     export CLIENT_ID=<CLIENT_ID from OAuth page>
@@ -113,7 +119,7 @@ Before installing Kubeflow ensure you have installed the following tools:
     kfctl apply platform
     ```
 
-   * If you get an error **legacy networks not supported** Follow the 
+   * If you get an error **legacy networks not supported**, follow the 
      [troubleshooting guide]( /docs/gke/troubleshooting-gke/#legacy-networks-are-not-supported) to create a new network.
 
      * You will need to manually create the network as a work around for [kubeflow/kubeflow#3071](https://github.com/kubeflow/kubeflow/issues/3071)
@@ -146,7 +152,7 @@ Before installing Kubeflow ensure you have installed the following tools:
     ks param set iap-ingress privateGKECluster true
     ```
 
-1. Obtain an HTTPS certificates for your ${FQDN} and create a k8s secret with it. 
+1. Obtain an HTTPS certificate for your ${FQDN} and create a Kubernetes secret with it. 
 
    * You can create a self signed cert using [kube-rsa](https://github.com/kelseyhightower/kube-rsa)
 
@@ -161,7 +167,7 @@ Before installing Kubeflow ensure you have installed the following tools:
         kubectl get ingress
         ```
 
-    * Then create your K8s secret
+    * Then create your Kubernetes secret
 
       ```
       kubectl create secret tls --namespace=kubeflow envoy-ingress-tls --cert=ca.pem --key=ca-key.pem
@@ -172,18 +178,18 @@ Before installing Kubeflow ensure you have installed the following tools:
 
      * See [kubeflow/kubeflow#3079](https://github.com/kubeflow/kubeflow/issues/3079)
 
-1. Update the various ksonnet components to use `gcr.io` images instead of dockerhub images:
+1. Update the various ksonnet components to use `gcr.io` images instead of Docker Hub images:
 
     ```
     cd ${KFAPP}/ks_app
     ${KUBEFLOW_SRC}/scripts/gke/use_gcr_for_all_images.sh
     ```
 
-1. Apply all the k8s resources:
+1. Apply all the Kubernetes resources:
 
     ```
     cd ${KFAPP}
-    kfctl apply k8s
+    kfctl apply Kubernetes
     ```
 1. Wait for Kubeflow to become accessible and then access it at
 
@@ -196,7 +202,7 @@ Before installing Kubeflow ensure you have installed the following tools:
       * You can get it by running `kubectl get ingress`
 
 
-   * Follow the [instructions](/content/docs/gke/deploy/monitor-iap-setup/) to monitor the 
+   * Follow the [instructions](/docs/gke/deploy/monitor-iap-setup/) to monitor the 
      deployment
 
    * It can take 10-20 minutes for the endpoint to become fully available

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -35,15 +35,15 @@ Before installing Kubeflow ensure you have installed the following tools:
 
    1. Clone the Kubeflow source 
 
-      ```
-      git clone https://github.com/kubeflow/kubeflow.git git_kubeflow      
-      ```
+       ```
+       git clone https://github.com/kubeflow/kubeflow.git git_kubeflow      
+       ```
    1. Use [Google Cloud Builder(GCB)](https://cloud.google.com/cloud-build/docs/) to replicate the images
 
-      ```
-      cd ~/git_kubeflow/scripts/gke
-      PROJECT=<PROJECT> make copy-gcb
-      ```
+       ```
+       cd ~/git_kubeflow/scripts/gke
+       PROJECT=<PROJECT> make copy-gcb
+       ```
 
    * This is needed because your GKE nodes won't be able to pull images from non GCR
      registries because they don't have public internet addresses

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -38,7 +38,6 @@ Before installing Kubeflow ensure you have installed the following tools:
       ```
       git clone https://github.com/kubeflow/kubeflow.git git_kubeflow      
       ```
-
    1. Use [Google Cloud Builder(GCB)](https://cloud.google.com/cloud-build/docs/) to replicate the images
 
       ```

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -191,19 +191,17 @@ Before installing Kubeflow ensure you have installed the following tools:
     ```
 1. Wait for Kubeflow to become accessible and then access it at
 
-   ```
-   https://${FQDN}/
-   ```
+    ```
+    https://${FQDN}/
+    ```
+    * ${FQDN} is the host associated with your ingress
 
-   * ${FQDN} is the host associated with your ingress
+       * You can get it by running `kubectl get ingress`
 
-      * You can get it by running `kubectl get ingress`
-
-
-   * Follow the [instructions](/docs/gke/deploy/monitor-iap-setup/) to monitor the 
-     deployment
-
-   * It can take 10-20 minutes for the endpoint to become fully available
+    * Follow the [instructions](/docs/gke/deploy/monitor-iap-setup/) to monitor the 
+      deployment
+ 
+    * It can take 10-20 minutes for the endpoint to become fully available
 
 ## Next steps
 

--- a/content/docs/gke/troubleshooting-gke.md
+++ b/content/docs/gke/troubleshooting-gke.md
@@ -290,11 +290,15 @@ Alternatively, you can request more backend services quota on the GCP Console.
 1. Follow the form instructions to apply for more quota.
 
 
-## Cloud Filestore: legacy networks are not supported
+## Legacy networks are not supported
 
-Cloud Filestore tries to use the network named `default` by default. For older projects,
-this will be a legacy network which is incompatible with Cloud Filestore. This will
-manifest as an error like the following when deploying Cloud Filestore:
+Cloud Filestore and GKE tries to use the network named `default` by default. For older projects,
+this will be a legacy network which is incompatible with Cloud Filestore and newer GKE features
+like private clusters. This will
+manifest as the error **"default is invalid; legacy networks are not supported"** when
+deploying Kubeflow.
+
+Here's an example error when deploying Cloud Filestore:
 
 ```
 ERROR: (gcloud.deployment-manager.deployments.update) Error in Operation [operation-1533189457517-5726d7cfd19c9-e1b0b0b5-58ca11b8]: errors:
@@ -309,8 +313,9 @@ ERROR: (gcloud.deployment-manager.deployments.update) Error in Operation [operat
 To fix this we can create a new network:
 
 ```
-cp ${KUBEFLOW_SRC}/scripts/deployment_manager_configs/network.* \
-   ${KFAPP}/gcp_config/
+cd ${KFAPP}
+cp .cache/master/deployment/gke/deployment_manager_configs/network.* \
+   ./gcp_config/
 ```
 
 Edit `network.yaml `to set the name for the network.

--- a/content/docs/gke/troubleshooting-gke.md
+++ b/content/docs/gke/troubleshooting-gke.md
@@ -292,7 +292,7 @@ Alternatively, you can request more backend services quota on the GCP Console.
 
 ## Legacy networks are not supported
 
-Cloud Filestore and GKE tries to use the network named `default` by default. For older projects,
+Cloud Filestore and GKE try to use the network named `default` by default. For older projects,
 this will be a legacy network which is incompatible with Cloud Filestore and newer GKE features
 like private clusters. This will
 manifest as the error **"default is invalid; legacy networks are not supported"** when


### PR DESCRIPTION
* Provide instructions for how to replicate non-GCR images to a GCR registry
  so that they are accessible from private GKE.

  * We no longer depend on Kubeflow hosting a mirror for all images; instead
    user's will mirrror the images to their own GCR and then update
    relevant Kubeflow components

  * The relevant scripts will be submitted in a pending PR to kubeflow/kubeflow

* Update instructions for dealing with legacy networks

* The cluster isn't fully functional yet

  * Pipelines is having some issues; looks like mnio might not be deployed
    fully.

  * vizier db and vizier core are also crash looping.

  * Will file additional issues to track that.

Related to: kubeflow/kubeflow#2086 deploy private GKE cluster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/651)
<!-- Reviewable:end -->
