### PR TITLE
remove trailing slash for example BASE_DIR

### DIFF
--- a/content/docs/started/k8s/kfctl-existing-arrikto.md
+++ b/content/docs/started/k8s/kfctl-existing-arrikto.md
@@ -56,7 +56,7 @@ export CONFIG_URI="{{% config-uri-existing-arrikto %}}"
 export KF_NAME=<your choice of name for the Kubeflow deployment>
 
 # Set the path to the base directory where you want to store one or more 
-# Kubeflow deployments. For example, /opt/.
+# Kubeflow deployments. For example, /opt.
 # Then set the Kubeflow application directory for this deployment.
 export BASE_DIR=<path to a base directory>
 export KF_DIR=${BASE_DIR}/${KF_NAME}


### PR DESCRIPTION
following these directions exactly ends you up with a path of `/opt//kf-test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1297)
<!-- Reviewable:end -->
