### PR TITLE
xgboost url update

### DIFF
--- a/content/docs/pipelines/overview/pipelines-overview.md
+++ b/content/docs/pipelines/overview/pipelines-overview.md
@@ -60,7 +60,7 @@ and [components](/docs/pipelines/concepts/component/).
 The screenshots and code below show the `xgboost-training-cm.py` pipeline, which
 creates an XGBoost model using structured data in CSV format. You can see the
 source code and other information about the pipeline on 
-[GitHub](https://github.com/kubeflow/pipelines/tree/master/samples/xgboost-spark).
+[GitHub](https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost-spark).
 
 ### The runtime execution graph of the pipeline
 
@@ -75,7 +75,7 @@ Kubeflow Pipelines UI:
 
 Below is an extract from the Python code that defines the 
 `xgboost-training-cm.py` pipeline. You can see the full code on 
-[GitHub](https://github.com/kubeflow/pipelines/tree/master/samples/xgboost-spark).
+[GitHub](https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost-spark).
 
 ```python
 


### PR DESCRIPTION
Pipeline overview doc reflected a stale URL for the xgboost-spark sample. This commit updates to the correct URL of the xgboost-spark directory of the Kubeflow repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1052)
<!-- Reviewable:end -->
