### PR TITLE
update to kubeflow-metadata due to renaming

### DIFF
--- a/content/docs/components/misc/metadata.md
+++ b/content/docs/components/misc/metadata.md
@@ -50,7 +50,7 @@ that you can use to log (record) your metadata.
 Run the following command to install the Metadata SDK:
 
 ```
-pip install kfmd
+pip install kubeflow-metadata
 ```
 
 <a id="demo-notebook"></a>


### PR DESCRIPTION
Fixes: #1171 

update to kubeflow-metadata due to metadata SDK has been renamed to kubeflow-metadata

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1173)
<!-- Reviewable:end -->
