### PR TITLE
Ingress is in the istio-system namespace

### DIFF
--- a/content/docs/gke/troubleshooting-gke.md
+++ b/content/docs/gke/troubleshooting-gke.md
@@ -269,7 +269,7 @@ Waiting for backend id PROJECT=<your-project> NAMESPACE=kubeflow SERVICE=envoy f
 You can verify the cause of the problem by entering the following command:
 
 ```
-kubectl -n kubeflow describe ingress
+kubectl -n istio-system describe ingress
 ```
 
 Look for something like this in the output:


### PR DESCRIPTION
Fix incorrect namespace for command "kubeflow" -> "istio-system"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1162)
<!-- Reviewable:end -->
