### PR TITLE
Removes kfctl download and unpack script

### DIFF
--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -19,18 +19,6 @@ Follow these steps to deploy Kubeflow:
     ```
     tar -xvf kfctl_<release tag>_<platform>.tar.gz
     ```
-    
-    Script to download and unpack for Linux/MacOS:
-    ```
-    opsys=linux # darwin for Mac
-    
-    curl -s https://api.github.com/repos/kubeflow/kubeflow/releases/latest |\
-        grep browser_download |\
-        grep $opsys |\
-        cut -d '"' -f 4 |\
-        xargs curl -O -L && \
-        tar -zvxf kfctl_*_${opsys}.tar.gz 
-    ```
 
 1. Run the following commands to set up and deploy Kubeflow. The code below includes an optional command to add the binary `kfctl` to your path. If you don't add the binary to your path, you must use the full path to the `kfctl` binary each time you run it.
 


### PR DESCRIPTION
Resolves: kubeflow/kubeflow#3939

Removes the linux/darwin script to download and install kfctl. Preferred way of installing would be to download the tar file and unpack - this instruction wouldn't base it on the platform kfctl is being deployed on. Rather, the downloader should be able to download the appropriate kfctl build for their platform.

/cc @jlewi
/assign @sarahmaddox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1231)
<!-- Reviewable:end -->
