### PR TITLE
Updated config URL to include version num for existing_arrikto

### DIFF
--- a/layouts/shortcodes/config-uri-existing-arrikto.html
+++ b/layouts/shortcodes/config-uri-existing-arrikto.html
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_existing_arrikto.yaml
+https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_existing_arrikto.0.7.0.yaml


### PR DESCRIPTION
PR https://github.com/kubeflow/manifests/pull/565 added the version number to the `kfctl_existing_arrikto` YAML file, so we need to update the URL in the docs too.

Working towards closing https://github.com/kubeflow/website/issues/1224

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1270)
<!-- Reviewable:end -->
