### PR TITLE
update kustomize download script

### DIFF
--- a/content/docs/other-guides/kustomize.md
+++ b/content/docs/other-guides/kustomize.md
@@ -182,9 +182,10 @@ Make sure that you have the minimum required version of kustomize:
     * Download the kustomize binary:
 
         ```
-        curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
+        curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases |\
         grep browser_download |\
-        grep $opsys |\
+        grep download/kustomize |\
+        grep -m 1 $opsys |\
         cut -d '"' -f 4 |\
         xargs curl -O -L
         ```


### PR DESCRIPTION
The [kustomize](https://github.com/kubernetes-sigs/kustomize/releases) has releases for other assets than `kustomize` and the latest one is not `kustomize`. Hence the current script is broken. Fix to download the kustomize latest version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1274)
<!-- Reviewable:end -->
