### PR TITLE
Update Microk8s install to specify K8s version

### DIFF
--- a/content/docs/started/workstation/getting-started-linux.md
+++ b/content/docs/started/workstation/getting-started-linux.md
@@ -19,7 +19,7 @@ GCP, AWS and Azure.
 [snapd](https://snapcraft.io/docs/getting-started), which is pre-installed on Ubuntu
 and Ubuntu derivative operating systems.
 
-1. Install MicroK8s - `snap install microk8s --classic`
+1. Install MicroK8s - `snap install microk8s --classic --channel=1.15/stable`
 2. Follow the getting started guide for Kubeflow on an
 [existing Kubernetes cluster](/docs/started/k8s/overview/).
 

--- a/content/docs/started/workstation/getting-started-linux.md
+++ b/content/docs/started/workstation/getting-started-linux.md
@@ -19,7 +19,7 @@ GCP, AWS and Azure.
 [snapd](https://snapcraft.io/docs/getting-started), which is pre-installed on Ubuntu
 and Ubuntu derivative operating systems.
 
-1. Install MicroK8s - `snap install microk8s --classic --channel=1.15/stable`
+1. Install MicroK8s - `snap install microk8s --classic --channel=1.14/stable`
 2. Follow the getting started guide for Kubeflow on an
 [existing Kubernetes cluster](/docs/started/k8s/overview/).
 


### PR DESCRIPTION
Current installation instructions will install (at the time of writing) k8s v1.17 - which is listed on https://www.kubeflow.org/docs/started/k8s/overview/ as being an incompatible version. Specifying the installation channel ensures the user installs a version that Kubeflow is verified against. 

These instructions will need to be updated as Kubeflow supports newer versions of K8s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1519)
<!-- Reviewable:end -->
