### PR TITLE
Clarified GCP APIs and quota requirements

### DIFF
--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -25,6 +25,9 @@ Before installing Kubeflow on the command line:
   [Cloud Shell](https://cloud.google.com/shell/), enable 
   [boost mode](https://cloud.google.com/shell/docs/features#boost_mode).
 
+1. Make sure that your GCP project meets the minimum requirements
+  described in the [project setup guide](/docs/gke/deploy/project-setup/).
+
 1. If you want to use [Cloud Identity-Aware Proxy (Cloud 
   IAP)](https://cloud.google.com/iap/docs/) for access control, follow the guide
   to [setting up OAuth credentials](/docs/gke/deploy/oauth-setup/). 

--- a/content/docs/gke/deploy/deploy-ui.md
+++ b/content/docs/gke/deploy/deploy-ui.md
@@ -12,9 +12,23 @@ For more control over your deployment, see the guide to
 [deployment using the CLI](/docs/gke/deploy/deploy-cli).
 The CLI supports Kubeflow {{% kf-latest-version %}} and later versions.
 
-## Overview of the deployment user interface (UI)
+## Before you start
 
-Here's a partial screenshot of the deployment UI:
+Check the following requirements before installing Kubeflow:
+
+1. Make sure that your GCP project meets the minimum requirements
+  described in the [project setup guide](/docs/gke/deploy/project-setup/).
+
+1. If you want to use [Cloud Identity-Aware Proxy (Cloud 
+  IAP)](https://cloud.google.com/iap/docs/) for access control, follow the guide
+  to [setting up OAuth credentials](/docs/gke/deploy/oauth-setup/). 
+  Cloud IAP is recommended for production deployments or deployments with 
+  access to sensitive data. Alternatively, you can use basic authentication 
+  with a username and password.
+
+## Deploy Kubeflow
+
+Here's a partial screenshot of the deployment user interface (UI):
 
 <img src="/docs/images/kubeflow-deployment.png" 
   alt="Kubeflow deployment UI"

--- a/content/docs/gke/deploy/project-setup.md
+++ b/content/docs/gke/deploy/project-setup.md
@@ -4,42 +4,54 @@ description = "Creating a Google Cloud Platform (GCP) project for your Kubeflow 
 weight = 1
 +++
 
-Follow these steps to set up a GCP account and project if you don't already
-have one:
+Follow these steps to set up your GCP project:
 
 1. Select or create a project on the 
   [GCP Console](https://console.cloud.google.com/cloud-resource-manager).
-  The deployment process creates various Service Accounts with
-  appropriate roles in order to enable seamless integration with
-  GCP services. This requires that the user has 
+
+
+1. Make sure that you have the 
   [owner role](https://cloud.google.com/iam/docs/understanding-roles#primitive_role_definitions)
-  for the project in order to deploy Kubeflow.
+  for the project.
+  The deployment process creates various service accounts with
+  appropriate roles in order to enable seamless integration with
+  GCP services. This process requires that you have the 
+  owner role for the project in order to deploy Kubeflow.
 
 1. Make sure that billing is enabled for your project. See the guide to
   [modifying a project's billing 
   settings](https://cloud.google.com/billing/docs/how-to/modify-project).
 
 1. Go to the following pages on the GCP Console and ensure that the 
-  specified APIs are enabled on your GCP account:
+  specified APIs are enabled:
 
   * [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com)
   * [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com)
   * [Identity and Access Management (IAM) API](https://console.cloud.google.com/apis/library/iam.googleapis.com)
   * [Deployment Manager API](https://console.cloud.google.com/apis/library/deploymentmanager.googleapis.com)
+  * [Cloud Resource Manager API](https://console.developers.google.com/apis/library/cloudresourcemanager.googleapis.com)
+  * [Cloud Filestore API](https://console.developers.google.com/apis/library/file.googleapis.com)
+  * [AI Platform Training & Prediction API](https://console.developers.google.com/apis/library/ml.googleapis.com)
 
-1. Check to see if you are eligible for the 
-  [GCP Free Tier](https://cloud.google.com/free/docs/gcp-free-tier), which gives
-  you free resources to try GCP services. The guide describes:
+1. If you are using the 
+  [GCP Free Tier](https://cloud.google.com/free/docs/gcp-free-tier) or the
+  12-month trial period with $300 credit, note that you can't run the default
+  GCP installation of Kubeflow, because the free tier does not offer enough
+  resources. You need to 
+  [upgrade to a paid account](https://cloud.google.com/free/docs/gcp-free-tier#how-to-upgrade).
+  
+    For more information, see the following issues: 
 
-  * the GCP services which are always free, and
-  * a 12-month trial period with $300 credit that you can use with any GCP 
-    services.
+  * [kubeflow/website #1065](https://github.com/kubeflow/website/issues/1065)
+    reports the problem.
+  * [kubeflow/kubeflow #3936](https://github.com/kubeflow/kubeflow/issues/3936)
+    requests a Kubeflow configuration to work with a free trial project.
 
 1. Read the GCP guide to [resource quotas](https://cloud.google.com/compute/quotas)
   to understand the quotas on resource usage that Compute Engine enforces, and 
   to learn how to check your quota and how to request an increase in quota.
 
-You do not need a running GKE cluster. The deployment process will create a
+You do not need a running GKE cluster. The deployment process creates a
 cluster for you.
 
 ## Next steps


### PR DESCRIPTION
Adds more GCP APIs that need to be enabled, and clarifies the quota situation for GCP free tier.

Fixes https://github.com/kubeflow/website/issues/1288
Fixes https://github.com/kubeflow/website/issues/1248
Fixes https://github.com/kubeflow/website/issues/1065

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1289)
<!-- Reviewable:end -->
