### PR TITLE
markdown formatting fix.

### DIFF
--- a/content/docs/other-guides/virtual-dev/getting-started-minikube.md
+++ b/content/docs/other-guides/virtual-dev/getting-started-minikube.md
@@ -209,7 +209,7 @@ $ minikube start --cpus 4 --memory 8096 --disk-size=40g
 ### Install Kubeflow on an existing Kubernetes cluster
 
 Now that you have a Kubernetes cluster running - the Minikube cluster - follow the
-[existing Kubernetes cluster]((/docs/started/k8s/overview/)) instructions for installing
+[existing Kubernetes cluster](/docs/started/k8s/overview/) instructions for installing
 Kubeflow.
 
 ### Where to go next


### PR DESCRIPTION
this fix changes markdown formating for link to `/docs/started/k8s/overview` page,
that currently broken on the website.

see - https://www.kubeflow.org/docs/other-guides/virtual-dev/getting-started-minikube/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1088)
<!-- Reviewable:end -->
