### PR TITLE
Fixed and parameterised local config file names

### DIFF
--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -110,13 +110,13 @@ configuration before deploying Kubeflow:
 1. Set an environment variable pointing to your local configuration file:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_aws.0.7.0.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-aws-standard %}}
   ```
 
     Or:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_aws_cognito.0.7.0.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-aws-cognito %}}
   ```
 
 ## Customize your configuration

--- a/content/docs/gke/cloud-filestore.md
+++ b/content/docs/gke/cloud-filestore.md
@@ -31,13 +31,13 @@ This guide assumes the following settings:
   Kubeflow configuration file.
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_iap.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
     Or:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_basic_auth.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
   ```
 
 * The `${KF_NAME}` environment variable contains the name of your Kubeflow 

--- a/content/docs/gke/customizing-gke.md
+++ b/content/docs/gke/customizing-gke.md
@@ -43,13 +43,13 @@ This guide assumes the following settings:
   Kubeflow configuration file.
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_iap.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
     Or:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_basic_auth.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
   ```
 
 * The `${KF_NAME}` environment variable contains the name of your Kubeflow 

--- a/content/docs/gke/deploy/delete-cli.md
+++ b/content/docs/gke/deploy/delete-cli.md
@@ -23,13 +23,13 @@ This guide assumes the following settings:
   Kubeflow configuration file.
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_iap.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
     Or:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_basic_auth.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
   ```
 
 For further background about the above settings, see the guide to

--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -166,13 +166,13 @@ deploy Kubeflow:
 1. Set an environment variable for your local configuration file:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_iap.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
     Or:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_basic_auth.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
   ```
 
 1. Run the `kfctl apply` command to deploy Kubeflow:

--- a/content/docs/gke/troubleshooting-gke.md
+++ b/content/docs/gke/troubleshooting-gke.md
@@ -29,13 +29,13 @@ This guide assumes the following settings:
   Kubeflow configuration file.
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_iap.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
     Or:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_gcp_basic_auth.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
   ```
 
 * The `${KF_NAME}` environment variable contains the name of your Kubeflow 

--- a/content/docs/other-guides/kustomize.md
+++ b/content/docs/other-guides/kustomize.md
@@ -87,12 +87,12 @@ which you can further customize if necessary.
 Follow these steps to apply the configurations to your Kubeflow cluster:
 
 1. Set an environment variable pointing to your local configuration file.
-  For example, this guide uses the `kfctl_k8s_istio.yaml` configuration. If you
-  chose a different configuration in the previous step, you
-  must change the file name to reflect your configuration:
+  For example, this guide uses the `{{% config-file-k8s-istio %}}` 
+  configuration. If you chose a different configuration in the previous step, 
+  you must change the file name to reflect your configuration:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_k8s_istio.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-k8s-istio %}}
   ```
 
 1. Apply the configurations:

--- a/content/docs/other-guides/usage-reporting.md
+++ b/content/docs/other-guides/usage-reporting.md
@@ -42,7 +42,8 @@ interface to deploy Kubeflow.
 
 This guide refers to the `${CONFIG_FILE}`, which is the Kubeflow configuration 
 file in your Kubeflow deployment directory. For example,
-`${KF_DIR}/kfctl_k8s_istio.yaml` or `${KF_DIR}/{{% config-file-gcp-iap %}}`.
+`${KF_DIR}/{{% config-file-k8s-istio %}}` or 
+`${KF_DIR}/{{% config-file-gcp-iap %}}`.
 
 To prevent Spartakus from being deployed:
 

--- a/content/docs/other-guides/usage-reporting.md
+++ b/content/docs/other-guides/usage-reporting.md
@@ -42,7 +42,7 @@ interface to deploy Kubeflow.
 
 This guide refers to the `${CONFIG_FILE}`, which is the Kubeflow configuration 
 file in your Kubeflow deployment directory. For example,
