### PR TITLE
fix: conda environment selection

### DIFF
--- a/content/docs/pipelines/tutorials/pipelines-tutorial.md
+++ b/content/docs/pipelines/tutorials/pipelines-tutorial.md
@@ -286,7 +286,7 @@ Create a clean Python 3 environment (this tutorial uses Python 3.7):
  
 ```bash
 conda create --name mlpipeline python=3.7
-source activate mlpipeline
+conda activate mlpipeline
 ```
  
 If the `conda` command is not found, be sure to add Miniconda to your path:


### PR DESCRIPTION
This will remove the problem to ensure ```activate``` and ```deactivate``` are in the ```PATH```.

https://askubuntu.com/questions/1068768/when-using-conda-source-activate-env-name-doesnt-work-but-conda-activate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/828)
<!-- Reviewable:end -->
