### PR TITLE
fix bash brace expansion in troubleshooting guide

### DIFF
--- a/content/docs/other-guides/troubleshooting.md
+++ b/content/docs/other-guides/troubleshooting.md
@@ -127,7 +127,7 @@ If you have not configured [dynamic provisioning] (https://kubernetes.io/docs/co
 You can use the example below to create local persistent volumes.
 
 ```commandline
-sudo mkdir /mnt/pv[1-3]
+sudo mkdir /mnt/pv{1..3}
 
 kubectl create -f - <<EOF
 kind: PersistentVolume


### PR DESCRIPTION
I goofed this up in my last PR.

    sudo mkdir /mnt/pv[1-3]

creates a single directory name `/mnt/pv[1-3]`. Instead, we want

    sudo mkdir /mnt/pv{1..3}

which will create the desired 3 directories: `/mnt/pv1`, `/mnt/pv2`, and `/mnt/pv3`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/936)
<!-- Reviewable:end -->
