### PR TITLE
undead link for XGBoost source

### DIFF
--- a/content/docs/pipelines/overview/pipelines-overview.md
+++ b/content/docs/pipelines/overview/pipelines-overview.md
@@ -75,7 +75,7 @@ Kubeflow Pipelines UI:
 
 Below is an extract from the Python code that defines the 
 `xgboost-training-cm.py` pipeline. You can see the full code on 
-[GitHub](https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost-spark).
+[GitHub](https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost_training_cm).
 
 ```python
 


### PR DESCRIPTION
Fixed broken link to xgboost_training_cm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1098)
<!-- Reviewable:end -->
