### PR TITLE
add owner role requirement in GCP project setup

### DIFF
--- a/content/docs/gke/deploy/project-setup.md
+++ b/content/docs/gke/deploy/project-setup.md
@@ -9,6 +9,11 @@ have one:
 
 1. Select or create a project on the 
   [GCP Console](https://console.cloud.google.com/cloud-resource-manager).
+  The deployment process creates various Service Accounts with
+  appropriate roles in order to enable seamless integration with
+  GCP services. This requires that the user has 
+  [owner role](https://cloud.google.com/iam/docs/understanding-roles#primitive_role_definitions)
+  for the project in order to deploy Kubeflow.
 
 1. Make sure that billing is enabled for your project. See the guide to
   [modifying a project's billing 


### PR DESCRIPTION
Users are still confused what role/permissions they might need to deploy Kubeflow. Additionally, clarifying why the role is needed.

Fixes #1013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1016)
<!-- Reviewable:end -->
