### PR TITLE
Added doc URL to 'Create issue' option

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,0 +1,15 @@
+{{ if .Path }}
+{{ $gh_repo := ($.Param "github_repo") }}
+{{ if $gh_repo }}
+<div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
+{{ $editURL := printf "%s/edit/master/content/%s" $gh_repo .Path }}
+{{ if .Site.IsMultiLingual }}
+{{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
+{{ end }}
+{{$doc_url := printf "https:%s" .Permalink }}
+{{ $issuesURL := printf "%s/issues/new?title=%s&body=%s" $gh_repo (htmlEscape $.Title) (htmlEscape $doc_url) }}
+<a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+</div>
+{{ end }}
+{{ end }}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -6,7 +6,7 @@
 {{ if .Site.IsMultiLingual }}
 {{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
 {{ end }}
-{{$doc_url := printf "https:%s" .Permalink }}
+{{$doc_url := printf "https://www.kubeflow.org%s" .URL }}
 {{ $issuesURL := printf "%s/issues/new?title=%s&body=%s" $gh_repo (htmlEscape $.Title) (htmlEscape $doc_url) }}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>


### PR DESCRIPTION
Added a site-specific version of the `layouts/partials/page-meta-links.html` file, so that I can add code to inject the page URL into any issue created when the user clicks the **Create issue** option on a doc page. In the file, line 9 is new and file 10 is adjusted to add the `body` of the issue:

```
{{$doc_url := printf "https://www.kubeflow.org%s" .URL }}
{{ $issuesURL := printf "%s/issues/new?title=%s&body=%s" $gh_repo (htmlEscape $.Title) (htmlEscape $doc_url) }}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/807)
<!-- Reviewable:end -->
