### PR TITLE
Use apps/v1 Deployments

### DIFF
--- a/content/docs/components/serving/tfserving_new.md
+++ b/content/docs/components/serving/tfserving_new.md
@@ -33,7 +33,7 @@ spec:
     app: mnist
   type: ClusterIP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -245,7 +245,7 @@ Then use the following manifest as an example:
 
 ```yaml
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
In k8s 1.16 extensions/v1beta1 is no longer available, while apps/v1 has
been available for some time now and should be a safe to transition to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1321)
<!-- Reviewable:end -->
