### PR TITLE
Instructions on setting up dynamic volume provisioner

### DIFF
--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -10,7 +10,8 @@ This config creates a vanilla deployment of Kubeflow with all its core component
 
 ### Deploy Kubeflow
 
-Before you proceed to install Kubeflow, ensure you have configured volume provisioning in your Kubernetes cluster appropriately as mentioned [below](#automatic-provisioning-of-persistent-volumes-in-kubernetes). This installation creates PersistentVolumeClaims with the default StorageClass. Verify this by checking the `provisioner` field of your default StorageClass definition.
+This Kubeflow deployment requires default StorageClass with a provisioner. Verify the `provisioner` field of your default StorageClass definition.
+If you don't have a provisioner, ensure you have configured volume provisioning in your Kubernetes cluster appropriately as mentioned [below](#provisioning-of-persistent-volumes-in-kubernetes).
 
 Follow these steps to deploy Kubeflow:
 
@@ -88,18 +89,14 @@ Your Kubeflow app directory contains the following files and directories:
 * **${KFAPP}/app.yaml** defines configurations related to your Kubeflow deployment.
 * **${KFAPP}/kustomize**: contains the YAML manifests that will be deployed.
 
-### Automatic Provisioning of Persistent Volumes in Kubernetes
+### Provisioning of Persistent Volumes in Kubernetes
 
-Note that you can skip this step if you have a dynamic volume provisioner already installed in your cluster or if you choose to create PVs manually after deployment of kubeflow.
+Note that you can skip this step if you have a [dynamic volume provisioner](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) already installed in your cluster.
 
-Set up [dynamic volume provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) to create PVs on demand, if not present in your Kubernetes cluster.
+If you don't have one:
 
-Reference Dynamic Volume Provisioners:
-
-* [Install Local Path Provisioner](https://github.com/rancher/local-path-provisioner#deployment)
-
-Ensure that the StorageClass used by this provisioner is the default storage class.
-
+* You can choose to create PVs manually after deployment of Kubeflow.
+* Or install a dynamic volume provisioner like [Local Path Provisioner](https://github.com/rancher/local-path-provisioner#deployment). Ensure that the StorageClass used by this provisioner is the default StorageClass.
 
 ### Next steps
 

--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -10,8 +10,8 @@ This config creates a vanilla deployment of Kubeflow with all its core component
 
 ### Deploy Kubeflow
 
-This Kubeflow deployment requires default StorageClass with a provisioner. Verify the `provisioner` field of your default StorageClass definition.
-If you don't have a provisioner, ensure you have configured volume provisioning in your Kubernetes cluster appropriately as mentioned [below](#provisioning-of-persistent-volumes-in-kubernetes).
+This Kubeflow deployment requires a default StorageClass with a [dynamic volume provisioner](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) . Verify the `provisioner` field of your default StorageClass definition.
+If you don't have a provisioner, ensure that you have configured volume provisioning in your Kubernetes cluster appropriately as mentioned [below](#provisioning-of-persistent-volumes-in-kubernetes).
 
 Follow these steps to deploy Kubeflow:
 
@@ -91,7 +91,7 @@ Your Kubeflow app directory contains the following files and directories:
 
 ### Provisioning of Persistent Volumes in Kubernetes
 
-Note that you can skip this step if you have a [dynamic volume provisioner](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) already installed in your cluster.
+Note that you can skip this step if you have a dynamic volume provisioner already installed in your cluster.
 
 If you don't have one:
 
@@ -114,4 +114,4 @@ Check if PersistentVolumeClaims get `Bound` to PersistentVolumes.
 
    ```
 
-If the PersistentVolumeClaims (PVCs) are in `Pending` state after deployment and they are not bound to PersistentVolumes (PVs), you may have to either manually create PVs for each PVC in your Kubernetes Cluster or an alternative is to set up [dynamic volume provisioning](#automatic-provisioning-of-persistent-volumes-in-kubernetes) to create PVs on demand and redeploy Kubeflow after deleting existing PVCs.
+If the PersistentVolumeClaims (PVCs) are in `Pending` state after deployment and they are not bound to PersistentVolumes (PVs), you may have to either manually create PVs for each PVC in your Kubernetes Cluster or an alternative is to set up [dynamic volume provisioning](#provisioning-of-persistent-volumes-in-kubernetes) to create PVs on demand and redeploy Kubeflow after deleting existing PVCs.

--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -10,6 +10,8 @@ This config creates a vanilla deployment of Kubeflow with all its core component
 
 ### Deploy Kubeflow
 
+Before you proceed to install Kubeflow, ensure you have configured volume provisioning in your Kubernetes cluster appropriately as mentioned [below](#automatic-provisioning-of-persistent-volumes-in-kubernetes).
+
 Follow these steps to deploy Kubeflow:
 
 1. Download a `kfctl` release from the [Kubeflow releases page](https://github.com/kubeflow/kubeflow/releases/) and unpack it:
@@ -33,7 +35,7 @@ Follow these steps to deploy Kubeflow:
    kfctl apply all -V
    ```
 
-   * **${KFAPP}** - the _name_ of a directory where you want Kubeflow 
+   * **${KFAPP}** - the _name_ of a directory where you want Kubeflow
   configurations to be stored. This directory is created when you run
   `kfctl init`. If you want a custom deployment name, specify that name here.
   The value of this variable becomes the name of your deployment.
@@ -86,7 +88,32 @@ Your Kubeflow app directory contains the following files and directories:
 * **${KFAPP}/app.yaml** defines configurations related to your Kubeflow deployment.
 * **${KFAPP}/kustomize**: contains the YAML manifests that will be deployed.
 
+### Automatic Provisioning of Persistent Volumes in Kubernetes
+
+Set up [dynamic volume provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) to create PVs on demand, if not present in your Kubernetes cluster.
+
+Available Dynamic Volume Provisioners:
+
+* [Install Local Path Provisioner](https://github.com/rancher/local-path-provisioner#deployment)
+
+Ensure that the StorageClass used by this provisioner is the default storage class.
+
+Note that you can skip this step if you have a dynamic volume provisioner already installed in your cluster or if you choose to create PVs manually after deployment of kubeflow.
+
 ### Next steps
 
 * Run a [sample machine learning workflow](/docs/examples/resources/).
 * Get started with [Kubeflow Pipelines](/docs/pipelines/pipelines-quickstart/)
+
+
+### Troubleshooting
+
+#### Persistent Volume Claims are in Pending State
+
+Check if PersistentVolumeClaims get `Bound` to PersistentVolumes.
+   ```
+   kubectl -n kubeflow get pvc
+
+   ```
+
+If the PersistentVolumeClaims (PVCs) are in `Pending` state after deployment and they are not bound to PersistentVolumes (PVs), you may have to either manually create PVs for each PVC in your Kubernetes Cluster or an alternative is to set up [dynamic volume provisioning](#automatic-provisioning-of-persistent-volumes-in-kubernetes) to create PVs on demand and redeploy Kubeflow after deleting it.

--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -116,4 +116,4 @@ Check if PersistentVolumeClaims get `Bound` to PersistentVolumes.
 
    ```
 
-If the PersistentVolumeClaims (PVCs) are in `Pending` state after deployment and they are not bound to PersistentVolumes (PVs), you may have to either manually create PVs for each PVC in your Kubernetes Cluster or an alternative is to set up [dynamic volume provisioning](#automatic-provisioning-of-persistent-volumes-in-kubernetes) to create PVs on demand and redeploy Kubeflow after deleting it.
+If the PersistentVolumeClaims (PVCs) are in `Pending` state after deployment and they are not bound to PersistentVolumes (PVs), you may have to either manually create PVs for each PVC in your Kubernetes Cluster or an alternative is to set up [dynamic volume provisioning](#automatic-provisioning-of-persistent-volumes-in-kubernetes) to create PVs on demand and redeploy Kubeflow after deleting existing PVCs.

--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -10,7 +10,7 @@ This config creates a vanilla deployment of Kubeflow with all its core component
 
 ### Deploy Kubeflow
 
-Before you proceed to install Kubeflow, ensure you have configured volume provisioning in your Kubernetes cluster appropriately as mentioned [below](#automatic-provisioning-of-persistent-volumes-in-kubernetes).
+Before you proceed to install Kubeflow, ensure you have configured volume provisioning in your Kubernetes cluster appropriately as mentioned [below](#automatic-provisioning-of-persistent-volumes-in-kubernetes). This installation creates PersistentVolumeClaims with the default StorageClass. Verify this by checking the `provisioner` field of your default StorageClass definition.
 
 Follow these steps to deploy Kubeflow:
 
@@ -90,15 +90,16 @@ Your Kubeflow app directory contains the following files and directories:
 
 ### Automatic Provisioning of Persistent Volumes in Kubernetes
 
+Note that you can skip this step if you have a dynamic volume provisioner already installed in your cluster or if you choose to create PVs manually after deployment of kubeflow.
+
 Set up [dynamic volume provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) to create PVs on demand, if not present in your Kubernetes cluster.
 
-Available Dynamic Volume Provisioners:
+Reference Dynamic Volume Provisioners:
 
 * [Install Local Path Provisioner](https://github.com/rancher/local-path-provisioner#deployment)
 
 Ensure that the StorageClass used by this provisioner is the default storage class.
 
-Note that you can skip this step if you have a dynamic volume provisioner already installed in your cluster or if you choose to create PVs manually after deployment of kubeflow.
 
 ### Next steps
 

--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -10,7 +10,7 @@ This config creates a vanilla deployment of Kubeflow with all its core component
 
 ### Deploy Kubeflow
 
-This Kubeflow deployment requires a default StorageClass with a [dynamic volume provisioner](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) . Verify the `provisioner` field of your default StorageClass definition.
+This Kubeflow deployment requires a default StorageClass with a [dynamic volume provisioner](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/). Verify the `provisioner` field of your default StorageClass definition.
 If you don't have a provisioner, ensure that you have configured volume provisioning in your Kubernetes cluster appropriately as mentioned [below](#provisioning-of-persistent-volumes-in-kubernetes).
 
 Follow these steps to deploy Kubeflow:
@@ -98,12 +98,6 @@ If you don't have one:
 * You can choose to create PVs manually after deployment of Kubeflow.
 * Or install a dynamic volume provisioner like [Local Path Provisioner](https://github.com/rancher/local-path-provisioner#deployment). Ensure that the StorageClass used by this provisioner is the default StorageClass.
 
-### Next steps
-
-* Run a [sample machine learning workflow](/docs/examples/resources/).
-* Get started with [Kubeflow Pipelines](/docs/pipelines/pipelines-quickstart/)
-
-
 ### Troubleshooting
 
 #### Persistent Volume Claims are in Pending State
@@ -115,3 +109,8 @@ Check if PersistentVolumeClaims get `Bound` to PersistentVolumes.
    ```
 
 If the PersistentVolumeClaims (PVCs) are in `Pending` state after deployment and they are not bound to PersistentVolumes (PVs), you may have to either manually create PVs for each PVC in your Kubernetes Cluster or an alternative is to set up [dynamic volume provisioning](#provisioning-of-persistent-volumes-in-kubernetes) to create PVs on demand and redeploy Kubeflow after deleting existing PVCs.
+
+### Next steps
+
+* Run a [sample machine learning workflow](/docs/examples/resources/).
+* Get started with [Kubeflow Pipelines](/docs/pipelines/pipelines-quickstart/)


### PR DESCRIPTION
Resolves kubeflow/kubeflow#3774

The current instructions for kfctl_k8s_istio.yaml deployment of Kubeflow lack volume provisioner instructions before Kubeflow's deployment which lead to all of Kubeflow's PVCs to `Pending` state in Kubernetes clusters not having a dynamic volume provisioner.

This PR updates the instructions for the setup of a dynamic volume provisioner or alternative methods of handling the same issue.

/assign @krishnadurai 

/cc @johnugeorge @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1040)
<!-- Reviewable:end -->
