### PR TITLE
Fixed links to tutorials and codelabs

### DIFF
--- a/content/docs/examples/codelabs-tutorials.md
+++ b/content/docs/examples/codelabs-tutorials.md
@@ -1,41 +1,42 @@
 +++
 title = "Codelabs, Workshops, and Tutorials"
-description = "Recommended end-to-end tutorials, workshops, walk-throughs, and codelabs"
+description = "Recommended end-to-end tutorials, workshops, walk throughs, and codelabs"
 weight = 20
 +++
 
-{{% blocks/content-item title="OpenShift Kubeflow Workshop"
-  url="https://github.com/AICoE/openshift_kubeflow_workshop" %}}
-Run Kubeflow on Red Hat [OpenShift](https://www.openshift.com/).
-{{% /blocks/content-item %}}
+## Agile Stacks Kubeflow Pipelines tutorials
 
-{{% blocks/content-item title="Agile Stacks Kubeflow Pipelines Tutorial"
-  url="https://www.agilestacks.com/tutorials/ml-pipelines" %}}
 Run Kubeflow Pipelines tutorials on AWS, GCP, or on-prem hardware using [Agile Stacks](https://www.agilestacks.com/).
 Pipeline templates provide step-by-step examples for working with object storage filesystem, Kaniko, Keras, and Seldon.
-{{% /blocks/content-item %}}
 
-{{% blocks/content-item title="Katacoda scenarios"
-  url="https://www.katacoda.com/kubeflow" %}}
-Follow the tutorials to deploy Kubeflow and run a machine learning model.
-{{% /blocks/content-item %}}
+* [ML Pipeline Templates: End-to-end Tutorial](https://www.agilestacks.com/tutorials/ml-pipelines).
 
-{{% blocks/content-item title="Introduction to Kubeflow Codelab"
-  url="https://codelabs.developers.google.com/codelabs/kubeflow-introduction/index.html" %}}
-Run MNIST with Kubeflow on Google Kubernetes Engine.
-{{% /blocks/content-item %}}
+## Google codelabs
 
-{{% blocks/content-item title="Introduction to Kubeflow Qwiklab"
-  url="https://www.qwiklabs.com/catalog_lab/933" %}}
-Run MNIST with resources provided by Qwiklabs.
-{{% /blocks/content-item %}}
+Google Developers Codelabs provide a guided, tutorial, hands-on coding experience.
 
-{{% blocks/content-item title="Kubeflow End to End Codelab"
-  url="https://codelabs.developers.google.com/codelabs/cloud-kubeflow-e2e-gis/index.html" %}}
-Run GitHub Issue Summarization with Kubeflow on Google Kubernetes Engine.
-{{% /blocks/content-item %}}
+* [Introduction to Kubeflow on GKE](https://codelabs.developers.google.com/codelabs/kubeflow-introduction/index.html): Run MNIST with Kubeflow on Google Kubernetes Engine (GKE).
 
-{{% blocks/content-item title="Kubeflow End to End Qwiklab"
-  url="https://www.qwiklabs.com/catalog_lab/1046" %}}
-Run GitHub Issue Summarization with resources provided by Qwiklabs.
-{{% /blocks/content-item %}}
+* [Kubeflow End to End - GitHub Issue Summarization](https://codelabs.developers.google.com/codelabs/cloud-kubeflow-e2e-gis/): Run GitHub Issue Summarization with Kubeflow on GKE.
+
+* [Kubeflow Pipelines - GitHub Issue
+  Summarization](https://codelabs.developers.google.com/codelabs/cloud-kubeflow-pipelines-gis/index.html): Run GitHub Issue Summarization with Kubeflow Pipelines on GKE.
+
+## Katacoda scenarios
+
+Follow the [Katacoda tutorials](https://www.katacoda.com/kubeflow) to deploy Kubeflow and run a machine learning model.
+
+* [Deploying GitHub Issue Summarization with
+  Kubeflow](https://www.katacoda.com/kubeflow/scenarios/deploying-github-issue-summarization).
+* [Deploying
+  Kubeflow](https://www.katacoda.com/kubeflow/scenarios/deploying-kubeflow).
+* [Deploying Kubeflow with
+  ksonnet](https://www.katacoda.com/kubeflow/scenarios/deploying-kubeflow-with-ksonnet).
+* [Deploying Pytorch with
+  Kubeflow](https://www.katacoda.com/kubeflow/scenarios/deploy-pytorch-with-kubeflow).
+
+## OpenShift Kubeflow workshops
+
+Run Kubeflow on [Red Hat OpenShift](https://www.openshift.com/).
+
+* [Kubeflow on OpenShift Workshop](https://github.com/AICoE/openshift_kubeflow_workshop).

--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -101,28 +101,8 @@ See the [Kubeflow troubleshooting guide](/docs/other-guides/troubleshooting/).
 
 ## Next steps
 
-* See the [documentation](/docs/) for in-depth instructions on using Kubeflow.
+* Read the [documentation](/docs/) for in-depth instructions on using Kubeflow.
+* Explore the [tutorials and 
+  codelabs](/docs/examples/codelabs-tutorials/) for learning and trying out Kubeflow.
 * Build machine-learning pipelines with the [Kubeflow Pipelines
   SDK](/docs/pipelines/sdk/sdk-overview/).
-* Explore the self-paced scenarios for learning and trying out Kubeflow:
-  * [Codelabs](https://codelabs.developers.google.com/?cat=tensorflow)
-      * [Introduction to Kubeflow on Google Kubernetes
-        Engine](https://codelabs.developers.google.com/codelabs/kubeflow-introduction/index.html)
-      * [Kubeflow End to End: GitHub Issue
-        Summarization](https://codelabs.developers.google.com/codelabs/cloud-kubeflow-e2e-gis/index.html)
-      * [Kubeflow Pipelines: GitHub Issue
-        Summarization](https://codelabs.developers.google.com/codelabs/cloud-kubeflow-pipelines-gis/index.html)
-  * [Katacoda](https://www.katacoda.com/kubeflow)
-      * [Deploying GitHub Issue Summarization with
-        Kubeflow](https://www.katacoda.com/kubeflow/scenarios/deploying-github-issue-summarization)
-      * [Deploying
-        Kubeflow](https://www.katacoda.com/kubeflow/scenarios/deploying-kubeflow)
-      * [Deploying Kubeflow with
-        Ksonnet](https://www.katacoda.com/kubeflow/scenarios/deploying-kubeflow-with-ksonnet)
-      * [Deploying Pytorch with
-        Kubeflow](https://www.katacoda.com/kubeflow/scenarios/deploy-pytorch-with-kubeflow)
-  * [Qwiklabs](https://qwiklabs.com/catalog?keywords=kubeflow)
-      * [Introduction to Kubeflow on Google Kubernetes
-        Engine](https://qwiklabs.com/focuses/960?locale=en&parent=catalog)
-      * [Kubeflow End to End: GitHub Issue
-        Summarization](https://qwiklabs.com/focuses/1257?locale=en&parent=catalog)


### PR DESCRIPTION
Fixes https://github.com/kubeflow/website/issues/983
Fixes https://github.com/kubeflow/website/issues/1002

* Moved the long list of tutorial/codelabs from the getting-started page, and added a link to the tutorials/codelabs page instead.
* Reorganised the tutorials/codelabs page for better readability.
* Removed all links to Qwiklabs, as the labs are all either non-existent or restricted access.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1003)
<!-- Reviewable:end -->
