### PR TITLE
Fixed link to Pipelines SDK reference

### DIFF
--- a/content/docs/pipelines/reference/_index.md
+++ b/content/docs/pipelines/reference/_index.md
@@ -3,5 +3,3 @@ title = "Reference"
 description = "Reference docs for Kubeflow Pipelines"
 weight = 55
 +++
-
-* [Python SDK reference docs](https://kubeflow-pipelines.readthedocs.io/en/latest/).

--- a/content/docs/pipelines/reference/sdk.md
+++ b/content/docs/pipelines/reference/sdk.md
@@ -1,0 +1,9 @@
++++
+title = " Pipelines SDK Reference"
+description = "Reference documentation for the Kubeflow Pipelines SDK."
+weight = 20
++++
+
+See the [generated reference docs for the Python 
+SDK](https://kubeflow-pipelines.readthedocs.io/en/latest/) (hosted on 
+*Read the Docs*).

--- a/content/docs/pipelines/reference/sdk.md
+++ b/content/docs/pipelines/reference/sdk.md
@@ -1,6 +1,6 @@
 +++
 title = " Pipelines SDK Reference"
-description = "Reference documentation for the Kubeflow Pipelines SDK."
+description = "Reference documentation for the Kubeflow Pipelines SDK"
 weight = 20
 +++
 


### PR DESCRIPTION
On this page:
https://www.kubeflow.org/docs/pipelines/reference/

PR https://github.com/kubeflow/website/pull/740 attempted to add a link to the Pipelines SDK docs, but the PR added the link in the wrong place. The result is no link.

Fixes https://github.com/kubeflow/website/issues/769
Fixes https://github.com/kubeflow/website/issues/345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/770)
<!-- Reviewable:end -->
