### PR TITLE
Add extra step to clean up kustomize for aws 

### DIFF
--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -163,6 +163,7 @@ configuration before deploying Kubeflow:
 
     ```
     cd ${KF_DIR}
+    rm -rf kustomize/  # Remove kustomize folder and regenerate files after customization
     kfctl apply -V -f ${CONFIG_FILE}
     ```
 


### PR DESCRIPTION
Once we run `kfctl build`, `aws_config` and `kustomize` are generate and `kfctl apply` will not regenerate them as they exist. (see PR https://github.com/kubeflow/kubeflow/pull/4369)

The problem is aws customization will be done after `build`. `apply` won't pick up new parameters.
Since PR is included in RC6 and later versions. We need to make this change to unblock deployment.

Talked with team jeremy on solutions here. https://github.com/kubeflow/kubeflow/issues/4368#issuecomment-545889048


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1284)
<!-- Reviewable:end -->
