### PR TITLE
undead link and prempting a DNS 1123 error

### DIFF
--- a/content/docs/other-guides/virtual-dev/getting-started-minikube.md
+++ b/content/docs/other-guides/virtual-dev/getting-started-minikube.md
@@ -209,7 +209,7 @@ $ minikube start --cpus 4 --memory 8096 --disk-size=40g
 ### Install Kubeflow on an existing Kubernetes cluster
 
 Now that you have a Kubernetes cluster running - the Minikube cluster - follow the
-[existing Kubernetes cluster]((/docs/started/k8s/overview/)) instructions for installing
+[existing Kubernetes cluster]((/docs/started/k8s/)) instructions for installing
 Kubeflow.
 
 ### Where to go next

--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -25,6 +25,7 @@ Follow these steps to deploy Kubeflow:
 
    ```bash
    # Add kfctl to PATH, to make the kfctl binary easier to use.
+   # only use alphanumeric characters or - for the folder name 
    export PATH=$PATH:"<path to kfctl>"
    export KFAPP="<your choice of application directory name>"
    # Installs istio by default. Comment out istio components in the config file to skip istio installation. See https://github.com/kubeflow/kubeflow/pull/3663


### PR DESCRIPTION
I used kubeflow_app at one point as folder name and lost time.

I put a bash log here: https://github.com/kubeflow/kubeflow/issues/3901#issuecomment-521200663 for OSX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1074)
<!-- Reviewable:end -->
