### PR TITLE
Changed link of "good first issue" and "help wanted"

### DIFF
--- a/content/docs/about/contributing.md
+++ b/content/docs/about/contributing.md
@@ -94,8 +94,8 @@ should be fixed, you should own it. Here is how you get started.
 
 To find Kubeflow issues that make good entry points, look at the following tags:
 
-* [`good first issue`](https://github.com/kubeflow/kubeflow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-* [`help wanted`](https://github.com/kubeflow/kubeflow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+* [`good first issue`](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+org%3Akubeflow)
+* [`help wanted`](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+org%3Akubeflow)
 
 ## Owners files and PR workflow
 


### PR DESCRIPTION
Resolved #1332 
For help wanted issue link which is added
 https://github.com/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+org%3Akubeflow

@sarahmaddox Please review it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1406)
<!-- Reviewable:end -->
