### PR TITLE
Fix link to Kubeflow community in Serving overview site

### DIFF
--- a/content/docs/components/serving/overview.md
+++ b/content/docs/components/serving/overview.md
@@ -182,7 +182,7 @@ Further information:
  * KFServing:
    * [Kubeflow documentation](/docs/components/serving/kfserving/)
    * [GitHub repository](https://github.com/kubeflow/kfserving)
-   * [Community](https://www.kubeflow.org/docs/about/community/)
+   * [Community](/docs/about/community/)
  * Seldon Core
    * [Kubeflow documentation](/docs/components/serving/seldon/)
    * [Seldon Core documentation](https://docs.seldon.io/projects/seldon-core/en/latest/)

--- a/content/docs/components/serving/overview.md
+++ b/content/docs/components/serving/overview.md
@@ -182,7 +182,7 @@ Further information:
  * KFServing:
    * [Kubeflow documentation](/docs/components/serving/kfserving/)
    * [GitHub repository](https://github.com/kubeflow/kfserving)
-   * [Community]/docs/about/community/)
+   * [Community](https://www.kubeflow.org/docs/about/community/)
  * Seldon Core
    * [Kubeflow documentation](/docs/components/serving/seldon/)
    * [Seldon Core documentation](https://docs.seldon.io/projects/seldon-core/en/latest/)


### PR DESCRIPTION
In https://www.kubeflow.org/docs/components/serving/overview/

under "Further Information" > KFServing: 3rd bullet:
- [Community]/docs/about/community/)

Use this PR to fix this (to point to the community url)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1471)
<!-- Reviewable:end -->
