### PR TITLE
Update the v0.6.2 gcp instructions.

### DIFF
--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -82,9 +82,9 @@ Follow these steps to deploy Kubeflow:
     # For example,  'kubeflow-test' or 'kfw-test'.
     export KFAPP=<your choice of application directory name>
     # Run this command for the default installation which uses Cloud IAP:
-    kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml -V
+    kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/c54401e/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml -V
     # Alternatively, run this command if you want to use basic authentication:
-    kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml -V
+    kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/c54401e/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml -V
 
     cd ${KFAPP}
     kfctl generate all -V --zone ${ZONE}

--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -82,9 +82,9 @@ Follow these steps to deploy Kubeflow:
     # For example,  'kubeflow-test' or 'kfw-test'.
     export KFAPP=<your choice of application directory name>
     # Run this command for the default installation which uses Cloud IAP:
-    kfctl init ${KFAPP} --platform gcp --project ${PROJECT}
+    kfctl init ${KFAPP} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml --project ${PROJECT} -V
     # Alternatively, run this command if you want to use basic authentication:
-    kfctl init ${KFAPP} --platform gcp --project ${PROJECT} --use_basic_auth -V
+    kfctl init ${KFAPP} --config=https://raw.github.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml --project ${PROJECT} -V
 
     cd ${KFAPP}
     kfctl generate all -V --zone ${ZONE}

--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -82,9 +82,9 @@ Follow these steps to deploy Kubeflow:
     # For example,  'kubeflow-test' or 'kfw-test'.
     export KFAPP=<your choice of application directory name>
     # Run this command for the default installation which uses Cloud IAP:
-    kfctl init ${KFAPP} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml --project ${PROJECT} -V
+    kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml -V
     # Alternatively, run this command if you want to use basic authentication:
-    kfctl init ${KFAPP} --config=https://raw.github.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml --project ${PROJECT} -V
+    kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.github.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml -V
 
     cd ${KFAPP}
     kfctl generate all -V --zone ${ZONE}

--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -84,7 +84,7 @@ Follow these steps to deploy Kubeflow:
     # Run this command for the default installation which uses Cloud IAP:
     kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml -V
     # Alternatively, run this command if you want to use basic authentication:
-    kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.github.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml -V
+    kfctl init ${KFAPP} --project ${PROJECT} --config=https://raw.githubusercontent.com/kubeflow/kubeflow/47a0e4c/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml -V
 
     cd ${KFAPP}
     kfctl generate all -V --zone ${ZONE}


### PR DESCRIPTION
With 0.6.2 we want to start using the --config flag.

We decided to pin to specific commits of the KFDef files. This
might be overkill because on the tip of the branch the config files
are named based on the version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1106)
<!-- Reviewable:end -->
