### PR TITLE
Fix docs link 404 errors.

### DIFF
--- a/content/docs/pipelines/tutorials/build-pipeline.md
+++ b/content/docs/pipelines/tutorials/build-pipeline.md
@@ -37,7 +37,7 @@ Set up your environment:
 
 Examine the pipeline samples that you downloaded and choose one to work with.
 The 
-[`sequential.py` sample pipeline](https://github.com/kubeflow/pipelines/blob/master/samples/basic/sequential.py):
+[`sequential.py` sample pipeline](https://github.com/kubeflow/pipelines/blob/master/samples/core/sequential/sequential.py):
 is a good one to start with.
 
 Each pipeline is defined as a Python program. Before you can submit a pipeline
@@ -53,7 +53,7 @@ dsl-compile --py [path/to/python/file] --output [path/to/output/tar.gz]
 ```
 
 For example, to compile the
-[`sequential.py` sample pipeline](https://github.com/kubeflow/pipelines/blob/master/samples/basic/sequential.py):
+[`sequential.py` sample pipeline](https://github.com/kubeflow/pipelines/blob/master/samples/core/sequential/sequential.py):
 
 ```bash
 export DIR=[YOUR PIPELINES REPO DIRECTORY]/samples/basic


### PR DESCRIPTION
Some file links can't be fond and report as the 404 errors.  URL:https://www.kubeflow.org/docs/pipelines/tutorials/build-pipeline/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1032)
<!-- Reviewable:end -->
