### PR TITLE
Fixed indentation that broke numbering on CLI deployment page.

### DIFF
--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -36,9 +36,9 @@ Follow these steps to deploy Kubeflow:
 
 1. Create user credentials. You only need to run this command once:
    
-   ```
-   gcloud auth application-default login
-   ```
+    ```
+    gcloud auth application-default login
+    ```
 
 1. Create environment variables for your access control services:
 


### PR DESCRIPTION
Indentation on code block was off by one space. Verified fix by running Hugo server locally.
fixes kubeflow/kubeflow#3266

Signed-off-by: Chris Hupman <chupman@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/709)
<!-- Reviewable:end -->
