### PR TITLE
Change 'source activate' to 'conda activate'

### DIFF
--- a/content/docs/pipelines/sdk/install-sdk.md
+++ b/content/docs/pipelines/sdk/install-sdk.md
@@ -65,7 +65,7 @@ up Python using [Miniconda](https://conda.io/miniconda.html):
  
     ```bash
     conda create --name mlpipeline python=3.7
-    source activate mlpipeline
+    conda activate mlpipeline
     ```
  
 ## Install the Kubeflow Pipelines SDK


### PR DESCRIPTION
Closes #830.

The [other](https://github.com/kubeflow/website/blob/aeccc6297bcf23d588b14cca6d732796ac2e3c59/content/docs/pipelines/tutorials/build-pipeline.md) occurrence of 'source activate' should not be change as it is not limited to conda and may refer to other virtual environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/831)
<!-- Reviewable:end -->
