### PR TITLE
 Changed AWS kubeflow installation to be more in line with current documentation

### DIFF
--- a/content/docs/aws/authentication.md
+++ b/content/docs/aws/authentication.md
@@ -49,7 +49,7 @@ ks param set istio-ingress enableCognito true
 ks param set istio-ingress certArn arn:aws:acm:us-west-2:xxx:certificate/xxxe4031c
 ```
 
-After you finish the TLS and Authentication configuration, then you can run `${KUBEFLOW_SRC}/${KFAPP}/scripts/kfctl.sh apply k8s`.
+After you finish the TLS and Authentication configuration, then you can run `kfctl apply k8s`. (This command assumes you have added kfctl to your path)
 
 After your ingress DNS is ready, you need to create a `CNAME` in your DNS records.
 

--- a/content/docs/aws/deploy/existing-cluster.md
+++ b/content/docs/aws/deploy/existing-cluster.md
@@ -39,8 +39,8 @@ If you would like to deploy Kubeflow on existing Amazon EKS cluster, the only di
 
     ```shell
     cd ${KUBEFLOW_SRC}
-
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform aws \
+    # This command assumes you have added the binary to your path.
+    kfctl init ${KFAPP} --platform aws \
     --awsClusterName ${AWS_CLUSTER_NAME} \
     --awsRegion ${AWS_REGION} \
     --awsNodegroupRoleNames ${AWS_NODEGROUP_ROLE_NAMES}

--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -4,10 +4,8 @@ description = "Instructions for deploying Kubeflow with the shell"
 weight = 4
 +++
 
-This guide describes how to use the `kfctl.sh` script to
+This guide describes how to use the `kfctl` script to
 deploy Kubeflow on Amazon Web Services (AWS).
-
-> Note: Amazon Web Services (AWS) is moving from `kfctl.sh` to a command line interface (CLI) which gives you more control over your configuration and better reliability.
 
 
 ## Prerequisites
@@ -48,7 +46,7 @@ Your Kubeflow `app` directory contains the following files and directories:
     * These values are set when you run `kfctl init`.
     * These values are snapshotted inside `app.yaml` to make your app self contained.
 * **${KFAPP}/aws_config** - A directory that contains a sample `eksctl` cluster configuration file that defines the AWS cluster and policy files to attach to your node group roles.
