### PR TITLE
Fix port-forarding instructions; port-forward to istio gateway

### DIFF
--- a/content/docs/other-guides/accessing-uis.md
+++ b/content/docs/other-guides/accessing-uis.md
@@ -56,8 +56,7 @@ guide to
 ## Using kubectl and port-forwarding
 
 If you didn't configure Kubeflow to integrate with an identity provider and perform 
-any authorization checks (for example you aren't using IAP with Google or DEX)
-then you can port-forward directly to the ISTIO gateway.
+any authorization then you can port-forward directly to the ISTIO gateway.
 
 Port-forwarding typically won't work if any of the following are true
 

--- a/content/docs/other-guides/accessing-uis.md
+++ b/content/docs/other-guides/accessing-uis.md
@@ -7,6 +7,14 @@ weight = 1
 Kubeflow includes a number of web user interfaces (UIs). This document provides
 instructions on how to connect to them.
 
+To access the Kubeflow UI's you need to connect to the 
+[ISTIO gateway](https://istio.io/docs/concepts/traffic-management/#gateways) that 
+provides access to the Kubeflow 
+[service mesh](https://istio.io/docs/concepts/what-is-istio/#what-is-a-service-mesh).
+
+How you access the ISTIO gateway will vary depending on how you've configured it.
+
+
 ## Accessing Kubeflow web UIs
 
 The Kubeflow web UIs include the following:
@@ -47,6 +55,18 @@ guide to
 
 ## Using kubectl and port-forwarding
 
+If you didn't configure Kubeflow to integrate with an identity provider and perform 
+any authorization checks (for example you aren't using IAP with Google or DEX)
+then you can port-forward directly to the ISTIO gateway.
+
+Port-forwarding typically won't work if any of the following are true
+
+  * you've configured the ISTIO ingress to only accept 
+HTTPS traffic on a specific domain or IP address
+
+  * you've configured the ISTIO ingress to perform an authorization check (e.g. using IAP or Dex)
+
+
 You can access Kubeflow via `kubectl` and port-forwarding as follows:
 
 1. Install `kubectl` if you haven't already done so:
@@ -57,7 +77,7 @@ You can access Kubeflow via `kubectl` and port-forwarding as follows:
     installation guide](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 1. Use the following command to set up port forwarding to the
-  [Ambassador](https://www.getambassador.io/) service that provides the reverse proxy.
+  [ISTIO gateway](https://istio.io/docs/tasks/traffic-management/ingress/ingress-control/).
 
     {{% code-webui-port-forward %}}
 

--- a/layouts/shortcodes/code-webui-port-forward.html
+++ b/layouts/shortcodes/code-webui-port-forward.html
@@ -1,3 +1,3 @@
 <pre><code>export NAMESPACE=istio-system
-kubectl port-forward svc/ambassador -n ${NAMESPACE} 8080:80
+kubectl port-forward -n istio-system svc/istio-ingressgateway 8080:80
 </code></pre>


### PR DESCRIPTION
See #1041 and kubeflow/kubeflow#3618

* With 0.6 if no auth is setup and you want to connect via port-forwarding
  then you need to port-forward to the ISTIO gateway; not ambassador

* I suspect the original suggestion in #1041 to port-forward to Ambassador
  only worked in the basic auth setting in which case we are still setting
  up Ambassador.

Fix: #1041

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1067)
<!-- Reviewable:end -->
