### PR TITLE
AWS_REGION to REGION

### DIFF
--- a/content/docs/aws/deploy/existing-cluster.md
+++ b/content/docs/aws/deploy/existing-cluster.md
@@ -42,6 +42,6 @@ If you would like to deploy Kubeflow on existing Amazon EKS cluster, the only di
 
     ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform aws \
     --awsClusterName ${AWS_CLUSTER_NAME} \
-    --awsRegion ${AWS_REGION} \
+    --awsRegion ${REGION} \
     --awsNodegroupRoleNames ${AWS_NODEGROUP_ROLE_NAMES}
     ```


### PR DESCRIPTION
I found that we use `REGION` env parameter for aws_region at the document, but one command use `AWS_REGION` which isn't declared.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/944)
<!-- Reviewable:end -->
