### PR TITLE
Remove WtD AU 2019 doc fixit hosts from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -25,8 +25,6 @@ approvers:
   - vicaire
   - joeliedtke
   - animeshsingh
-  - alecglassford # Temporary for WtD AU 2019 fixit
-  - rionam # Temporary for WtD AU 2019 fixit
 reviewers:
   - abhi-g
   - aronchick
@@ -55,5 +53,3 @@ reviewers:
   - thedriftofwords
   - vicaire
   - animeshsingh
-  - alecglassford # Temporary for WtD AU 2019 fixit
-  - rionam # Temporary for WtD AU 2019 fixit


### PR DESCRIPTION
Reverts kubeflow/website#1335 now that the fixit has passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1418)
<!-- Reviewable:end -->
