### PR TITLE
add statement about assumerole

### DIFF
--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -23,7 +23,7 @@ deploy Kubeflow on Amazon Web Services (AWS).
 
 You do not need to have an existing Amazon Elastic Container Service for Kubernetes (Amazon EKS) cluster. The deployment process will create a cluster for you.
 
-The installation tool uses the `eksctl` command and doesn't support  the `--profile` [option]().
+The installation tool uses the `eksctl` command and doesn't support the `--profile` option in that command.
 If you need to switch role, use the `aws sts assume-role` commands. See the AWS guide to [using temporary security credentials to request access to AWS resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).
 
 

--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -23,8 +23,8 @@ deploy Kubeflow on Amazon Web Services (AWS).
 
 You do not need to have an existing Amazon Elastic Container Service for Kubernetes (Amazon EKS) cluster. The deployment process will create a cluster for you.
 
-The install tools uses `eksctl` command, and doesn't support `--profile` option, now.
-So please use `aws sts assume-role` commands with [this document](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) if you use switch role.
+The installation tool uses the `eksctl` command and doesn't support  the `--profile` [option]().
+If you need to switch role, use the `aws sts assume-role` commands. See the AWS guide to [using temporary security credentials to request access to AWS resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).
 
 
 ## Understanding the deployment process

--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -23,6 +23,9 @@ deploy Kubeflow on Amazon Web Services (AWS).
 
 You do not need to have an existing Amazon Elastic Container Service for Kubernetes (Amazon EKS) cluster. The deployment process will create a cluster for you.
 
+The install tools uses `eksctl` command, and doesn't support `--profile` option, now.
+So please use `aws sts assume-role` commands with [this document](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) if you use switch role.
+
 
 ## Understanding the deployment process
 


### PR DESCRIPTION
Currently kubeflow's installation script use `eksctl` commands such as below.
https://github.com/kubeflow/kubeflow/blob/master/scripts/aws/util.sh#L28

But the command option is hard coded and we can't use `--profile` option.
When we'd like to install kubeflow using switch role, we have to use `aws sts assume-role` before installation.
I think it's better to write about it on the installation document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/947)
<!-- Reviewable:end -->
