### PR TITLE
 Linked to the new Pipelines SDK intro from various pages

### DIFF
--- a/content/docs/notebooks/setup.md
+++ b/content/docs/notebooks/setup.md
@@ -256,6 +256,8 @@ exposed to the internet and is an unsecured endpoint by default.
 
 ## Next steps
 
+* Build machine-learning pipelines with the [Kubeflow Pipelines 
+  SDK](/docs/pipelines/sdk/sdk-overview/).
 * Explore [Kubeflow Fairing](/docs/fairing/) for a complete solution to 
   building, training, and deploying an ML model from a notebook.
 * Learn the advanced features available from a Kubeflow notebook, such as

--- a/content/docs/pipelines/overview/pipelines-overview.md
+++ b/content/docs/pipelines/overview/pipelines-overview.md
@@ -10,7 +10,7 @@ scalable machine learning (ML) workflows based on Docker containers.
 ## Quickstart
 
 Run your first pipeline by following the 
-[pipelines quickstart guide](/docs/guides/pipelines/pipelines-quickstart).
+[pipelines quickstart guide](/docs/pipelines/pipelines-quickstart).
 
 ## What is Kubeflow Pipelines?
 
@@ -213,7 +213,7 @@ At a high level, the execution of a pipeline proceeds as follows:
 ## Next steps
 
 * Follow the 
-  [pipelines quickstart guide](/docs/guides/pipelines/pipelines-quickstart) to 
+  [pipelines quickstart guide](/docs/pipelines/pipelines-quickstart) to 
   deploy Kubeflow and run a sample pipeline directly from the 
   Kubeflow Pipelines UI.
 * Build machine-learning pipelines with the [Kubeflow Pipelines 

--- a/content/docs/pipelines/overview/pipelines-overview.md
+++ b/content/docs/pipelines/overview/pipelines-overview.md
@@ -216,6 +216,8 @@ At a high level, the execution of a pipeline proceeds as follows:
   [pipelines quickstart guide](/docs/guides/pipelines/pipelines-quickstart) to 
   deploy Kubeflow and run a sample pipeline directly from the 
   Kubeflow Pipelines UI.
+* Build machine-learning pipelines with the [Kubeflow Pipelines 
+  SDK](/docs/pipelines/sdk/sdk-overview/).
 * Follow the full guide to experimenting with
   [the Kubeflow Pipelines samples](/docs/pipelines/tutorials/build-pipeline/).
   

--- a/content/docs/pipelines/pipelines-quickstart.md
+++ b/content/docs/pipelines/pipelines-quickstart.md
@@ -187,3 +187,5 @@ finished with them:
   Pipelines UI. Next, you may want to run a pipeline from a notebook, or compile 
   and run a sample from the code. See the guide to experimenting with
   [the Kubeflow Pipelines samples](/docs/pipelines/tutorials/build-pipeline/).
+* Build your own machine-learning pipelines with the [Kubeflow Pipelines 
+  SDK](/docs/pipelines/sdk/sdk-overview/).

--- a/content/docs/pipelines/sdk/install-sdk.md
+++ b/content/docs/pipelines/sdk/install-sdk.md
@@ -92,7 +92,7 @@ The response should be something like this:
 
 ## Next steps
 
+* [See how to use the SDK](/docs/pipelines/sdk/sdk-overview/).
 * [Build a component and a pipeline](/docs/pipelines/sdk/build-component/).
-* [Get started](/docs/pipelines/pipelines-quickstart) with the 
-  Kubeflow Pipelines UI.
-* Read more about [pipeline concepts](/docs/pipelines/concepts/).
+* [Get started with the UI](/docs/pipelines/pipelines-quickstart).
+* [Understand pipeline concepts](/docs/pipelines/concepts/).

--- a/content/docs/pipelines/tutorials/build-pipeline.md
+++ b/content/docs/pipelines/tutorials/build-pipeline.md
@@ -125,6 +125,8 @@ The following notebooks are available:
 
 ## Next steps
 
+* Understand the various ways to use the [Kubeflow Pipelines 
+  SDK](/docs/pipelines/sdk/sdk-overview/).
 * See how to 
   [build your own pipeline components](/docs/pipelines/sdk/build-component/).
 * Read more about 

--- a/content/docs/pipelines/tutorials/build-pipeline.md
+++ b/content/docs/pipelines/tutorials/build-pipeline.md
@@ -125,7 +125,7 @@ The following notebooks are available:
 
 ## Next steps
 
-* Understand the various ways to use the [Kubeflow Pipelines 
+* Learn the various ways to use the [Kubeflow Pipelines 
   SDK](/docs/pipelines/sdk/sdk-overview/).
 * See how to 
   [build your own pipeline components](/docs/pipelines/sdk/build-component/).

--- a/content/docs/pipelines/tutorials/pipelines-tutorial.md
+++ b/content/docs/pipelines/tutorials/pipelines-tutorial.md
@@ -565,6 +565,11 @@ gsutil rm -r gs://${BUCKET_NAME}
 As an alternative to the command line, you can delete the various resources 
 using the [GCP Console][gcp-console].
 
+## Next steps
+
+Build your own machine-learning pipelines with the [Kubeflow Pipelines 
+SDK](/docs/pipelines/sdk/sdk-overview/).
+
 [mnist-data]: http://yann.lecun.com/exdb/mnist/index.html
 
 [tensorflow]: https://www.tensorflow.org/

--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -67,10 +67,12 @@ to suit your environment (cloud, on premises (on prem), or local):
 
 See the [Kubeflow troubleshooting guide](/docs/other-guides/troubleshooting/).
 
-## Resources
+## Next steps
 
-* The [documentation](/docs/) provides in-depth instructions for using Kubeflow.
-* Self-paced scenarios for learning and trying out Kubeflow:
+* See the [documentation](/docs/) for in-depth instructions on using Kubeflow.
+* Build machine-learning pipelines with the [Kubeflow Pipelines 
+  SDK](/docs/pipelines/sdk/sdk-overview/).
+* Explore the self-paced scenarios for learning and trying out Kubeflow:
   * [Codelabs](https://codelabs.developers.google.com/?cat=tensorflow)
       * [Introduction to Kubeflow on Google Kubernetes
         Engine](https://codelabs.developers.google.com/codelabs/kubeflow-introduction/index.html)


### PR DESCRIPTION
We recently added an introduction to the Pipelines SDK (https://github.com/kubeflow/website/pull/811). This PR adds links from various pages to the new new intro, so that people can find the intro more easily.

I've also fixed a couple of links that pointed to the obsolete "guides" section - our redirects are handling those links, but it's good to fix them when we find them.

Where necessary, I've adjusted other lines in the "Next steps" sections to ensure that the bullet items have parallel syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/827)
<!-- Reviewable:end -->
