### PR TITLE
Delete duplicated explanation for 'restartPolicy ExitCode' in tfJob

### DIFF
--- a/content/docs/components/training/tftraining.md
+++ b/content/docs/components/training/tftraining.md
@@ -422,7 +422,6 @@ Success or failure of a job is determined as follows
   * For the restartPolicy ExitCode the behavior is exit code dependent.
   * If the restartPolicy doesn't allow restarts a non-zero exit code is considered
     a permanent failure and the job is marked failed.
-  * For the restartPolicy ExitCode the behavior is exit code dependent.        
 
 ### tfReplicaStatuses
 


### PR DESCRIPTION
This explanation is duplicated with previous previous line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1179)
<!-- Reviewable:end -->
