### PR TITLE
GCP Auth guide

### DIFF
--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -22,7 +22,7 @@ associated with the account, and registering it with gcloud using
 [`gcloud auth activate-service-account`](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account).
 This is the recommended way to authenticate with GCP.
 
-- A **user account** is a Google (typically gmail) account that users can use to authenticate.
+- A **user account** is a Google (typically Gmail) account that users can use to authenticate.
 You can register a user account using [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login), 
 which brings up a browser window to start the familiar Google authentication flow.
 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -63,7 +63,7 @@ The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is 
 
 ### Connecting to a cluster using a GCP account
 If you set up your Kubernetes cluster using GKE, you can authenticate with the cluster using a GCP account. 
-The following commands fetch the credentials for your cluster and saves them to your local 
+The following commands fetch the credentials for your cluster and save them to your local 
 [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/):
 
 ```
@@ -172,7 +172,7 @@ spec:
 In [Kubeflow Pipelines](https://www.kubeflow.org/docs/pipelines/), each step describes a 
 container that is run independently. If you want to grant access for a single step to use
  one of your service accounts, you can use 
-[`kfp.gcp.use_gcp_secret()`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret)
+[`kfp.gcp.use_gcp_secret()`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret).
 Examples for how to use this function can be found in the 
 [Kubeflow examples repo](https://github.com/kubeflow/examples/blob/871895c54402f68685c8e227c954d86a81c0575f/pipelines/mnist-pipelines/mnist_pipeline.py#L97).
 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -30,7 +30,7 @@ More information can be found in the [GCP docs](https://cloud.google.com/sdk/doc
 
 ### Listing Active Accounts
 
-You can run the following commend to verify you are authenticating with the expected account. 
+You can run the following command to verify you are authenticating with the expected account. 
 Your active account will be denoted with an asterisk.
 
 ```
