### PR TITLE
Added code style within tables

### DIFF
--- a/resources/_gen/assets/scss/scss/main.scss_9fadf33d895a46083cdd64396b57ef68.content
+++ b/resources/_gen/assets/scss/scss/main.scss_9fadf33d895a46083cdd64396b57ef68.content
@@ -12024,14 +12024,14 @@ readers do not read off random characters that represent icons */
     margin: 0;
     padding: 0; }
 
-.td-content p code, .td-content li > code {
+.td-content p code, .td-content li > code, .td-content td > code, .td-content th > code {
   color: inherit;
   padding: 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
   background-color: rgba(0, 0, 0, 0.05);
   border-radius: 0.25rem; }
-  .td-content p code br, .td-content li > code br {
+  .td-content p code br, .td-content li > code br, .td-content td > code br, .td-content th > code br {
     display: none; }
 
 .td-content pre {

--- a/themes/docsy/assets/scss/_code.scss
+++ b/themes/docsy/assets/scss/_code.scss
@@ -20,7 +20,7 @@
     }
 
     // Inline code
-    p code, li > code {
+    p code, li > code, td > code, th > code {
         color: inherit;
         padding: 0.2em 0.4em;
         margin: 0;


### PR DESCRIPTION
Fixes https://github.com/kubeflow/website/issues/730

Code formatting embedded in text within a table is hard to read - the colour is too light. This change makes the inline code style within a table the same as the style outside a table.

**Before:**
![without-style-fix](https://user-images.githubusercontent.com/6138251/58441254-d2ae7d80-8123-11e9-857a-23aae66ffb0f.png)

**After:**
![with-style-fix](https://user-images.githubusercontent.com/6138251/58441258-e0fc9980-8123-11e9-8426-30f01f5a2735.png)

I'll submit this change to the Docsy theme as well, so that it won't be overwritten next time we get an updated version of Docsy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/733)
<!-- Reviewable:end -->
