### PR TITLE
Added instructions to start port forwarding before trying to access Web UIs

### DIFF
--- a/content/docs/other-guides/accessing-uis.md
+++ b/content/docs/other-guides/accessing-uis.md
@@ -46,10 +46,7 @@ This URL brings up the landing page illustrated above.
 You can use the following command to set up port forwarding to the
 [Ambassador](https://www.getambassador.io/) service that provides the reverse proxy.
 
-```
-export NAMESPACE=kubeflow
-kubectl port-forward svc/ambassador -n ${NAMESPACE} 8080:80
-```
+{{% code-webui-port-forward %}}
 
 You can then access the central navigation dashboard at:
 

--- a/content/docs/started/getting-started-minikube.md
+++ b/content/docs/started/getting-started-minikube.md
@@ -238,6 +238,10 @@ Access Jupyter notebooks at http://localhost:8080/notebooks/
 
 ### Where to go next
 
+You can use the following command to set up port forwarding and access the Web UIs:
+
+{{% code-webui-port-forward %}}
+
 Now you can access the Kubeflow dashboard at http://localhost:8080/ and Jupyter
 notebooks at http://localhost:8080/notebooks/.
 

--- a/layouts/shortcodes/code-webui-port-forward.html
+++ b/layouts/shortcodes/code-webui-port-forward.html
@@ -1,0 +1,4 @@
+```sh
+export NAMESPACE=kubeflow
+kubectl port-forward svc/ambassador -n ${NAMESPACE} 8080:80
+```

--- a/layouts/shortcodes/code-webui-port-forward.html
+++ b/layouts/shortcodes/code-webui-port-forward.html
@@ -1,4 +1,3 @@
-```sh
-export NAMESPACE=kubeflow
+<pre><code>export NAMESPACE=kubeflow
 kubectl port-forward svc/ambassador -n ${NAMESPACE} 8080:80
-```
+</code></pre>


### PR DESCRIPTION
Added instructions to start port forwarding before trying to access Web UIs, after installation via Minikube.

Also created short code to share commands with relevant section in "Accessing UIs" page.

_(addresses issue #656)_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/731)
<!-- Reviewable:end -->
