### PR TITLE
fix mini problem in fairing doc

### DIFF
--- a/content/docs/fairing/gcp/tutorials/gcp-kubeflow-notebook.md
+++ b/content/docs/fairing/gcp/tutorials/gcp-kubeflow-notebook.md
@@ -57,7 +57,7 @@ Follow these instructions to run the XGBoost quickstart notebook:
         ```
 
 1.  Use the notebook user interface to open the XGBoost quickstart notebook
-    at `[path-to-cloned-fairing-repo]fairing/examples/prediction/xgboost-high-level-apis.ipynb`.
+    at `fairing/examples/prediction/xgboost-high-level-apis.ipynb`.
 
 1.  Follow the instructions in the notebook to:
 


### PR DESCRIPTION
There is no var named `path-to-cloned-fairing-repo`, and in fact, that's no need since git clone to current path, Just remove `path-to-cloned-fairing-rep` to avoid confusing user. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1031)
<!-- Reviewable:end -->