-    * This directory is created when you run `kfctl.sh generate platform`.
+    * This directory is created when you run `kfctl generate platform`.
     * You can modify the `cluster_config.yaml` and `cluster_features.sh` files to customize your AWS infrastructure.
 * **${KFAPP}/k8s_specs** - A directory that contains YAML specifications for daemons deployed on your Kubernetes Engine cluster.
 * **${KFAPP}/ks_app** - A directory that contains the [ksonnet](https://ksonnet.io/) application for Kubeflow.

--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -4,7 +4,7 @@ description = "Instructions for deploying Kubeflow with the shell"
 weight = 4
 +++
 
-This guide describes how to use the `kfctl` script to
+This guide describes how to use the `kfctl` binary to
 deploy Kubeflow on Amazon Web Services (AWS).
 
 

--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -120,7 +120,7 @@ If you experience any issues running these scripts, see the [troubleshooting gui
 
     To secure your installation, you have two options:
 
-    * Disable ingress before you `apply k8s`. Open `env.sh` in your $KFAPP directory and edit the `KUBEFLOW_COMPONENTS` environment variable. Delete `,\"alb-ingress-controller\",\"istio-ingress\"` and save the file.
+    * Disable ingress before you `apply k8s`. Open `env.sh` in your ${KFAPP} directory and edit the `KUBEFLOW_COMPONENTS` environment variable. Delete `,\"alb-ingress-controller\",\"istio-ingress\"` and save the file.
 
     * Follow the [instructions](/docs/aws/authentication) to add authentication before you `apply k8s`
 

--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -63,17 +63,16 @@ If you experience any issues running these scripts, see the [troubleshooting gui
 
 ## Kubeflow installation
 
-1. Run the following commands to download the latest `kfctl.sh`
+1. Download a ```kfctl``` release from the [Kubeflow releases page](https://github.com/kubeflow/kubeflow/releases/).
 
     ```shell
-    export KUBEFLOW_SRC=/tmp/kubeflow-aws
-    export KUBEFLOW_TAG=master
-
-    mkdir -p ${KUBEFLOW_SRC} && cd ${KUBEFLOW_SRC}
-    curl https://raw.githubusercontent.com/kubeflow/kubeflow/${KUBEFLOW_TAG}/scripts/download.sh | bash
+    wget https://github.com/kubeflow/kubeflow/releases/download/<release_tag>/kfctl_<release_tag>_<platform>.tar.gz
     ```
+1. Unpack the tar ball:
 
-    * KUBEFLOW_SRC - Full path to your preferred download directory. Please use the full absolute path, for example `/tmp/kubeflow-aws`
+    ```
+    tar -xvf kfctl_<release tag>_<platform>.tar.gz
+    ```
 
 1. Run the following commands to set up your environment and initialize the cluster.
 
@@ -83,11 +82,14 @@ If you experience any issues running these scripts, see the [troubleshooting gui
 
 
     ```shell
+    # The following command is optional, to make the kfctl binary easier to use.
+    export PATH=$PATH:<path to kfctl in your kubeflow installation>
+    
     export KFAPP=kfapp
     export REGION=us-west-2
     export AWS_CLUSTER_NAME=kubeflow-aws
 
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform aws \
+    kfctl init ${KFAPP} --platform aws \
     --awsClusterName ${AWS_CLUSTER_NAME} \
     --awsRegion ${REGION}
     ```
@@ -103,28 +105,28 @@ If you experience any issues running these scripts, see the [troubleshooting gui
 
     ```shell
     cd ${KFAPP}
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh generate platform
+    kfctl generate platform
     # Customize your Amazon EKS cluster configuration before following the next step
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh apply platform
+    kfctl apply platform
     ```
 
 1. Generate and apply the Kubernetes changes.
 
     ```shell
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh generate k8s
+    kfctl generate k8s
     ```
 
     __*Important!!!*__ By default, these scripts create an AWS Application Load Balancer for Kubeflow that is open to public. This is good for development testing and for short term use, but we do not recommend that you use this configuration for production workloads.
 
     To secure your installation, you have two options:
 
-    * Disable ingress before you `apply k8s`. Open `${KUBEFLOW_SRC}/${KFAPP}/env.sh` and edit the `KUBEFLOW_COMPONENTS` environment variable. Delete `,\"alb-ingress-controller\",\"istio-ingress\"` and save the file.
+    * Disable ingress before you `apply k8s`. Open `env.sh` in your $KFAPP directory and edit the `KUBEFLOW_COMPONENTS` environment variable. Delete `,\"alb-ingress-controller\",\"istio-ingress\"` and save the file.
 
     * Follow the [instructions](/docs/aws/authentication) to add authentication before you `apply k8s`
 
     Once your customization is done, you can run this command to deploy Kubeflow.
     ```shell
-    ${KUBEFLOW_SRC}/scripts/kfctl.sh apply k8s
+    kfctl apply k8s
     ```
 
 1. Wait for all the resources to become ready in the `kubeflow ` namespace.

--- a/content/docs/aws/deploy/uninstall-kubeflow.md
+++ b/content/docs/aws/deploy/uninstall-kubeflow.md
@@ -9,7 +9,7 @@ weight = 10
 
 ```
 cd ${KUBEFLOW_SRC}/${KFAPP}
-${KUBEFLOW_SRC}/scripts/kfctl.sh delete all
+kfctl delete all
 ```
 
 > Note: If you installed Kubeflow on an existing Amazon EKS cluster, these scripts won't tear down your cluster in this step. In this case, you must manually delete your cluster.

--- a/content/docs/aws/troubleshooting-aws.md
+++ b/content/docs/aws/troubleshooting-aws.md
@@ -21,7 +21,7 @@ Please remove the escape backslashes surrounding `{KUBEFLOW_TAG}`.
 
 ```shell
 + source env.sh
-/tmp/kubeflow-aws/scripts/kfctl.sh: line 485: env.sh: No such file or directory
+kfctl: line 485: env.sh: No such file or directory
 ```
 
 When you run generate/apply platform/k8s, Please make sure you verify the following steps and run your command from within the ${KFAPP} folder.
@@ -40,7 +40,7 @@ This happens if you have invalid arguments when you initialize your configuratio
 
 ### EKS Cluster Creation Failure
 
-There are several problems that could lead to cluster creation failure. If you see some errors when creating your cluster using `eksctl`, please open the CloudFormation console and check your stacks. To recover from failure, you need to follow the guidance from the `eksctl` output logs. Once you understand the root cause of your failure, you can delete your cluster and rerun `${KUBEFLOW_SRC}/scripts/kfctl.sh apply platform`.
+There are several problems that could lead to cluster creation failure. If you see some errors when creating your cluster using `eksctl`, please open the CloudFormation console and check your stacks. To recover from failure, you need to follow the guidance from the `eksctl` output logs. Once you understand the root cause of your failure, you can delete your cluster and rerun `kfctl apply platform`.
 
 Common issues:
 

--- a/content/docs/other-guides/troubleshooting.md
+++ b/content/docs/other-guides/troubleshooting.md
@@ -144,7 +144,7 @@ spec:
     path: "/mnt/pv1"
 EOF
 ```
- Repeat two more times creating a new directory and changing the name and path fields to satisfy all three PVCs. Once created the scheduler will successfully start the remaining three pods. The PVs may also be created prior to running any of the `kfctl.sh` commands.
+ Repeat two more times creating a new directory and changing the name and path fields to satisfy all three PVCs. Once created the scheduler will successfully start the remaining three pods. The PVs may also be created prior to running any of the `kfctl` commands.
 
 
 ## OpenShift


### PR DESCRIPTION
After deploying on GKE, I realized AWS' docs were slightly outdated. I'm working on fixing them up to be more in line with the current standards, and more concise for the sake of clarity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/763)
<!-- Reviewable:end -->