@@ -58,7 +58,7 @@ More information about IAM can be found in the
 [GCP docs](https://cloud.google.com/iam/docs/granting-changing-revoking-access).
 
 # Authenticating kubectl
-The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is used for interacting with a Kubernetes cluster through the command line
+The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is used for interacting with a Kubernetes cluster through the command line.
 
 ### Connecting to a Cluster using a GCP Account
 If you set up your Kubernetes cluster using GKE, you can authenticate with the cluster using a GCP account. 
@@ -115,6 +115,7 @@ More information can be found in the
 ### Adding RBAC Permissions
 If you find you are missing a permission you need, you can grant the missing roles to your service account using
 Kubernetes resources.
+
 - **Roles** describe the permissions you want to assign. For example, `verbs: ["create"], resources:["deployments"]`
 - **RoleBindings** define a mapping between the `Role`, and a specific service account
 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -103,7 +103,7 @@ right roles assigned to it, certain tasks will fail.
 
 To check if an account has the proper permissions to run a command, you can build a query structured as
 `kubectl auth can-i [VERB] [RESOURCE] --namespace [NAMESPACE]`. For example, the following command will verify
-that your account has permissions to create deployments in the `Kubeflow` namespace:
+that your account has permissions to create deployments in the `kubeflow` namespace:
 , 
 ```
 kubectl auth can-i create deployments --namespace kubeflow
@@ -126,8 +126,7 @@ More information can be found in the
 
 # In-Cluster Authentication
 
-### Kubeflow GCP Service Accounts
-When you set up Kubeflow for GCP, it will automatically 
+When you [set up Kubeflow for GCP](/docs/gke/deploy), it will automatically 
 [provision three service accounts](https://www.kubeflow.org/docs/gke/deploy/deploy-cli/#gcp-service-accounts) with different
 privileges. In particular, the `${KFAPP}-user` service account is meant to grant your user services access to GCP. 
 The credentials to this service account can be accessed within the cluster as a
@@ -138,12 +137,13 @@ The secret will have basic access to a limited set of GCP services by default, b
 
 ### Authentication from a Pod
 To access the service account from a Pod, you have to do two things:
+
 1. **Mount the secret as a file.** This will give your pod access to your GCP account, 
 so be careful which pods you grant access to.
 1. **Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable** to point to the service account.
 GCP libraries will use this environment variable to find the service account and authenticate with GCP.
 
-The following YAML describes Pod that has access to the `${KFAPP}-user` service account:
+The following YAML describes a Pod that has access to the `${KFAPP}-user` service account:
 ```
 apiVersion: v1
 kind: Pod
@@ -169,7 +169,7 @@ spec:
 ### Authentication from Kubeflow Pipelines
 In [Kubeflow Pipelines](https://www.kubeflow.org/docs/pipelines/), each step describes a 
 container that is run independently. If you want to grant access for a single step to use
-the credentials in one of your service account secrets, you can use 
+ one of your service accounts, you can use 
 [`kfp.gcp.use_gcp_secret()`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret)
 Examples for how to use this function can be found in the 
 [Kubeflow examples repo](https://github.com/kubeflow/examples/blob/871895c54402f68685c8e227c954d86a81c0575f/pipelines/mnist-pipelines/mnist_pipeline.py#L97).

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -1,6 +1,6 @@
 +++
 title = "Authenticating Kubeflow to GCP"
-description = "Troubleshooting guide for authentication and authorization to GCP"
+description = "Authentication and authorization to GCP"
 weight = 4
 +++
 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -15,17 +15,15 @@ and interact with other Google services.
 
 You have two options for authenticating the `gcloud` command:
 
+- You can use a **user account** to authenticate using a Google account (typically Gmail). 
+You can register a user account using [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login), 
+which brings up a browser window to start the familiar Google authentication flow.
 
 - You can create a **service account** within your GCP project. You can then
 [download a `.json` key file](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) 
 associated with the account, and run the 
 [`gcloud auth activate-service-account`](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account)
 command to authenticate your `gcloud` session.
-This is the recommended way to authenticate with GCP.
-
-- You can use a **user account** to authenticate using a Google account (typically Gmail). 
-You can register a user account using [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login), 
-which brings up a browser window to start the familiar Google authentication flow.
 
 You can find more information in the [GCP docs](https://cloud.google.com/sdk/docs/authorizing).
 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -27,12 +27,12 @@ This is the recommended way to authenticate with GCP.
 You can register a user account using [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login), 
 which brings up a browser window to start the familiar Google authentication flow.
 
-More information can be found in the [GCP docs](https://cloud.google.com/sdk/docs/authorizing).
+You can find more information in the [GCP docs](https://cloud.google.com/sdk/docs/authorizing).
 
 ### Listing active accounts
 
 You can run the following command to verify you are authenticating with the expected account. 
-Your active account will be denoted with an asterisk.
+In the output of the command, an asterisk denotes your active account.
 
 ```
 gcloud auth list
@@ -51,11 +51,11 @@ gcloud projects get-iam-policy $PROJECT_ID --flatten="bindings[].members" \
     --filter="bindings.members:$(gcloud config list account --format 'value(core.account)')"
 ```
 
-Roles can also be viewed and modified through the 
+You can view and modify roles through the 
 [GCP IAM console](https://console.cloud.google.com/iam-admin/).
 
 
-More information about IAM can be found in the 
+You can find more information about IAM in the 
 [GCP docs](https://cloud.google.com/iam/docs/granting-changing-revoking-access).
 
 # Authenticating kubectl
@@ -73,7 +73,7 @@ ZONE=your-gcp-zone
 gcloud container clusters get-credentials $CLUSTER_NAME --zone $ZONE
 ```
 
-More information can be found in the 
+You can find more information in the 
 [GCP docs](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl).
 
 ### Changing active clusters
@@ -93,7 +93,7 @@ CONTEXT_NAME=your-new-context
 kubectl config set-context $CONTEXT_NAME
 ```
 
-More information can be found in the 
+You can find more information in the 
 [Kubernetes docs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
 
 ### Checking RBAC permissions
@@ -110,7 +110,7 @@ that your account has permissions to create deployments in the `kubeflow` namesp
 kubectl auth can-i create deployments --namespace kubeflow
 ```
 
-More information can be found in the 
+You can find more information in the 
 [Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/authorization/).
 
 ### Adding RBAC permissions
@@ -123,7 +123,7 @@ Kubernetes resources.
 By default, `Roles` and `RoleBindings` apply only to resources in a specific namespace, but there are also
 `ClusterRoles` and `ClusterRoleBindings` that can grant access to resources cluster-wide
 
-More information can be found in the 
+You can find more information in the 
 [Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).
 
 # In-Cluster authentication

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -16,12 +16,11 @@ and interact with other Google services.
 There are two ways to authenticate the `gcloud` command:
 
 
-- A **service account** is an account set up within your GCP project. You can use a service account to
-authenticate to GCP by 
-[downloading a `.json` key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) 
-associated with the account, and running the 
+- You can create a **service account** within your GCP project. You can then
+[download a `.json` key file](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) 
+associated with the account, and run the 
 [`gcloud auth activate-service-account`](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account)
-command.
+command to authenticate your `gcloud` session.
 This is the recommended way to authenticate with GCP.
 
 - A **user account** is a Google (typically Gmail) account that end-users can use to authenticate.

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -8,7 +8,7 @@ weight = 4
 # Authenticating gcloud
 
 [The `gcloud` tool](https://cloud.google.com/sdk/gcloud/) is used to interact with Google Cloud Platform (GCP) over the command line. 
-It can be used to [set up Google Kubernetes Engine (GKE) clusters](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create), 
+You can use the `gcloud` command to [set up Google Kubernetes Engine (GKE) clusters](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create), 
 and interact with other Google services.
 
 ### Logging in
@@ -16,13 +16,15 @@ and interact with other Google services.
 There are two ways to authenticate the `gcloud` command:
 
 
-- A **service account** is an account set up within your GCP project. Authentication is handled by 
+- A **service account** is an account set up within your GCP project. You can use a service account to
+authenticate to GCP by 
 [downloading a `.json` key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) 
-associated with the account, and registering it with gcloud using 
-[`gcloud auth activate-service-account`](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account).
+associated with the account, and running the 
+[`gcloud auth activate-service-account`](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account)
+command.
 This is the recommended way to authenticate with GCP.
 
-- A **user account** is a Google (typically Gmail) account that users can use to authenticate.
+- A **user account** is a Google (typically Gmail) account that end-users can use to authenticate.
 You can register a user account using [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login), 
 which brings up a browser window to start the familiar Google authentication flow.
 
@@ -78,14 +80,14 @@ More information can be found in the
 ### Changing Active Clusters
 If you work with multiple Kubernetes clusters, you may have multiple contexts saved in your local 
 [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
-To view the clusters you have saved, run the following command:
+You can view the clusters you have saved by run the following command:
 
 ```
 kubectl config get-contexts
 ```
 
 This will show which cluster is currently being controlled by your `kubectl` commands.
-To change your active cluster, run the following command:
+You can change your active cluster with the following command:
 ```
 CONTEXT_NAME=your-new-context
 
@@ -101,7 +103,7 @@ Like GKE IAM, Kubernetes permissions are typically handled with a "role-based au
 Each Kubernetes service account has a set of authorized roles associated with it. If your account doesn't have the 
 right roles assigned to it, certain tasks will fail.
 
-To check if an account has the proper permissions to run a command, you can build a query structured as
+You can check if an account has the proper permissions to run a command by building a query structured as
 `kubectl auth can-i [VERB] [RESOURCE] --namespace [NAMESPACE]`. For example, the following command will verify
 that your account has permissions to create deployments in the `kubeflow` namespace:
 , 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -129,7 +129,7 @@ More information can be found in the
 ### Kubeflow GCP Service Accounts
 When you set up Kubeflow for GCP, it will automatically 
 [provision three service accounts](https://www.kubeflow.org/docs/gke/deploy/deploy-cli/#gcp-service-accounts) with different
-privileges. In particular, the `user-gcp-sa` service account is meant to grant your user services access to GCP. 
+privileges. In particular, the `${KFAPP}-user` service account is meant to grant your user services access to GCP. 
 The credentials to this service account can be accessed within the cluster as a
 [Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 
@@ -143,7 +143,7 @@ so be careful which pods you grant access to.
 1. **Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable** to point to the service account.
 GCP libraries will use this environment variable to find the service account and authenticate with GCP.
 
-The following YAML describes Pod that has access to the `user-gcp-sa` service account:
+The following YAML describes Pod that has access to the `${KFAPP}-user` service account:
 ```
 apiVersion: v1
 kind: Pod
@@ -155,21 +155,21 @@ spec:
     image: myimage
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: "/var/secrets/user-gcp-sa.json"
+      value: "/var/secrets/user-sa.json"
     volumeMounts:
     - name: gcp-secret
-      mountPath: "/var/secrets/user-gcp-sa.json"
+      mountPath: "/var/secrets/user-sa.json"
       readOnly: true
   volumes:
   - name: gcp-secret
     secret:
-      secretName: user-gcp-sa
+      secretName: myappname-user
 ```
 
 ### Authentication from Kubeflow Pipelines
 In [Kubeflow Pipelines](https://www.kubeflow.org/docs/pipelines/), each step describes a 
 container that is run independently. If you want to grant access for a single step to use
 the credentials in one of your service account secrets, you can use 
-[`kfp.gcp.use_gcp_secret(user-gcp-sa)`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret)
+[`kfp.gcp.use_gcp_secret()`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret)
 Examples for how to use this function can be found in the 
 [Kubeflow examples repo](https://github.com/kubeflow/examples/blob/871895c54402f68685c8e227c954d86a81c0575f/pipelines/mnist-pipelines/mnist_pipeline.py#L97).

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -137,7 +137,8 @@ The secret will have basic access to a limited set of GCP services by default, b
 [GCP IAM console](https://console.cloud.google.com/iam-admin/).
 
 ### Authentication from a Pod
-To access the service account from a Pod, you have to do two things:
+
+You must do two things to access a GCP service account from a Pod:
 
 1. **Mount the secret as a file.** This will give your Pod access to your GCP account, 
 so be careful which Pods you grant access to.

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -1,0 +1,170 @@
+## Authenticating gcloud
+
+[The `gcloud` tool](https://cloud.google.com/sdk/gcloud/) is used to interact with Google Cloud Platform (GCP) over the command line. 
+It can be used to [set up Google Kubernetes Engine (GKE) clusters](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create), 
+and interact with other Google services.
+
+#### Logging in
+
+There are two ways to authenticate the gcloud command:
+
+
+- A **service account** is an account set up within your GCP project. Authentication is handled by 
+[downloading a `.json` key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) 
+associated with the account, and registering it with gcloud using 
+[`gcloud auth activate-service-account`](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account).
+This is the recommended way to authenticate with GCP.
+
+- A **user account** is a Google (typically gmail) account that users can use to authenticate.
+You can register a user account using [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login), 
+which brings up a browser window to start the familiar Google authentication flow.
+
+More information can be found in the [GCP docs](https://cloud.google.com/sdk/docs/authorizing).
+
+#### Listing Active Accounts
+
+You can run the following commend to verify you are authenticating with the expected account. 
+Your active account will be denoted with an asterisk.
+
+```
+gcloud auth list
+```
+
+#### IAM Roles
+
+Permissions are handled in GCP using [IAM Roles](https://cloud.google.com/iam/docs/understanding-roles). 
+These roles define which resources your account can read or write to. You can check which roles were assigned to your account using the following gcloud command:
+
+```
+PROJECT_ID=your-gcp-project-id-here
+
+gcloud projects get-iam-policy $PROJECT_ID --flatten="bindings[].members" \
+    --format='table(bindings.role)' \
+    --filter="bindings.members:$(gcloud config list account --format 'value(core.account)')"
+```
+
+Roles can also be viewed and modified through the 
+[GCP IAM console](https://console.cloud.google.com/iam-admin/).
+
+
+More information about IAM can be found in the 
+[GCP docs](https://cloud.google.com/iam/docs/granting-changing-revoking-access).
+
+## Authenticating kubectl
+The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is used for interacting with a Kubernetes cluster through the command line
+
+### Authorizing with a GCP Account
+If you set up your Kubernetes cluster using GKE, you can authenticate with the cluster using a GCP account. 
+The following command will fetch the credentials for your cluster and save them to your local 
+[`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/):
+
+```
+CLUSTER_NAME=your-gke-cluster
+ZONE=your-gcp-zone
+
+gcloud container clusters get-credentials $CLUSTER_NAME --zone $ZONE
+```
+
+More information can be found in the 
+[GCP docs](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl).
+
+### Changing Active Clusters
+If you work with multiple Kubernetes clusters, you may have multiple contexts saved in your local 
+[`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
+To view the clusters you have saved, run the following command:
+
+```
+kubectl config get-contexts
+```
+
+This will show which cluster is currently being controlled by your `kubectl` commands.
+To change your active cluster, run the following command:
+```
+CONTEXT_NAME=your-new-context
+
+kubectl config set-context $CONTEXT_NAME
+```
+
+More information can be found in the 
+[Kubernetes docs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
+
+### Checking RBAC Permissions
+
+Like GKE IAM, Kubernetes permissions are typically handled with a "role-based authorization control" (RBAC) system.
+Each Kubernetes service account has a set of authorized roles associated with it. If your account doesn't have the 
+right roles assigned to it, certain tasks will fail.
+
+To check if an account has the proper permissions to run a command, you can build a query structured as
+`kubectl auth can-i [VERB] [RESOURCE] --namespace [NAMESPACE]`. For example, the following command will verify
+that your account has permissions to create deployments in the `Kubeflow` namespace:
+, 
+```
+kubectl auth can-i create deployments --namespace kubeflow
+```
+
+More information can be found in the 
+[Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/authorization/).
+
+### Adding RBAC Permissions
+If you find you are missing a permission you need, you can grant the missing roles to your service account using
+Kubernetes resources.
+- **Roles** describe the permissions you want to assign. For example, `verbs: ["create"], resources:["deployments"]`
+- **RoleBindings** define a mapping between the `Role`, and a specific service account
+
+By default, `Roles` and `RoleBindings` apply only to resources in a specific namespace, but there are also
+`ClusterRoles` and `ClusterRoleBindings` that can grant access to resources cluster-wide
+
+More information can be found in the 
+[Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).
+
+## In-Cluster Authentication
+Sometimes, you may wish to authenticate to GCP from within the cluster, to upload a file to Google Container 
+Storage for example. The recommended way to do this is using the Kubeflow GCP service accounts.
+
+### Kubeflow GCP Service Accounts
+When you set up Kubeflow for GCP, it will automatically 
+[provision three service accounts](https://www.kubeflow.org/docs/gke/deploy/deploy-cli/#gcp-service-accounts) with different
+privileges. In particular, the `user-gcp-sa` service account is meant to grant your user services access to GCP. 
+The credentials to this service account can be accessed within the cluster as a
+[Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+The secret will have basic access to a limited set of GCP services by default, but more roles can be granted through the
+[GCP IAM console](https://console.cloud.google.com/iam-admin/).
+
+### Authentication from a Pod
+To access the service account from a Pod, you have to do two things:
+1. **Mount the secret as a file.** This will give your pod access to your GCP account, 
+so be careful which pods you grant access to.
+1. **Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable** to point to the service account.
+GCP libraries will use this environment variable to find the service account and authenticate with GCP.
+
+The following YAML describes Pod that has access to the `user-gcp-sa` service account:
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mypod
+spec:
+  containers:
+  - name: mypod
+    image: myimage
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: "/var/secrets/user-gcp-sa.json"
+    volumeMounts:
+    - name: gcp-secret
+      mountPath: "/var/secrets/user-gcp-sa.json"
+      readOnly: true
+  volumes:
+  - name: gcp-secret
+    secret:
+      secretName: user-gcp-sa
+```
+
+### Authentication from Kubeflow Pipelines
+In [Kubeflow Pipelines](https://www.kubeflow.org/docs/pipelines/), each step describes a 
+container that is run independently. If you want to grant access for a single step to use
+the credentials in one of your service account secrets, you can use 
+[`kfp.gcp.use_gcp_secret(user-gcp-sa)`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret)
+Examples for how to use this function can be found in the 
+[Kubeflow examples repo](https://github.com/kubeflow/examples/blob/871895c54402f68685c8e227c954d86a81c0575f/pipelines/mnist-pipelines/mnist_pipeline.py#L97).

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -5,7 +5,7 @@ weight = 4
 +++
 
 
-# In-Cluster authentication
+# In-cluster authentication
 
 When you [set up Kubeflow for GCP](/docs/gke/deploy), it will automatically 
 [provision three service accounts](https://www.kubeflow.org/docs/gke/deploy/deploy-cli/#gcp-service-accounts) with different
@@ -57,8 +57,10 @@ Examples for how to use this function can be found in the
 [Kubeflow examples repo](https://github.com/kubeflow/examples/blob/871895c54402f68685c8e227c954d86a81c0575f/pipelines/mnist-pipelines/mnist_pipeline.py#L97).
 
 
+# Local Authentication
 
-# Authenticating gcloud
+## gcloud
+
 
 [The `gcloud` tool](https://cloud.google.com/sdk/gcloud/) is used to interact with Google Cloud Platform (GCP) over the command line. 
 You can use the `gcloud` command to [set up Google Kubernetes Engine (GKE) clusters](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create), 
@@ -109,7 +111,9 @@ You can view and modify roles through the
 You can find more information about IAM in the 
 [GCP docs](https://cloud.google.com/iam/docs/granting-changing-revoking-access).
 
-# Authenticating kubectl
+---
+
+## kubectl
 The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is used for interacting with a Kubernetes cluster through the command line.
 
 ### Connecting to a cluster using a GCP account

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -95,7 +95,9 @@ gcloud auth list
 ##### Viewing IAM roles
 
 Permissions are handled in GCP using [IAM Roles](https://cloud.google.com/iam/docs/understanding-roles). 
-These roles define which resources your account can read or write to. You can check which roles were assigned to your account using the following gcloud command:
+These roles define which resources your account can read or write to. Provided you have the 
+[necessary permissions](https://cloud.google.com/iam/docs/understanding-custom-roles#required_permissions_and_roles_),
+you can check which roles were assigned to your account using the following gcloud command:
 
 ```
 PROJECT_ID=your-gcp-project-id-here

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -29,7 +29,7 @@ which brings up a browser window to start the familiar Google authentication flo
 
 More information can be found in the [GCP docs](https://cloud.google.com/sdk/docs/authorizing).
 
-### Listing Active Accounts
+### Listing active accounts
 
 You can run the following command to verify you are authenticating with the expected account. 
 Your active account will be denoted with an asterisk.
@@ -38,7 +38,7 @@ Your active account will be denoted with an asterisk.
 gcloud auth list
 ```
 
-### Viewing IAM Roles
+### Viewing IAM roles
 
 Permissions are handled in GCP using [IAM Roles](https://cloud.google.com/iam/docs/understanding-roles). 
 These roles define which resources your account can read or write to. You can check which roles were assigned to your account using the following gcloud command:
@@ -61,7 +61,7 @@ More information about IAM can be found in the
 # Authenticating kubectl
 The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is used for interacting with a Kubernetes cluster through the command line.
 
-### Connecting to a Cluster using a GCP Account
+### Connecting to a cluster using a GCP account
 If you set up your Kubernetes cluster using GKE, you can authenticate with the cluster using a GCP account. 
 The following command will fetch the credentials for your cluster and save them to your local 
 [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/):
@@ -76,7 +76,7 @@ gcloud container clusters get-credentials $CLUSTER_NAME --zone $ZONE
 More information can be found in the 
 [GCP docs](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl).
 
-### Changing Active Clusters
+### Changing active clusters
 If you work with multiple Kubernetes clusters, you may have multiple contexts saved in your local 
 [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
 You can view the clusters you have saved by run the following command:
@@ -96,7 +96,7 @@ kubectl config set-context $CONTEXT_NAME
 More information can be found in the 
 [Kubernetes docs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
 
-### Checking RBAC Permissions
+### Checking RBAC permissions
 
 Like GKE IAM, Kubernetes permissions are typically handled with a "role-based authorization control" (RBAC) system.
 Each Kubernetes service account has a set of authorized roles associated with it. If your account doesn't have the 
@@ -113,7 +113,7 @@ kubectl auth can-i create deployments --namespace kubeflow
 More information can be found in the 
 [Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/authorization/).
 
-### Adding RBAC Permissions
+### Adding RBAC permissions
 If you find you are missing a permission you need, you can grant the missing roles to your service account using
 Kubernetes resources.
 
@@ -126,7 +126,7 @@ By default, `Roles` and `RoleBindings` apply only to resources in a specific nam
 More information can be found in the 
 [Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).
 
-# In-Cluster Authentication
+# In-Cluster authentication
 
 When you [set up Kubeflow for GCP](/docs/gke/deploy), it will automatically 
 [provision three service accounts](https://www.kubeflow.org/docs/gke/deploy/deploy-cli/#gcp-service-accounts) with different
@@ -140,8 +140,8 @@ The secret will have basic access to a limited set of GCP services by default, b
 ### Authentication from a Pod
 To access the service account from a Pod, you have to do two things:
 
-1. **Mount the secret as a file.** This will give your pod access to your GCP account, 
-so be careful which pods you grant access to.
+1. **Mount the secret as a file.** This will give your Pod access to your GCP account, 
+so be careful which Pods you grant access to.
 1. **Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable** to point to the service account.
 GCP libraries will use this environment variable to find the service account and authenticate with GCP.
 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -5,7 +5,7 @@ weight = 4
 +++
 
 
-# In-cluster authentication
+## In-cluster authentication
 
 When you [set up Kubeflow for GCP](/docs/gke/deploy), it will automatically 
 [provision three service accounts](https://www.kubeflow.org/docs/gke/deploy/deploy-cli/#gcp-service-accounts) with different
@@ -56,17 +56,18 @@ container that is run independently. If you want to grant access for a single st
 Examples for how to use this function can be found in the 
 [Kubeflow examples repo](https://github.com/kubeflow/examples/blob/871895c54402f68685c8e227c954d86a81c0575f/pipelines/mnist-pipelines/mnist_pipeline.py#L97).
 
+---
 
-# Local Authentication
+## Local Authentication
 
-## gcloud
+### gcloud
 
 
 [The `gcloud` tool](https://cloud.google.com/sdk/gcloud/) is used to interact with Google Cloud Platform (GCP) over the command line. 
 You can use the `gcloud` command to [set up Google Kubernetes Engine (GKE) clusters](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create), 
 and interact with other Google services.
 
-### Logging in
+##### Logging in
 
 You have two options for authenticating the `gcloud` command:
 
@@ -82,7 +83,7 @@ command to authenticate your `gcloud` session.
 
 You can find more information in the [GCP docs](https://cloud.google.com/sdk/docs/authorizing).
 
-### Listing active accounts
+##### Listing active accounts
 
 You can run the following command to verify you are authenticating with the expected account. 
 In the output of the command, an asterisk denotes your active account.
@@ -91,7 +92,7 @@ In the output of the command, an asterisk denotes your active account.
 gcloud auth list
 ```
 
-### Viewing IAM roles
+##### Viewing IAM roles
 
 Permissions are handled in GCP using [IAM Roles](https://cloud.google.com/iam/docs/understanding-roles). 
 These roles define which resources your account can read or write to. You can check which roles were assigned to your account using the following gcloud command:
@@ -113,10 +114,10 @@ You can find more information about IAM in the
 
 ---
 
-## kubectl
+### kubectl
 The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is used for interacting with a Kubernetes cluster through the command line.
 
-### Connecting to a cluster using a GCP account
+##### Connecting to a cluster using a GCP account
 If you set up your Kubernetes cluster using GKE, you can authenticate with the cluster using a GCP account. 
 The following commands fetch the credentials for your cluster and save them to your local 
 [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/):
@@ -131,7 +132,7 @@ gcloud container clusters get-credentials $CLUSTER_NAME --zone $ZONE
 You can find more information in the 
 [GCP docs](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl).
 
-### Changing active clusters
+##### Changing active clusters
 If you work with multiple Kubernetes clusters, you may have multiple contexts saved in your local 
 [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
 You can view the clusters you have saved by run the following command:
@@ -150,7 +151,7 @@ kubectl config set-context $CONTEXT_NAME
 You can find more information in the 
 [Kubernetes docs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/).
 
-### Checking RBAC permissions
+##### Checking RBAC permissions
 
 Like GKE IAM, Kubernetes permissions are typically handled with a "role-based authorization control" (RBAC) system.
 Each Kubernetes service account has a set of authorized roles associated with it. If your account doesn't have the 
@@ -167,7 +168,7 @@ kubectl auth can-i create deployments --namespace kubeflow
 You can find more information in the 
 [Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/authorization/).
 
-### Adding RBAC permissions
+##### Adding RBAC permissions
 If you find you are missing a permission you need, you can grant the missing roles to your service account using
 Kubernetes resources.
 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -63,7 +63,7 @@ The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is 
 
 ### Connecting to a cluster using a GCP account
 If you set up your Kubernetes cluster using GKE, you can authenticate with the cluster using a GCP account. 
-The following command will fetch the credentials for your cluster and save them to your local 
+The following commands fetch the credentials for your cluster and saves them to your local 
 [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/):
 
 ```
@@ -85,8 +85,7 @@ You can view the clusters you have saved by run the following command:
 kubectl config get-contexts
 ```
 
-This will show which cluster is currently being controlled by your `kubectl` commands.
-You can change your active cluster with the following command:
+You can view which cluster is currently being controlled by your `kubectl` tool with the following command:
 ```
 CONTEXT_NAME=your-new-context
 
@@ -105,7 +104,7 @@ right roles assigned to it, certain tasks will fail.
 You can check if an account has the proper permissions to run a command by building a query structured as
 `kubectl auth can-i [VERB] [RESOURCE] --namespace [NAMESPACE]`. For example, the following command will verify
 that your account has permissions to create deployments in the `kubeflow` namespace:
-, 
+
 ```
 kubectl auth can-i create deployments --namespace kubeflow
 ```
@@ -175,3 +174,7 @@ container that is run independently. If you want to grant access for a single st
 [`kfp.gcp.use_gcp_secret()`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret)
 Examples for how to use this function can be found in the 
 [Kubeflow examples repo](https://github.com/kubeflow/examples/blob/871895c54402f68685c8e227c954d86a81c0575f/pipelines/mnist-pipelines/mnist_pipeline.py#L97).
+
+## Next steps
+
+See the [troubleshooting guide](/docs/gke/troubleshooting-gke/) for help with diagnosing and fixing issues you may encounter with Kubeflow on GCP

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -13,7 +13,7 @@ and interact with other Google services.
 
 ### Logging in
 
-There are two ways to authenticate the gcloud command:
+There are two ways to authenticate the `gcloud` command:
 
 
 - A **service account** is an account set up within your GCP project. Authentication is handled by 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -13,7 +13,7 @@ and interact with other Google services.
 
 ### Logging in
 
-There are two ways to authenticate the `gcloud` command:
+You have two options for authenticating the `gcloud` command:
 
 
 - You can create a **service account** within your GCP project. You can then
@@ -23,7 +23,7 @@ associated with the account, and run the
 command to authenticate your `gcloud` session.
 This is the recommended way to authenticate with GCP.
 
-- A **user account** is a Google (typically Gmail) account that end-users can use to authenticate.
+- You can use a **user account** to authenticate using a Google account (typically Gmail). 
 You can register a user account using [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login), 
 which brings up a browser window to start the familiar Google authentication flow.
 
@@ -85,7 +85,7 @@ You can view the clusters you have saved by run the following command:
 kubectl config get-contexts
 ```
 
-You can view which cluster is currently being controlled by your `kubectl` tool with the following command:
+You can view which cluster is currently being controlled by `kubectl` with the following command:
 ```
 CONTEXT_NAME=your-new-context
 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -125,8 +125,6 @@ More information can be found in the
 [Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).
 
 # In-Cluster Authentication
-Sometimes, you may wish to authenticate to GCP from within the cluster, to upload a file to Google Container 
-Storage for example. The recommended way to do this is using the Kubeflow GCP service accounts.
 
 ### Kubeflow GCP Service Accounts
 When you set up Kubeflow for GCP, it will automatically 

--- a/content/docs/gke/authentication.md
+++ b/content/docs/gke/authentication.md
@@ -1,10 +1,17 @@
-## Authenticating gcloud
++++
+title = "Authenticating Kubeflow to GCP"
+description = "Troubleshooting guide for authentication and authorization to GCP"
+weight = 4
++++
+
+
+# Authenticating gcloud
 
 [The `gcloud` tool](https://cloud.google.com/sdk/gcloud/) is used to interact with Google Cloud Platform (GCP) over the command line. 
 It can be used to [set up Google Kubernetes Engine (GKE) clusters](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create), 
 and interact with other Google services.
 
-#### Logging in
+### Logging in
 
 There are two ways to authenticate the gcloud command:
 
@@ -21,7 +28,7 @@ which brings up a browser window to start the familiar Google authentication flo
 
 More information can be found in the [GCP docs](https://cloud.google.com/sdk/docs/authorizing).
 
-#### Listing Active Accounts
+### Listing Active Accounts
 
 You can run the following commend to verify you are authenticating with the expected account. 
 Your active account will be denoted with an asterisk.
@@ -30,7 +37,7 @@ Your active account will be denoted with an asterisk.
 gcloud auth list
 ```
 
-#### IAM Roles
+### Viewing IAM Roles
 
 Permissions are handled in GCP using [IAM Roles](https://cloud.google.com/iam/docs/understanding-roles). 
 These roles define which resources your account can read or write to. You can check which roles were assigned to your account using the following gcloud command:
@@ -50,10 +57,10 @@ Roles can also be viewed and modified through the
 More information about IAM can be found in the 
 [GCP docs](https://cloud.google.com/iam/docs/granting-changing-revoking-access).
 
-## Authenticating kubectl
+# Authenticating kubectl
 The [`kubectl` tool](https://kubernetes.io/docs/reference/kubectl/overview/) is used for interacting with a Kubernetes cluster through the command line
 
-### Authorizing with a GCP Account
+### Connecting to a Cluster using a GCP Account
 If you set up your Kubernetes cluster using GKE, you can authenticate with the cluster using a GCP account. 
 The following command will fetch the credentials for your cluster and save them to your local 
 [`kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/):
@@ -117,7 +124,7 @@ By default, `Roles` and `RoleBindings` apply only to resources in a specific nam
 More information can be found in the 
 [Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).
 
-## In-Cluster Authentication
+# In-Cluster Authentication
 Sometimes, you may wish to authenticate to GCP from within the cluster, to upload a file to Google Container 
 Storage for example. The recommended way to do this is using the Kubeflow GCP service accounts.
 


### PR DESCRIPTION
I wrote an auth guide to explain how to authenticate/control access to the different systems that make up Kubeflow on GCP. 

Related to https://github.com/kubeflow/website/issues/679

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/916)
<!-- Reviewable:end -->
