### PR TITLE
Update the Slack invite link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -182,7 +182,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubeflow/website/is
         desc = "Development takes place here!"
 [[params.links.user]]
 	name = "Slack"
-	url = "https://join.slack.com/t/kubeflow/shared_invite/enQtNDg5MTM4NTQyNjczLWUyZGI1ZmExZWExYWY4YzlkOWI4NjljNjJhZjhjMjEwNGFjNmVkNjg2NTg4M2I0ZTM5NDExZWI5YTIyMzVmNzM"
+	url = "https://kubeflow.slack.com/join/shared_invite/enQtNDg5MTM4NTQyNjczLTdkNTVhMjg1ZTExOWI0N2QyYTQ2MTIzNTJjMWRiOTFjOGRlZWEzODc1NzMwNTMwM2EzNjY1MTFhODczNjk4MTk"
 	icon = "fab fa-slack"
         desc = "Chat with other project contributors"
 [[params.links.user]]

--- a/content/_index.html
+++ b/content/_index.html
@@ -154,7 +154,9 @@ title = "Kubeflow"
           <h5 class="card-title text-light section-head">Community</h5>
           <p class="card-text text-light">
             We are an open and welcoming community of software developers, data
-            scientists, and organizations! Join our <a target='_blank' class='text-light' href='https://join.slack.com/t/kubeflow/shared_invite/enQtNDg5MTM4NTQyNjczLWUyZGI1ZmExZWExYWY4YzlkOWI4NjljNjJhZjhjMjEwNGFjNmVkNjg2NTg4M2I0ZTM5NDExZWI5YTIyMzVmNzM'>Slack workspace</a> 
+            scientists, and organizations! Join our <a target='_blank'
+		    class='text-light'
+		    href='https://kubeflow.slack.com/join/shared_invite/enQtNDg5MTM4NTQyNjczLTdkNTVhMjg1ZTExOWI0N2QyYTQ2MTIzNTJjMWRiOTFjOGRlZWEzODc1NzMwNTMwM2EzNjY1MTFhODczNjk4MTk'>Slack workspace</a> 
             for help with any issues you may face, and read <a target="_blank" class='text-light' href='/docs/about/community/'>more about the community</a>.
           </p>
         </div>


### PR DESCRIPTION
The Slack invite link on the homepage was out-of-date. See this relevant
issue: https://github.com/kubeflow/website/issues/1456

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1457)
<!-- Reviewable:end -->
