### PR TITLE
Fixed path in gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Ignore the resources files in diffs and merge conflicts
-resources/    linguist-generated=true
-resources/    -diff -merge
+resources/**    linguist-generated=true
+resources/**    -diff -merge


### PR DESCRIPTION
Fixes https://github.com/kubeflow/website/issues/716

I've checked the [docs](https://git-scm.com/docs/gitattributes), which state:

> patterns that match a directory do not recursively match paths inside that directory (so using the trailing-slash `path/` syntax is pointless in an attributes file; use `path/**` instead)

I've also tested the new setting by making a change to the site's CSS, which resulted in a change in the files under `/resources` - it seemed to work as expected. I'll keep an eye on the diff/merge behaviour for CSS-related changes for a while.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/777)
<!-- Reviewable:end -->
