### PR TITLE
Pin kfctl release binary to v0.6.2

### DIFF
--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -15,9 +15,9 @@ If you don't have a provisioner, ensure that you have configured volume provisio
 
 Follow these steps to deploy Kubeflow:
 
-1. Download the latest `kfctl` release from the [Kubeflow releases page](https://github.com/kubeflow/kubeflow/releases/) and unpack it:
+1. Download the latest `kfctl` release (v0.6.2) from the [Kubeflow release page](https://github.com/kubeflow/kubeflow/releases/tag/v0.6.2) and unpack it:
     ```
-    tar -xvf kfctl_<release tag>_<platform>.tar.gz
+    tar -xvf kfctl_v0.6.2_<platform>.tar.gz
     ```
 
 1. Run the following commands to set up and deploy Kubeflow. The code below includes an optional command to add the binary `kfctl` to your path. If you don't add the binary to your path, you must use the full path to the `kfctl` binary each time you run it.


### PR DESCRIPTION
This is done because the config also points to the same version.

Relates to issue #1246

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1250)
<!-- Reviewable:end -->
