### PR TITLE
Fix invalid sed statement in install docu

### DIFF
--- a/content/docs/aws/deploy/install-kubeflow.md
+++ b/content/docs/aws/deploy/install-kubeflow.md
@@ -126,7 +126,7 @@ configuration before deploying Kubeflow:
   the file. For example, use this `sed` command:
 
   ```
-  sed -i '.bak' -e 's/kubeflow-aws/'"$AWS_CLUSTER_NAME"'/' ${CONFIG_FILE}
+  sed -i'.bak' -e 's/kubeflow-aws/'"$AWS_CLUSTER_NAME"'/' ${CONFIG_FILE}
   ```
 
 1. Retrieve the AWS Region and IAM role name for your worker nodes.


### PR DESCRIPTION
I had to remove the space between `sed -i` and the extension because I received this error: `# sed: can't read .bak: No such file or directory`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1407)
<!-- Reviewable:end -->
