### PR TITLE
Add missing `gcloud auth login` step to "Deploy using CLI" doc

### DIFF
--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -51,7 +51,7 @@ some handy environment variables:
     tar -xvf kfctl_{{% kf-latest-version %}}_<platform>.tar.gz
     ```
 
-1. Login. You only need to run this command once:
+1. Log in. You only need to run this command once:
 
     ```
     gcloud auth login

--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -51,6 +51,12 @@ some handy environment variables:
     tar -xvf kfctl_{{% kf-latest-version %}}_<platform>.tar.gz
     ```
 
+1. Login. You only need to run this command once:
+
+    ```
+    gcloud auth login
+    ```
+
 1. Create user credentials. You only need to run this command once:
    
     ```


### PR DESCRIPTION
/assign @sarahmaddox 

@rmgogogo found this step is also required for following actions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1484)
<!-- Reviewable:end -->