-`${KF_DIR}/kfctl_k8s_istio.yaml` or `${KF_DIR}/kfctl_gcp_iap.yaml`.
+`${KF_DIR}/kfctl_k8s_istio.yaml` or `${KF_DIR}/{{% config-file-gcp-iap %}}`.
 
 To prevent Spartakus from being deployed:
 

--- a/content/docs/started/cloud/getting-started-icp.md
+++ b/content/docs/started/cloud/getting-started-icp.md
@@ -200,7 +200,7 @@ Set the `${CONFIG_FILE}` environment variable to the path for your
 Kubeflow configuration file:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_k8s_istio.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-k8s-istio %}}
   ```
 
 Run the following commands to delete your deployment and reclaim all resources:

--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -115,7 +115,7 @@ deploy Kubeflow:
 1. Set an environment variable pointing to your local configuration file:
 
   ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_k8s_istio.yaml
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-k8s-istio %}}
   ```
 
 1. Run the `kfctl apply` command to deploy Kubeflow:

--- a/content/docs/upgrading/upgrade.md
+++ b/content/docs/upgrading/upgrade.md
@@ -22,7 +22,7 @@ Nonetheless, here are some instructions for updating your deployment::
 
     The `${CONFIG_FILE}` environment variable must contain the path to the 
     Kubeflow configuration file in your `${KF_DIR}` directory. For example,
-    `${KF_DIR}/kfctl_k8s_istio.yaml` or `${KF_DIR}/kfctl_existing_arrikto.yaml`
+    `${KF_DIR}/{{% config-file-k8s-istio %}}` or `${KF_DIR}/kfctl_existing_arrikto.yaml`
 
 1. Download the kfctl {{% kf-latest-version %}} release from the
   [Kubeflow releases 

--- a/layouts/shortcodes/config-file-aws-cognito.html
+++ b/layouts/shortcodes/config-file-aws-cognito.html
@@ -1,0 +1,1 @@
+kfctl_aws_cognito.0.7.0.yaml

--- a/layouts/shortcodes/config-file-aws-standard.html
+++ b/layouts/shortcodes/config-file-aws-standard.html
@@ -1,0 +1,1 @@
+kfctl_aws.0.7.0.yaml

--- a/layouts/shortcodes/config-file-gcp-basic-auth.html
+++ b/layouts/shortcodes/config-file-gcp-basic-auth.html
@@ -1,0 +1,1 @@
+kfctl_gcp_basic_auth.0.7.0.yaml

--- a/layouts/shortcodes/config-file-gcp-iap.html
+++ b/layouts/shortcodes/config-file-gcp-iap.html
@@ -1,0 +1,1 @@
+kfctl_gcp_iap.0.7.0.yaml

--- a/layouts/shortcodes/config-file-k8s-istio.html
+++ b/layouts/shortcodes/config-file-k8s-istio.html
@@ -1,0 +1,1 @@
+kfctl_k8s_istio.0.7.0.yaml


### PR DESCRIPTION
The config files created by kfctl now include version number in the file name. We've adjusted all the config URIs but we also need to adjust the file names as referred to in the docs. For example, this:

```
export CONFIG_FILE=${KF_DIR}/kfctl_gcp_iap.yaml
```

Should become:

```
export CONFIG_FILE=${KF_DIR}/kfctl_gcp_iap.0.7.0.yaml
```

This PR creates the relevant shortcodes to future-proof this change throughout the deployment guides and other docs. It sets the shortcode values to the `<config file name>.0.7.0.yaml` pattern which we use for Kubeflow v0.7.0. We'll need to update the shortcodes for each release, along with the similar shortcodes for the config URIs.

This PR doesn't change the guide for [`kfctl_existing_arrikto`](https://www.kubeflow.org/docs/started/k8s/kfctl-existing-arrikto/) at this point, because that guide currently asks the user to download, rename, and update the config file before doing the deployment.

Fixes https://github.com/kubeflow/website/issues/1273

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1275)
<!-- Reviewable:end -->
