### PR TITLE
Add yaml info in KFServing install #1464

### DIFF
--- a/content/docs/components/serving/kfserving.md
+++ b/content/docs/components/serving/kfserving.md
@@ -58,9 +58,11 @@ Knative Serving (v0.8.0 +) and Istio (v1.1.7+) should be available on your Kuber
 Read more about [installing Knative on a Kubernetes cluster](https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md#install-knative-on-a-kubernetes-cluster).
 
 ## KFServing installation using kubectl
+The following commands install KFServing 0.2.2, using a yaml file in GitHub repo. See [here](https://github.com/kubeflow/kfserving/tree/master/install) for other available releases. Alternatively, you can clone the GitHub repo and run `kubectl` on top of it. 
 ```
-TAG=v0.2.0
-kubectl apply -f ./install/$TAG/kfserving.yaml
+TAG=0.2.2
+CONFIG_URI=https://raw.githubusercontent.com/kubeflow/kfserving/master/install/$TAG/kfserving.yaml
+kubectl apply -f ${CONFIG_URI}
 ```
 
 ## Use


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://www.kubeflow.org/docs/components/serving/kfserving/#kfserving-installation-using-kubectl,  add info about the yaml file so that user can install KFServing without cloning the Github repo.

**Which issue(s) this PR fixes** :
Fixes #1464

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1497)
<!-- Reviewable:end -->
