### PR TITLE
Added v0.5 branch to dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,17 @@ The versioned sites follow this convention:
 * `master.kubeflow.org` always points to Github head
 * `vXXX-YYY.kubeflow.org` points to the release at vXXX.YYY-branch
 
+We also hook up each version to the dropdown on the website menu bar. To add a 
+version to the dropdown, edit `config.toml` and add a `params.versions` entry.
+For example, to add v0.5, add this entry:
+
+```
+[[params.versions]]
+  version = "v0.5"
+  githubbranch = "v0.5-branch"
+  url = "https://v0-5.kubeflow.org"
+```
+
 Furthermore, whenever any documents reference any source code, the links should be created
 using the version shortcode, like so:
 ```

--- a/config.toml
+++ b/config.toml
@@ -129,6 +129,11 @@ githubbranch = "master"
   githubbranch = "v0.4-branch"
   url = "https://v0-4.kubeflow.org"
 
+[[params.versions]]
+  version = "v0.5"
+  githubbranch = "v0.5-branch"
+  url = "https://v0-5.kubeflow.org"
+
 # Docsy: User interface configuration
 [params.ui]
 # Docsy: Enable to show the side bar menu in its compact state.


### PR DESCRIPTION
Added v0.5 branch to dropdown in config file, and also updated the README to explain how to do this. 

Note that the v0.5 site isn't serving content: https://v0-5.kubeflow.org/ 

When we know more about how to fix the above problem, I'll add that info to the README in this PR too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/701)
<!-- Reviewable:end -->
