### PR TITLE
Deployment UI requires project id, not name

### DIFF
--- a/content/docs/gke/deploy/deploy-ui.md
+++ b/content/docs/gke/deploy/deploy-ui.md
@@ -30,7 +30,7 @@ Follow these steps to open the deployment UI and deploy Kubeflow on GCP:
   for your GCP project.
 1. Complete the following fields on the form:
 
-    * **Project:** Enter your GCP project name.
+    * **Project:** Enter your GCP project ID.
     * **Deployment name:** Enter a short name that you can use to recognize this 
       deployment of Kubeflow. If you plan to use [Cloud Identity-Aware Proxy
       (Cloud IAP)](https://cloud.google.com/iap/docs/) for access control (see


### PR DESCRIPTION
Following the instructions above:
- go to https://deploy.kubeflow.cloud
- enter previously created GCP project name and other required information
- click 'Create Deployment'
Result:
An error message indicates that the project can't be located. The required information was the project ID, not the project name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1028)
<!-- Reviewable:end -->
