### PR TITLE
updating broken pipelines references

### DIFF
--- a/content/docs/pipelines/overview/pipelines-overview.md
+++ b/content/docs/pipelines/overview/pipelines-overview.md
@@ -59,8 +59,8 @@ and [components](/docs/pipelines/concepts/component/).
 
 The screenshots and code below show the `xgboost-training-cm.py` pipeline, which
 creates an XGBoost model using structured data in CSV format. You can see the
-source code and other information about the pipeline on 
-[GitHub](https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost-spark).
+source code and other information about the pipeline on
+[GitHub](https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost_training_cm).
 
 ### The runtime execution graph of the pipeline
 

--- a/content/docs/pipelines/sdk/build-component.md
+++ b/content/docs/pipelines/sdk/build-component.md
@@ -32,8 +32,8 @@ Set up your environment:
 * Install [Docker](https://www.docker.com/get-docker).
 * Install the [Kubeflow Pipelines SDK](/docs/pipelines/sdk/install-sdk/).
 
-The examples on this page come from the 
-[XGBoost Spark pipeline sample](https://github.com/kubeflow/pipelines/tree/master/samples/xgboost-spark) 
+The examples on this page come from the
+[XGBoost Spark pipeline sample](https://github.com/kubeflow/pipelines/tree/master/samples/core/xgboost_training_cm)
 in the Kubeflow Pipelines sample repository.
 
 ## Create a container image for each component

--- a/content/docs/pipelines/sdk/build-component.md
+++ b/content/docs/pipelines/sdk/build-component.md
@@ -120,11 +120,11 @@ Note:
   either provided by the user at pipeline run time or received as an output from an upstream component. 
 * Although the value of each `dsl.PipelineParam` is only available at run time,
   you can still use the parameters inline in the `arguments` by using `%s`
-  variable substitution. At run time the argument contains the value of the 
-  parameter. For an example of this technique in operation, see the 
-  [taxi cab classification pipeline](https://github.com/kubeflow/pipelines/blob/master/samples/core/tfx_cab_classification/tfx_cab_classification.py). 
-* `file_outputs` is a mapping between labels and local file paths. In the above 
-  example, the content of `/output.txt` contains the string output of the 
+  variable substitution. At run time the argument contains the value of the
+  parameter. For an example of this technique in operation, see the
+  [taxi cab classification pipeline](https://github.com/kubeflow/pipelines/tree/master/samples/core/tfx-oss).
+* `file_outputs` is a mapping between labels and local file paths. In the above
+  example, the content of `/output.txt` contains the string output of the
   component. To reference the output in code:
 
     ```python

--- a/content/docs/pipelines/sdk/manipulate-resources.md
+++ b/content/docs/pipelines/sdk/manipulate-resources.md
@@ -71,7 +71,7 @@ specification.
 ### Samples
 
 For better understanding, please refer to the following samples:
-[1](https://github.com/kubeflow/pipelines/blob/master/samples/core/resource_ops/resourceop_basic.py)
+[1](https://github.com/kubeflow/pipelines/blob/master/samples/core/resource_ops/resource_ops.py)
 
 ---
 
@@ -256,7 +256,7 @@ The user may otherwise use the `step.outputs["name"]` as `data_source`.
 ### Samples
 
 For better understanding, please refer to the following samples:
-[1](https://github.com/kubeflow/pipelines/blob/master/samples/core/volume_snapshot_ops/volume_snapshot_op.py),
+[1](https://github.com/kubeflow/pipelines/blob/master/samples/core/volume_snapshot_ops/volume_snapshot_ops.py),
 [2](https://github.com/kubeflow/pipelines/blob/master/samples/contrib/volume_snapshot_ops/volume_snapshotop_rokurl.py)
 
 ## Next steps

--- a/content/docs/pipelines/sdk/pipelines-metrics.md
+++ b/content/docs/pipelines/sdk/pipelines-metrics.md
@@ -67,8 +67,8 @@ ML - TFX - Taxi Tip Prediction Model Trainer** from the Kubeflow Pipelines UI.
 For help getting started with the UI, follow the 
 [Kubeflow Pipelines quickstart](/docs/pipelines/pipelines-quickstart/).
 
-The sample code is available in the [Kubeflow Pipelines samples 
-repo](https://github.com/kubeflow/pipelines/tree/master/samples/tfx). The
+The sample code is available in the [Kubeflow Pipelines samples
+repo](https://github.com/kubeflow/pipelines/tree/master/samples/core/tfx-oss). The
 pipeline uses a number of prebuilt components, including:
 
 * The [Confusion Matrix 

--- a/content/docs/pipelines/sdk/pipelines-metrics.md
+++ b/content/docs/pipelines/sdk/pipelines-metrics.md
@@ -61,23 +61,6 @@ The following example shows the **accuracy-score** and
   alt="Metrics from a pipeline run"
   class="mt-3 mb-3 border border-info rounded">
 
-The above example comes from the *taxi tip prediction* sample that is
-pre-installed when you deploy Kubeflow. You can run the sample by selecting **[Sample]
-ML - TFX - Taxi Tip Prediction Model Trainer** from the Kubeflow Pipelines UI.
-For help getting started with the UI, follow the 
-[Kubeflow Pipelines quickstart](/docs/pipelines/pipelines-quickstart/).
-
-The sample code is available in the [Kubeflow Pipelines samples
-repo](https://github.com/kubeflow/pipelines/tree/master/samples/core/tfx-oss). The
-pipeline uses a number of prebuilt components, including:
-
-* The [Confusion Matrix 
-  component](https://github.com/kubeflow/pipelines/blob/master/components/local/confusion_matrix/src/confusion_matrix.py)
-  which writes out the **accuracy-score** metric.
-* The [ROC 
-  component](https://github.com/kubeflow/pipelines/blob/master/components/local/roc/src/roc.py)
-  which writes out the **roc-auc-score** metric.
-
 ## Next step
 
 Visualize the output of your component by [writing out metadata for an output 

--- a/content/docs/pipelines/tutorials/build-pipeline.md
+++ b/content/docs/pipelines/tutorials/build-pipeline.md
@@ -68,7 +68,7 @@ guide to [getting started with the UI](/docs/pipelines/pipelines-quickstart).
 ## Building a pipeline in a Jupyter notebook
 
 You can choose to build your pipeline in a Jupyter notebook. The
-[sample notebooks](https://github.com/kubeflow/pipelines/tree/master/samples/notebooks)
+[sample notebooks](https://github.com/kubeflow/pipelines/tree/master/samples/core)
 walk you through the process.
 
 It's easiest to use the Jupyter services that are installed in the same cluster as 
@@ -92,10 +92,10 @@ Follow these steps to start a notebook:
 1. Follow the [Kubeflow notebooks setup guide](/docs/notebooks/setup/) to
   create a Jupyter notebook server and open the Jupyter UI.
 
-1. Download the sample notebooks from 
-  https://github.com/kubeflow/pipelines/tree/master/samples/notebooks. 
-  
-1. Upload these notebooks from the Jupyter UI: In Jupyter, go to the tree view 
+1. Download the sample notebooks from
+  https://github.com/kubeflow/pipelines/tree/master/samples/core.
+
+1. Upload these notebooks from the Jupyter UI: In Jupyter, go to the tree view
   and find the **upload** button in the top right-hand area of the screen.
 
 1. Open one of the uploaded notebooks.
@@ -107,7 +107,7 @@ Follow these steps to start a notebook:
 
 The following notebooks are available:
 
-* [KubeFlow pipeline using TFX OSS components](https://github.com/kubeflow/pipelines/blob/master/samples/core/kubeflow_pipeline_using_TFX_OSS_components/KubeFlow%20Pipeline%20Using%20TFX%20OSS%20Components.ipynb): 
+* [KubeFlow pipeline using TFX OSS components](https://github.com/kubeflow/pipelines/blob/master/samples/core/tfx-oss/TFX%20Example.ipynb):
   This notebook demonstrates how to build a machine learning pipeline based on
   [TensorFlow Extended (TFX)](https://www.tensorflow.org/tfx/) components. 
   The pipeline includes a TFDV step to infer the schema, a TFT preprocessor, a 


### PR DESCRIPTION
This is global update, its meaning to fix links to kubeflow/pipelines
repository

1. `pipeline-metrics.md` - taxy pipeline and notebook link (tfx)
2. `manipulate-reposerces.md` - renamed resources
    see kubeflow/pipelines@fe0bc678a
3. `build-pipeline.md` link to tfx notebook + general link to
    samples/core, as notebooks now located in multiple directories.
4. `build-pipeline.md` - other pipeline repo changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1199)
<!-- Reviewable:end -->
