### PR TITLE
Improves link and formatting of Pipelines API reference docs

### DIFF
--- a/content/docs/pipelines/reference/api.md
+++ b/content/docs/pipelines/reference/api.md
@@ -1,7 +1,0 @@
-+++
-title = " Pipelines API Reference"
-description = "Reference documentation for the Kubeflow Pipelines API."
-weight = 10
-+++
-
-See the [generated reference for Kubeflow Pipelines API v0.1.20](/docs/pipelines/reference/api/kubeflow-pipeline-api-spec.html).

--- a/content/docs/pipelines/reference/api/kubeflow-pipeline-api-spec.html
+++ b/content/docs/pipelines/reference/api/kubeflow-pipeline-api-spec.html
@@ -1,3 +1,8 @@
++++
+title = "Pipelines API Reference"
+description = "Reference documentation for the Kubeflow Pipelines API"
+weight = 10
++++
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
There's an empty bullet point on the Pipelines reference index page:
https://www.kubeflow.org/docs/pipelines/reference/

And the navigation of the website is broken by the Pipelines API reference (generated HTML):
https://www.kubeflow.org/docs/pipelines/reference/api/kubeflow-pipeline-api-spec/

This PR goes some way to improving the situation, given that the HTML file is auto-generated from Swagger. The style of the website nav is affected by the styling injected by Swagger, but at least we have a navigation now. And the index page no longer has an empty bullet point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/772)
<!-- Reviewable:end -->
