### PR TITLE
Removed obsolete sections from the reference index page

### DIFF
--- a/content/docs/reference/_index.md
+++ b/content/docs/reference/_index.md
@@ -3,30 +3,3 @@ title = "Reference"
 description = "Reference documentation for Kubeflow."
 weight = 900
 +++
-
-<a id="tfjob">
-## TFJob
-
-TFJob is a Kubernetes
-[custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
-that you can use to run [TensorFlow](https://www.tensorflow.org/get_started/) training
-jobs on Kubernetes. For help with using TFJob with Kubeflow, see the
-[user guide](/docs/components/tftraining/).
-
-API references:
-
-  * [v1](/docs/reference/tfjob/v1/tensorflow/)
-  * [v1beta2](/docs/reference/tfjob/v1beta2/tensorflow/)
-
-<a id="pytorchjob">
-## PyTorchJob
-
-PyTorchJob is a Kubernetes
-[custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
-that you can use to run PyTorch training jobs on Kubernetes. For help with
-using PyTorch with Kubeflow, see the [user guide](/docs/components/pytorch/).
-
-API references:
-
-  * [v1](/docs/reference/pytorchjob/v1/pytorch/)
-  * [v1beta2](/docs/reference/pytorchjob/v1beta2/pytorch/)


### PR DESCRIPTION
Removed some obsolete sections from the reference docs index page. The sections are now duplicated in the overview page:
https://www.kubeflow.org/docs/reference/overview/

The index page need only contain a list of pages in the reference section.

Fixes https://github.com/kubeflow/website/issues/1309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1310)
<!-- Reviewable:end -->
