### PR TITLE
Updated non-working URL

### DIFF
--- a/content/docs/components/pytorchserving.md
+++ b/content/docs/components/pytorchserving.md
@@ -31,7 +31,7 @@ docker run -v $(pwd):/my_model seldonio/core-python-wrapper:0.7 /my_model mnistd
 
 You can then push the image by running `gcloud docker -- push gcr.io/kubeflow-examples/mnistddpserving:0.1`.
 
-You can find more details about wrapping a model with seldon-core [here](https://github.com/SeldonIO/seldon-core/blob/master/docs/wrappers/python.md)
+You can find more details about wrapping a model with seldon-core [here](https://docs.seldon.io/projects/seldon-core/en/latest/python/index.html)
 
 ## Deploying the model to your Kubeflow cluster
 


### PR DESCRIPTION
Related to #826 though really more of an existing edit at this point.

While reading through the PyTorch Serving example I discovered the old URL to the Seldon Docs was not working. This appears to be their updated python wrapper documentation which has links to using Seldon-Core with Python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/895)
<!-- Reviewable:end -->
