### PR TITLE
Updated language in pytorch-operator to fix broken link in issue 635

### DIFF
--- a/content/docs/components/pytorch.md
+++ b/content/docs/components/pytorch.md
@@ -42,7 +42,7 @@ ks apply ${ENVIRONMENT} -c pytorch-operator
 
 ## Creating a PyTorch Job
 
-You can create PyTorch Job by defining a PyTorchJob config file. See [distributed MNIST example](https://github.com/kubeflow/pytorch-operator/blob/master/examples/tcp-dist/mnist/v1beta1/pytorch_job_mnist.yaml) config file. You may change the config file based on your requirements.
+You can create PyTorch Job by defining a PyTorchJob config file. See the manifests for the [distributed MNIST example](https://github.com/kubeflow/pytorch-operator/tree/master/examples/mnist). You may change the config file based on your requirements.
 
 ```
 cat pytorch_job_mnist.yaml


### PR DESCRIPTION
Updated language to match what's in the `pytorch-operator` `README.md`
Here's the [diff](https://github.com/kubeflow/pytorch-operator/pull/126/files#diff-04c6e90faac2675aa89e2176d2eec7d8R22) with the change

fixes #635 

Signed-off-by: Chris Hupman <chupman@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/715)
<!-- Reviewable:end -->
