### PR TITLE
Update upgrade doc for upgrading from v0.6.2

### DIFF
--- a/content/docs/upgrading/upgrade.md
+++ b/content/docs/upgrading/upgrade.md
@@ -13,7 +13,7 @@ Nonetheless, here are some instructions for updating your deployment:
 1. Check your Kubeflow configuration directory (`${KF_DIR}`) into source control
   as a backup.
 
-1. Delete your existing Kubeflow cluster:
+1. Delete your existing Kubeflow cluster (if you are upgrading from v0.6.2, apply step# 3 and 4 below first to get the latest verison of kfctl (Kubeflow v0.7.0) that support -f flag):
 
   ```
   export CONFIG_FILE=<the path to your Kubeflow config file>

--- a/content/docs/upgrading/upgrade.md
+++ b/content/docs/upgrading/upgrade.md
@@ -13,16 +13,13 @@ Nonetheless, here are some instructions for updating your deployment:
 1. Check your Kubeflow configuration directory (`${KF_DIR}`) into source control
   as a backup.
 
-1. Delete your existing Kubeflow cluster (if you are upgrading from v0.6.2, apply step# 3 and 4 below first to get the latest verison of kfctl (Kubeflow v0.7.0) that support -f flag):
+1. Delete your existing Kubeflow cluster:
 
-  ```
-  export CONFIG_FILE=<the path to your Kubeflow config file>
-  kfctl delete -V -f ${CONFIG_FILE}
+  ```  
+  kfctl delete -V 
   ```
 
-    The `${CONFIG_FILE}` environment variable must contain the path to the 
-    Kubeflow configuration file in your `${KF_DIR}` directory. For example,
-    `${KF_DIR}/{{% config-file-k8s-istio %}}` or `${KF_DIR}/kfctl_existing_arrikto.yaml`
+    
 
 1. Download the kfctl {{% kf-latest-version %}} release from the
   [Kubeflow releases 
@@ -37,8 +34,12 @@ Nonetheless, here are some instructions for updating your deployment:
 1. Update your kustomize manifests:
 
   ```
+  export CONFIG_FILE=<the path to your Kubeflow config file>
   kfctl build -V -f ${CONFIG_FILE}
   ```
+    The `${CONFIG_FILE}` environment variable must contain the path to the 
+    Kubeflow configuration file in your `${KF_DIR}` directory. For example,
+    `${KF_DIR}/{{% config-file-k8s-istio %}}` or `${KF_DIR}/kfctl_existing_arrikto.yaml`
   
 1. Re-apply any customizations that you need.
 


### PR DESCRIPTION
Currently, kfctl of v0.6.2 does not support -f flag, following exiting documentation in https://www.kubeflow.org/docs/upgrading/upgrade/ 

Step 2 : 
...
kfctl delete -V -f ${CONFIG_FILE}

will throw an error. 
The documentation should be modified to download the kfctl of v0.7.0 first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1420)
<!-- Reviewable:end -->
