### PR TITLE
WIP Expands info on config with kustomize

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -87,7 +87,6 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/started/getting-started-gke/             /docs/started/cloud/getting-started-gke/
 /docs/started/getting-started-icp/             /docs/started/cloud/getting-started-icp/
 
-
 /docs/other-guides/job-scheduling/             /docs/use-cases/job-scheduling/
 /docs/other-guides/upgrade/                    /docs/upgrading/upgrade/
 
@@ -95,3 +94,6 @@ docs/started/requirements/                    /docs/started/getting-started/
 
 # Remove Kubeflow installation on existing EKS cluster
 /docs/aws/deploy/existing-cluster/             /docs/aws/deploy/install-kubeflow/
+
+# Move the kustomize guide to the config section
+/docs/components/misc/kustomize/              /docs/other-guides/kustomize/

--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -189,7 +189,7 @@ Your Kubeflow app directory **${KFAPP}** contains the following files and direct
 
 * **kustomize** is a directory that contains the kustomize packages for Kubeflow 
   applications. See 
-  [how Kubeflow uses kustomize](/docs/components/misc/kustomize/).
+  [how Kubeflow uses kustomize](/docs/other-guides/kustomize/).
 
   * The directory is created when you run `kfctl generate`.
   * You can customize the Kubernetes resources by modifying the manifests and 

