### PR TITLE
update Amazon EKS name on aws docs

### DIFF
--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -21,7 +21,7 @@ deploy Kubeflow on Amazon Web Services (AWS).
 There're many ways to provision EKS cluster, using AWS EKS CLI, CloudFormation or Terraform, AWS CDK or eksctl.
 Here, we highly recommend you to create an EKS cluster using [eksctl](https://github.com/weaveworks/eksctl).
 
-You are required to have an existing Amazon Elastic Container Service for Kubernetes (Amazon EKS) cluster before moving the next step.
+You are required to have an existing Amazon Elastic Kubernetes Service (Amazon EKS) cluster before moving the next step.
 
 The installation tool uses the `eksctl` command and doesn't support the `--profile` option in that command.
 If you need to switch role, use the `aws sts assume-role` commands. See the AWS guide to [using temporary security credentials to request access to AWS resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).

--- a/content/docs/started/cloud/getting-started-aws.md
+++ b/content/docs/started/cloud/getting-started-aws.md
@@ -5,4 +5,4 @@ weight = 2
 +++
 
 Please refer to the [deployment section](/docs/aws/deploy) in the
-[AWS docs](/docs/aws/) for information on setting up your AWS environment and deploying Kubeflow on Amazon Elastic Container Service for Kubernetes (Amazon EKS).
+[AWS docs](/docs/aws/) for information on setting up your AWS environment and deploying Kubeflow on Amazon Elastic Kubernetes Service (Amazon EKS).


### PR DESCRIPTION
old name: Amazon Elastic Container Service for Kubernetes
new name: Amazon Elastic Kubernetes Service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1294)
<!-- Reviewable:end -->
