### PR TITLE
Fix an issue in gcp-e2e.md.

### DIFF
--- a/content/docs/gke/gcp-e2e.md
+++ b/content/docs/gke/gcp-e2e.md
@@ -569,6 +569,7 @@ Set the variable by passing the following parameters:
 ```
 kustomize edit add configmap mnist-map-training --from-literal=secretName=user-gcp-sa
 kustomize edit add configmap mnist-map-training --from-literal=secretMountPath=/var/secrets
+kustomize edit add configmap mnist-map-training --from-literal=GOOGLE_APPLICATION_CREDENTIALS=/var/secrets/user-gcp-sa.json
 ```
 
 <a id="train-model"></a>


### PR DESCRIPTION
Fix issue for GOOGLE_APPLICATION_CREDENTIALS cannot be found on kubeflow.
Here is the [issue](https://stackoverflow.com/questions/56287936/google-application-credentials-cannot-be-found-on-kubeflow).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/735)
<!-- Reviewable:end -->
