### PR TITLE
update Getting Started / Kubfelow on Kubernetes page

### DIFF
--- a/content/docs/started/getting-started-k8s.md
+++ b/content/docs/started/getting-started-k8s.md
@@ -44,7 +44,7 @@ Follow these steps to deploy Kubeflow:
 
     export KFAPP=<your choice of application directory name>
     # Default uses IAP.
-    kfctl init ${KFAPP}
+    kfctl init -v <git release tag, e.g. v0.5.1> ${KFAPP}
     cd ${KFAPP}
     kfctl generate all -V
     kfctl apply all -V


### PR DESCRIPTION
Many issues on kubeflow/kubeflow github project are created due to the default behaviour of `kfctl init` command which is fetching unstable `master` branch by default. Explicitly mentioning `-v` flag in Kubeflow Getting started documentation page will help to reduce this misunderstanding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/695)
<!-- Reviewable:end -->