--- a/content/docs/other-guides/kustomize.md
+++ b/content/docs/other-guides/kustomize.md
@@ -5,17 +5,85 @@ weight = 10
 +++
 
 Kubeflow makes use of [kustomize](https://kustomize.io/) to help customize YAML
-configurations.
+configurations. 
+
+With kustomize, you can traverse a Kubernetes manifest to add, remove or update 
+configuration options without forking. A _manifest_ is a YAML file containing a 
+description of all the components that you want to deploy.
+
+## Overview of kfctl and kustomize
+
+This section describes how Kubeflow's command-line interface (CLI), kfctl, works 
+with kustomize to configure your Kubeflow deployment.
+
+### The Kubeflow installation process
+
+kfctl is Kubeflow's CLI that you can use to set up a Kubernetes cluster with 
+Kubeflow installed, or to deploy Kubeflow to an existing Kubernetes cluster. 
+See the [Kubeflow getting-started guide](/docs/started/getting-started/) for
+installation instructions based on your deployment scenario.
+
+The deployment process consists of three steps, _init_, _generate_, and 
+_apply_, so that you can modify your configuration before actually deploying 
+Kubeflow.
+
+* `kfctl init` - one time set up.
+* `kfctl generate` - creates config files defining the various resources.
+* `kfctl apply` - creates or updates the resources.
+
+### Your Kubeflow directory layout
+
+Your Kubeflow app directory, `${KFAPP}`, is the directory where you've stored 
+your Kubeflow configurations during deployment. The directory contains the 
+following files and directories:
+
+* **app.yaml** stores your primary Kubeflow configuration in the form of a
+  `KfDef` Kubernetes object.
+
+  * The values are set when you run `kfctl init`.
+  * The values are snapshotted inside `app.yaml` to make your app 
+    self contained.
+  * The YAML defines each Kubeflow application as a kustomize package.  
+
+* **<platform-name>_config** is a directory that contains 
+  configurations specific to your chosen platform or cloud provider. This 
+  directory may or may not be present, depending on your setup.
+
+  * The directory is created when you run `kfctl generate platform`.
+  * You can modify these configurations to customize your infrastructure.
+
+* **kustomize** is a directory that contains Kubeflow application manifests.
+  In other words, it contains the kustomize packages for the Kubeflow 
+  applications that are included in your deployment.
+
+  * The directory is created when you run `kfctl generate`.
+  * You can customize the Kubernetes resources by modifying the manifests and 
+    running `kfctl apply` again.
+
+### How your configuration is generated
+
+The content of your `app.yaml` is the result of running kustomize 
+on the base and overlay `kustomization.yaml` files in the 
+[Kubeflow config](https://github.com/kubeflow/kubeflow/tree/master/bootstrap/config) directory. The overlays reflect the options that you choose when calling 
+`kfctl init`.
+
+Below are some examples of `KfDef` configuration files:
+
+* [kfctl_k8s_istio.yaml](https://github.com/kubeflow/kubeflow/blob/master/bootstrap/config/kfctl_k8s_istio.yaml) 
+  to install Kubeflow on an existing Kubernetes cluster.
+* [kfctl_gcp_basic_auth.yaml](https://github.com/kubeflow/kubeflow/blob/master/bootstrap/config/kfctl_gcp_basic_auth.yaml) 
+  to set up a Google Kubernetes Engine (GKE) cluster with Kubeflow using basic
+  authentication.
+
+The kustomize package manager in kfctl uses the information in your
+`app.yaml` to traverse the directories under the 
+[Kubeflow manifests](https://github.com/kubeflow/manifests) and to 
+create kustomize build targets based on the manifests.
 
 ## Installing kustomize
 
-Make sure you have the minimum required version of kustomize:
-**{{% kustomize-min-version %}}** or later.
-
-The simplest way to install kustomize is to run `go get sigs.k8s.io/kustomize`.
-
-If you prefer installing it from source follow the steps below to install
-kustomize:
+Make sure that you have the minimum required version of kustomize:
+<b>{{% kustomize-min-version %}}</b> or later.
 
 1. Follow the [kustomize installation
    guide](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md),
@@ -52,24 +120,90 @@ kustomize:
       export PATH=$PATH:${HOME}/bin/kustomize
       ```
 
-## More about kustomize
+## Using kustomize
 
 kustomize lets you customize raw, template-free YAML files for multiple
 purposes, leaving the original YAML untouched and usable as is.
 
-kustomize directories can be built and applied using
-`kustomize build <kustomization_directory> | kubectl apply -f -`.
+You can use the following command to build and apply kustomize directories:
 
-The [kustomize manifests repo](https://github.com/kubeflow/manifests) contains
-kustomize targets, each with a `base` directory. You can use kustomize to
-generate YAML output and pass it to the kubeflow CLI, `kfctl`. You can also make
-changes to the kustomize targets in the manifests repo as needed and more
-information can be found at
-[customizing kubeflow](https://www.kubeflow.org/docs/gke/customizing-gke/).
+```
+kustomize build <kustomization_directory> | kubectl apply -f -
+```
 
-Some useful kustomize terms:
+The [Kubeflow manifests repo](https://github.com/kubeflow/manifests) contains
+kustomize build targets, each with a `base` directory. You can use kustomize to
+generate YAML output and pass it to kfctl. You can also make
+changes to the kustomize targets in the manifests repo as needed. 
 
-* **kustomization:** Refers to a kustomization.yaml file.
+### Modifying configuration before deployment
+
+TODO
+
+
+### Modifying the configuration of an existing deployment
+
+You can apply many changes to an existing configuration by running
+the following command, where `KFAPP` is the directory where you've stored 
+your Kubeflow configurations during deployment:
+
+```
+cd ${KFAPP}
+kfctl apply platform
+```
+
+To customize the Kubeflow resources running within the cluster you can modify the kustomize manifests in `${KFAPP}/kustomize`.
+
+For example, to modify settings for the Jupyter web app:
+
+1. Edit the configuration file at `${KFAPP}/kustomize/jupyter-web-app.yaml`.
+
+1. Find and replace the parameter values:
+
+    ```
+    apiVersion: v1
+    data:
+    ROK_SECRET_NAME: secret-rok-{username}
+    UI: default
+    clusterDomain: cluster.local
+    policy: Always
+    prefix: jupyter
+    kind: ConfigMap
+    metadata:
+    labels:
+        app: jupyter-web-app
+        kustomize.component: jupyter-web-app
+    name: jupyter-web-app-parameters
+    namespace: kubeflow
+    ```
+
+1. Redeploy using `kfctl`:
+
+    ```
+    cd ${KFAPP}
+    kfctl apply k8s
+    ```
+
+    Alternatively, you can redeploy using kubectl directly:
+
+    ```
+    cd ${KFAPP}/kustomize
+    kubectl apply -f jupyter-web-app.yaml
+    ```
+
+### More examples
+
+For more usage examples, see the guide to [customizing Kubeflow on 
+GKE](https://www.kubeflow.org/docs/gke/customizing-gke/).
+
+## More about kustomize
+
+Below are some useful kustomize terms (from the 
+[kustomize glossary](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md)):
+
+* **kustomization:** Refers to a `kustomization.yaml` file, or more generally to
+  a directory containing the `kustomization.yaml` file and all the relative file 
+  paths that the YAML file references.
 
 * **resource:** Any valid YAML file that defines an object with a kind and a
 metadata/name field.

--- a/content/docs/other-guides/kustomize.md
+++ b/content/docs/other-guides/kustomize.md
@@ -1,7 +1,7 @@
 +++
-title = "kustomize"
-description = "Information about kustomize as used in Kubeflow"
-weight = 20
+title = "Configuring Kubeflow with kustomize"
+description = "The basics of Kubeflow configuration with kustomize"
+weight = 10
 +++
 
 Kubeflow makes use of [kustomize](https://kustomize.io/) to help customize YAML

--- a/content/docs/started/getting-started.md
+++ b/content/docs/started/getting-started.md
@@ -51,18 +51,17 @@ to suit your environment (desktop or server, existing Kubernetes cluster or publ
 The following information is useful if you need or prefer to use command line
 tools for deploying and managing Kubeflow:
 
-* Download the `kfctl` binary from the
+* Download the kfctl binary from the
   [Kubeflow releases page](https://github.com/kubeflow/kubeflow/releases/).
 
-* Follow the `kubectl` installation and setup instructions from the [Kubernetes
+* Follow the kubectl installation and setup instructions from the [Kubernetes
   documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
   As described in the Kubernetes documentation, your kubectl
   version must be within one minor version of the Kubernetes version that you
   use in your Kubeflow cluster.
 
-* Follow the `kustomize` installation and setup instructions from the
-  [kustomize component guide](/docs/components/misc/kustomize/).
-
+* Follow the kustomize installation and setup instructions from the guide to
+  [kustomize in Kubeflow](/docs/other-guides/kustomize/).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes https://github.com/kubeflow/website/issues/1092

Goals:

* Give people more guidance on how to manage their Kubeflow config.
* Move the kustomize info into the section containing other config guides, because kustomize isn't really a component of Kubeflow, but rather the configuration manager. The guide therefore doesn't belong in the "components" section.
