### PR TITLE
Add the Codelab of the Kubeflow workshop

### DIFF
--- a/content/docs/examples/codelabs-tutorials.md
+++ b/content/docs/examples/codelabs-tutorials.md
@@ -22,6 +22,8 @@ Google Developers Codelabs provide a guided, tutorial, hands-on coding experienc
 * [Kubeflow Pipelines - GitHub Issue
   Summarization](https://codelabs.developers.google.com/codelabs/cloud-kubeflow-pipelines-gis/index.html): Run GitHub Issue Summarization with Kubeflow Pipelines on GKE.
 
+* [From Notebook to Kubeflow Pipelines with MiniKF and Kale](https://codelabs.developers.google.com/codelabs/cloud-kubeflow-minikf-kale/index.html): Run an end-to-end ML workflow all the way from a Notebook to a reproducible multi-step pipeline with Kale on MiniKF.
+
 ## Katacoda scenarios
 
 Follow the [Katacoda tutorials](https://www.katacoda.com/kubeflow) to deploy Kubeflow and run a machine learning model.


### PR DESCRIPTION
Add the Codelab of the Kubeflow workshop that was presented at KubeCon +
CloudNativeCon NA 2019, San Diego.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1461)
<!-- Reviewable:end -->
