### PR TITLE
Fixed launching Kubeflow dashboard in 0.6.1.

### DIFF
--- a/content/docs/started/cloud/getting-started-icp.md
+++ b/content/docs/started/cloud/getting-started-icp.md
@@ -176,6 +176,9 @@ http://${MANAGEMENT_IP}:$AMBASSADOR_PORT/
 ```
 * **MANAGEMENT_IP** is management node IP.
 * **AMBASSADOR_PORT** is the ambassador port.
+  
+
+For Kubeflow 0.6.1, the Ambassador service has been dropped. The Kubeflow Dashboard can be accessed via `istio-ingressgateway` service. If loadbalancer is not available in your environment, NodePort or Port forwarding can be used to access the Kubeflow Dashboard. Refer [Ingress Gateway guide](https://istio.io/docs/tasks/traffic-management/ingress/ingress-control/).  
 
 ## Delete Kubeflow
 


### PR DESCRIPTION
Since Ambassador service has been dropped in Kubeflow 0.6.1, update the instruction to access Kubeflow Dashboard via istio-ingressgateway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1105)
<!-- Reviewable:end -->
