### PR TITLE
Getting started guide does not refer ks

### DIFF
--- a/content/docs/started/getting-started-k8s.md
+++ b/content/docs/started/getting-started-k8s.md
@@ -17,6 +17,7 @@ Before installing Kubeflow on the command line:
   * Ensure you have installed the following tools:
     
      * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+     * [ks] (https://github.com/ksonnet/ksonnet/releases/)
 
 
 ## Deploy Kubeflow


### PR DESCRIPTION
The guide does not refer to ks but it is needed. 
The error can be found here: https://github.com/kubeflow/kubeflow/issues/3132

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/687)
<!-- Reviewable:end -->
