### PR TITLE
Add ONNX sample to website

### DIFF
--- a/content/docs/components/serving/overview.md
+++ b/content/docs/components/serving/overview.md
@@ -60,7 +60,7 @@ KFServing and Seldon Core. A check mark (**&check;**) indicates that the system
       <tr>
         <td></td>
         <td>ONNX</td>
-        <td><b>&check;</b> <a href="https://docs.seldon.io/projects/seldon-core/en/latest/examples/onnx_resnet.html">docs</a></td>
+        <td><b>&check;</b> <a href="https://github.com/kubeflow/kfserving/tree/master/docs/samples/onnx">sample</a></td>
         <td><b>&check;</b> <a href="https://docs.seldon.io/projects/seldon-core/en/latest/examples/onnx_resnet.html">docs</a></td>
       </tr>
 


### PR DESCRIPTION
Currently in KFServing overview website: https://www.kubeflow.org/docs/components/serving/overview/

KFServing and Seldon Core info for ONNX are both pointing to same Seldon-core documentation.
Modify one to point to KFServing sample.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1479)
<!-- Reviewable:end -->
