### PR TITLE
Update katib Dockerfile locations link

### DIFF
--- a/content/docs/reference/images.md
+++ b/content/docs/reference/images.md
@@ -11,14 +11,15 @@ weight = 10
 | ml-pipeline/scheduledworkflow | <https://github.com/kubeflow/pipelines/tree/master/backend> |
 | ml-pipeline/frontend | <https://github.com/kubeflow/pipelines/blob/master/frontend/Dockerfile> |
 | metrics-collector |    <https://github.com/kubeflow/katib/tree/master/cmd/metricscollector>
-| katib/studyjob-controller    | <https://github.com/kubeflow/katib/tree/master/cmd/katib-controller> |
-| katib/katib-ui    | <https://github.com/kubeflow/katib/tree/master/cmd/ui> |
-| katib/vizier-core |     <https://github.com/kubeflow/katib/tree/master/cmd/manager/v1alpha1> |
-| katib/vizier-core-rest    | <https://github.com/kubeflow/katib/blob/master/cmd/manager-rest/v1alpha1/Dockerfile> |
-| katib/suggestion-bayesianoptimization    | <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/bayesianoptimization/v1alpha1/Dockerfile> |
-| katib/suggestion-grid |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/grid/v1alpha1/Dockerfile> |
-| katib/suggestion-hyperband |     <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/hyperband/v1alpha1/Dockerfile> |
-| katib/suggestion-random |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/random/v1alpha1/Dockerfile> |
+| katib/katib-controller    | <https://github.com/kubeflow/katib/tree/master/cmd/katib-controller/v1alpha2/Dockerfile> |
+| katib/katib-ui    | <https://github.com/kubeflow/katib/tree/master/cmd/ui/v1alpha2/Dockerfile> |
+| katib/katib-manager |     <https://github.com/kubeflow/katib/tree/master/cmd/manager/v1alpha2/Dockerfile> |
+| katib/katib-manager-rest    | <https://github.com/kubeflow/katib/blob/master/cmd/manager-rest/v1alpha2/Dockerfile> |
+| katib/katib-suggestion-bayesianoptimization    | <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/bayesianoptimization/v1alpha2/Dockerfile> |
+| katib/katib-suggestion-grid |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/grid/v1alpha2/Dockerfile> |
+| katib/katib-suggestion-hyperband |     <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/hyperband/v1alpha2/Dockerfile> |
+| katib/katib-suggestion-random |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/random/v1alpha2/Dockerfile> |
+| katib/katib-suggestion-nasrl |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/nasrl/v1alpha2/Dockerfile> |
 | jupyterhub-k8s |    <https://github.com/kubeflow/kubeflow/blob/master/components/jupyterhub/docker/Dockerfile> |
 | datawire/ambassador    | <https://github.com/datawire/ambassador/blob/master/Dockerfile> |
 | tensorflow-1.13.1-notebook-cpu |    <https://github.com/kubeflow/kubeflow/blob/master/components/tensorflow-notebook-image/Dockerfile> |


### PR DESCRIPTION
For now, when install kubeflow, Katib v1alpha2 is installed. We should update Katib related Dockerfile to v1alpha2 instead of v1alpha1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1049)
<!-- Reviewable:end -->
