### PR TITLE
Added a support page for Kubeflow v1.0.0

### DIFF
--- a/content/docs/other-guides/support.md
+++ b/content/docs/other-guides/support.md
@@ -8,10 +8,6 @@ This page describes the Kubeflow resources and support options that you can
 explore when you encounter a problem, have a question, or want to make a
 suggestion about Kubeflow.
 
-TODO: This page currently mentions an "alpha" status whereas the version policy
-uses "experimental". I'm proposing a change to "alpha". If we decide to keep
-"experimental", I'll change this page.
-
 ## Levels of support
 
 Kubeflow applications offer various levels of support, based on the application

--- a/content/docs/other-guides/support.md
+++ b/content/docs/other-guides/support.md
@@ -1,0 +1,54 @@
++++
+title = "Support"
+description = "Where to go with questions and suggestions"
+weight = 110
++++
+
+This page describes the Kubeflow resources and support options that you can
+explore when you encounter a problem, have a question, or want to make a
+suggestion about Kubeflow.
+
+## Support from a cloud provider
+
+If you're using the services of a cloud provider to host Kubeflow, the cloud
+provider may be able to help you diagnose and solve a problem.
+
+Support pages for cloud services:
+
+* [Amazon Web Services (AWS)](https://aws.amazon.com/contact-us/)
+* [Google Cloud Platform (GCP)](https://cloud.google.com/support-hub/)
+* [IBM Cloud Private](https://www.ibm.com/cloud/support)
+* [Microsoft Azure](https://azure.microsoft.com/en-au/support/options/)
+
+## Support from the Kubeflow community
+
+TODO support levels v1.0 or not - refer to the versioning guide - Mention the stability notes that appear on component docs
+Also note some features are Alpha
+
+TODO Slack - various channels
+
+TODO kubeflow-discuss mailing list
+
+TODO Docs - especially overview, guide to components, guides to platforms, troubleshooting
+
+TODO Issue tracker for logging bugs and asking questions
+Search our issue database to see if we already know about your problem and learn about when we think we can fix it. If you don’t find your problem in the database, please open a new issue and let us know what’s going on.
+
+## Other places to ask questions
+
+TODO Can also try Stack Overflow - questions tagged with “Kubeflow”: https://stackoverflow.com/questions/tagged/kubeflow
+
+
+## Getting involved
+
+TODO community page
+
+TODO community meetings per group - Community meetings to talk to maintainers about specific topics
+
+TODO issue tracker for suggesting features and improvements
+
+## News
+
+Blog
+Twitter
+Release notes per component

--- a/content/docs/other-guides/support.md
+++ b/content/docs/other-guides/support.md
@@ -100,7 +100,7 @@ You can ask questions and make suggestions in the following places:
 
 * **Kubeflow issue trackers** for known issues, questions, and feature requests.
   Search the open issues to see if someone else has already logged the problem 
-  that you're encountering and learn about any workarounds to date. If no-one
+  that you're encountering and learn about any workarounds to date. If no one
   has logged your problem, create a new issue to describe the problem.
 
     Each Kubeflow application has its own issue tracker within the [Kubeflow

--- a/content/docs/other-guides/support.md
+++ b/content/docs/other-guides/support.md
@@ -82,11 +82,9 @@ You can ask questions and make suggestions in the following places:
 
 * **Slack** for online chat and messaging. See details of Kubeflow's 
   [Slack workspace and channels](/docs/about/community/#slack).
-
 * **Kubeflow discuss** for email-based group discussion. Join the
   [kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss) 
   group.
-
 * **Kubeflow documentation** for overviews and how-to guides. In particular,
   refer to the following documents when troubleshooting a problem:
 

--- a/content/docs/other-guides/support.md
+++ b/content/docs/other-guides/support.md
@@ -8,12 +8,68 @@ This page describes the Kubeflow resources and support options that you can
 explore when you encounter a problem, have a question, or want to make a
 suggestion about Kubeflow.
 
+TODO: This page currently mentions an "alpha" status whereas the version policy
+uses "experimental". I'm proposing a change to "alpha". If we decide to keep
+"experimental", I'll change this page.
+
+## Levels of support
+
+Kubeflow applications offer various levels of support, based on the application
+status. To see the status of each application, refer to the 
+[Kubeflow application 
+matrix](/docs/reference/version-policy/#kubeflow-application-matrix) on the
+version policies page.
+
+The following table describes the level of support that you can expect based on
+the status of an application:
+
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Application status</th>
+        <th>Level of support</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Stable</td>
+        <td>TODO What are the expectations here? Some examples:
+          <ul>
+            <li><a href="https://github.com/kubeflow/community/blob/master/proposals/issue_triage.md>">Issue
+              triage</a> within 48 hours.</li>
+            <li>Response to question on Slack or the kubeflow-discuss mailing
+              list within 24 hours.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>Beta</td>
+        <td>TODO What are the expectations here? Some examples:
+          <ul>
+            <li><a href="https://github.com/kubeflow/community/blob/master/proposals/issue_triage.md>">Issue
+              triage</a> within 48 hours.</li>
+            <li>Response to question on Slack or the kubeflow-discuss mailing
+              list within 72 hours.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>Alpha</td>
+        <td>The response differs per application in alpha status, depending on
+          the size of the community for that application and the current level
+          of active development of the application.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
 ## Support from a cloud provider
 
 If you're using the services of a cloud provider to host Kubeflow, the cloud
 provider may be able to help you diagnose and solve a problem.
 
-Support pages for cloud services:
+Consult the support page for the cloud service that you're using:
 
 * [Amazon Web Services (AWS)](https://aws.amazon.com/contact-us/)
 * [Google Cloud Platform (GCP)](https://cloud.google.com/support-hub/)
@@ -22,33 +78,91 @@ Support pages for cloud services:
 
 ## Support from the Kubeflow community
 
-TODO support levels v1.0 or not - refer to the versioning guide - Mention the stability notes that appear on component docs
-Also note some features are Alpha
+Kubeflow has an active and helpful community of users and contributors. You
+can ask questions and make suggestions in the following places:
 
-TODO Slack - various channels
+* **Slack** for online chat and messaging. See details of Kubeflow's 
+  [Slack workspace and channels](/docs/about/community/#slack).
 
-TODO kubeflow-discuss mailing list
+* **Kubeflow discuss** for email-based group discussion. Join the
+  [kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss) 
+  group.
 
-TODO Docs - especially overview, guide to components, guides to platforms, troubleshooting
+* **Kubeflow documentation** for overviews and how-to guides. In particular,
+  refer to the following documents when troubleshooting a problem:
 
-TODO Issue tracker for logging bugs and asking questions
-Search our issue database to see if we already know about your problem and learn about when we think we can fix it. If you don’t find your problem in the database, please open a new issue and let us know what’s going on.
+  * [Kubeflow installation and setup](/docs/started/getting-started/)
+  * [Kubeflow components](/docs/components/)
+  * [Further setup and troubleshooting](/docs/other-guides/)
+
+* **Kubeflow issue trackers** for known issues, questions, and feature requests.
+  Search the open issues to see if someone else has already logged the problem 
+  that you're encountering and learn about any workarounds to date. If no-one
+  has logged your problem, create a new issue to describe the problem.
+
+    Each Kubeflow application has its own issue tracker within the [Kubeflow
+    organization on GitHub](https://github.com/kubeflow). To get you started,
+    here are the primary issue trackers:
+
+  * [Kubeflow core](https://github.com/kubeflow/kubeflow/issues)
+  * [kfctl command-line tool](https://github.com/kubeflow/kfctl/issues)
+  * [Kustomize manifests](https://github.com/kubeflow/manifests/issues)
+  * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/issues)
+  * [Katib hyperparameter tuning](https://github.com/kubeflow/katib/issues)
+  * [Metadata](https://github.com/kubeflow/metadata/issues)
+  * [Fairing notebook SDK](https://github.com/kubeflow/fairing/issues)
+  * [TensorFlow training (TFJob)](https://github.com/kubeflow/tf-operator/issues)
+  * [PyTorch training (PyTorchJob)](https://github.com/kubeflow/pytorch-operator/issues)
+  * [KFServing](https://github.com/kubeflow/kfserving/issues)
+  * [Examples](https://github.com/kubeflow/examples/issues)
+  * [Documentation](https://github.com/kubeflow/website/issues)
+
+## Support from partners
+
+TODO Shall we include a partners section like this?
+
+The following organizations offer advice and support for Kubeflow deployments:
+
+* [Arrikto](https://www.arrikto.com). Contacts: TODO We need a point of contact.
+  Should we list some or all of the contacts that 
+  are currently in the [org list](https://github.com/kubeflow/community/blob/master/member_organizations.yaml#L42)?
+
+* TODO Are there any other partners we should add?
 
 ## Other places to ask questions
 
-TODO Can also try Stack Overflow - questions tagged with “Kubeflow”: https://stackoverflow.com/questions/tagged/kubeflow
+You can also try searching for answers or asking a question on Stack Overflow. 
+See the [questions tagged with
+“kubeflow”](https://stackoverflow.com/questions/tagged/kubeflow).
 
+## Getting involved in the Kubeflow community
 
-## Getting involved
+You can get involved with Kubeflow in many ways. For example, you can
+contribute to the Kubeflow code or documentation. You can join the community
+meetings to talk to maintainers about a specific topic. See the
+[Kubeflow community page](/docs/about/community/) for further information.
 
-TODO community page
+## Following the news
 
-TODO community meetings per group - Community meetings to talk to maintainers about specific topics
+Keep up with Kubeflow news:
 
-TODO issue tracker for suggesting features and improvements
+* The [Kubeflow blog](https://medium.com/kubeflow) is the primary channel for
+  announcement of new releases, events, and technical walkthroughs.
+* Follow [Kubeflow on Twitter](https://twitter.com/kubeflow) for shared
+  technical tips.
+* The release notes give details of the latest updates for each Kubeflow 
+  application.
 
-## News
+    Each Kubeflow application has its own repository within the [Kubeflow
+    organization on GitHub](https://github.com/kubeflow). Some of the 
+    applications publish release notes. To get you started,
+    here are the release notes for the primary applications:
 
-Blog
-Twitter
-Release notes per component
+  * [Kubeflow core](https://github.com/kubeflow/kubeflow/releases)
+  * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/releases)
+  * [Katib hyperparameter tuning](https://github.com/kubeflow/katib/releases)
+  * [Metadata](https://github.com/kubeflow/metadata/releases)
+  * [Fairing notebook SDK](https://github.com/kubeflow/fairing/releases)
+  * [TensorFlow training (TFJob)](https://github.com/kubeflow/tf-operator/releases)
+  * [PyTorch training (PyTorchJob)](https://github.com/kubeflow/pytorch-operator/releases)
+  * [KFServing](https://github.com/kubeflow/kfserving/releases)

--- a/content/docs/other-guides/support.md
+++ b/content/docs/other-guides/support.md
@@ -136,9 +136,9 @@ The following organizations offer advice and support for Kubeflow deployments:
     <tbody>
       <tr>
         <td><a href="https://www.arrikto.com">Arrikto</a></td>
-        <td></td>
+        <td><a href="mailto:sales@arrikto.com">sales@arrikto.com</a></td>
       </tr>
-            <tr>
+      <tr>
         <td><a href="https://www.seldon.io/">Seldon</a></td>
         <td> 
         <a href="https://github.com/SeldonIO/seldon-core/issues">Issue 
@@ -154,7 +154,7 @@ The following organizations offer advice and support for Kubeflow deployments:
 If you're using the services of a cloud provider to host Kubeflow, the cloud
 provider may be able to help you diagnose and solve a problem.
 
-Consult the support page for the cloud service that you're using:
+Consult the support page for the cloud service or platform that you're using:
 
 * [Amazon Web Services (AWS)](https://aws.amazon.com/contact-us/)
 * [Google Cloud Platform (GCP)](https://cloud.google.com/support-hub/)

--- a/content/docs/other-guides/support.md
+++ b/content/docs/other-guides/support.md
@@ -125,14 +125,31 @@ You can ask questions and make suggestions in the following places:
 
 The following organizations offer advice and support for Kubeflow deployments:
 
-* [Arrikto](https://www.arrikto.com). Contacts: TODO We need a point of contact.
-  Should we list some or all of the contacts that 
-  are currently in the [org list](https://github.com/kubeflow/community/blob/master/member_organizations.yaml#L42)?
-
-* TODO Are there any other organizations we should add?
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Organization</th>
+        <th>Points of contact</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="https://www.arrikto.com">Arrikto</a></td>
+        <td></td>
+      </tr>
+            <tr>
+        <td><a href="https://www.seldon.io/">Seldon</a></td>
+        <td> 
+        <a href="https://github.com/SeldonIO/seldon-core/issues">Issue 
+        tracker</a></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 <a id="cloud-support"></a>
-## Support from a cloud provider
+## Support from a cloud or platform provider
 
 If you're using the services of a cloud provider to host Kubeflow, the cloud
 provider may be able to help you diagnose and solve a problem.
@@ -143,6 +160,7 @@ Consult the support page for the cloud service that you're using:
 * [Google Cloud Platform (GCP)](https://cloud.google.com/support-hub/)
 * [IBM Cloud Private](https://www.ibm.com/cloud/support)
 * [Microsoft Azure](https://azure.microsoft.com/en-au/support/options/)
+* [Red Hat OpenShift](https://help.openshift.com/)
 
 ## Other places to ask questions
 

--- a/content/docs/other-guides/support.md
+++ b/content/docs/other-guides/support.md
@@ -34,24 +34,23 @@ the status of an application:
     <tbody>
       <tr>
         <td>Stable</td>
-        <td>TODO What are the expectations here? Some examples:
-          <ul>
-            <li><a href="https://github.com/kubeflow/community/blob/master/proposals/issue_triage.md>">Issue
-              triage</a> within 48 hours.</li>
-            <li>Response to question on Slack or the kubeflow-discuss mailing
-              list within 24 hours.</li>
-          </ul>
+        <td>The Kubeflow community offers <i>best-effort support</i> for stable
+          applications. See the section on 
+          <a href="#community-support">community support</a> below for a
+          definition of best-effort support and the community channels where you 
+          can report and discuss the problem. You can also consider requesting 
+          support from a 
+          <a href="#provider-support">Kubeflow community provider</a> or from 
+          your <a href="#cloud-support">cloud provider</a>.
         </td>
       </tr>
       <tr>
         <td>Beta</td>
-        <td>TODO What are the expectations here? Some examples:
-          <ul>
-            <li><a href="https://github.com/kubeflow/community/blob/master/proposals/issue_triage.md>">Issue
-              triage</a> within 48 hours.</li>
-            <li>Response to question on Slack or the kubeflow-discuss mailing
-              list within 72 hours.</li>
-          </ul>
+        <td>The Kubeflow community offers <i>best-effort support</i> for beta
+          applications. See the section on 
+          <a href="#community-support">community support</a> below for a
+          definition of best-effort support and the community channels where you 
+          can report and discuss the problem. 
         </td>
       </tr>
       <tr>
@@ -64,22 +63,26 @@ the status of an application:
   </table>
 </div>
 
-## Support from a cloud provider
-
-If you're using the services of a cloud provider to host Kubeflow, the cloud
-provider may be able to help you diagnose and solve a problem.
-
-Consult the support page for the cloud service that you're using:
-
-* [Amazon Web Services (AWS)](https://aws.amazon.com/contact-us/)
-* [Google Cloud Platform (GCP)](https://cloud.google.com/support-hub/)
-* [IBM Cloud Private](https://www.ibm.com/cloud/support)
-* [Microsoft Azure](https://azure.microsoft.com/en-au/support/options/)
-
+<a id="community-support">
 ## Support from the Kubeflow community
 
-Kubeflow has an active and helpful community of users and contributors. You
-can ask questions and make suggestions in the following places:
+Kubeflow has an active and helpful community of users and contributors. 
+
+The Kubeflow community offers support on a best-effort basis for stable and beta
+applications.
+**Best-effort support** means that there's no formal agreement or
+commitment to solve a problem but the community appreciates the
+importance of addressing the problem as soon as possible. The community commits
+to helping you diagnose and address the problem if all the following are true:
+
+* The cause falls within the technical framework that Kubeflow controls. For
+  example, the Kubeflow community may not be able to help if the problem is 
+  caused by a specific network configuration within your organization.
+* Community members can reproduce the problem.
+* The reporter of the problem can help with further diagnosis and 
+  troubleshooting.
+
+You can ask questions and make suggestions in the following places:
 
 * **Slack** for online chat and messaging. See details of Kubeflow's 
   [Slack workspace and channels](/docs/about/community/#slack).
@@ -117,9 +120,8 @@ can ask questions and make suggestions in the following places:
   * [Examples](https://github.com/kubeflow/examples/issues)
   * [Documentation](https://github.com/kubeflow/website/issues)
 
-## Support from partners
-
-TODO Shall we include a partners section like this?
+<a id="provider-support"></a>
+## Support from providers in the Kubeflow ecosystem
 
 The following organizations offer advice and support for Kubeflow deployments:
 
@@ -127,7 +129,20 @@ The following organizations offer advice and support for Kubeflow deployments:
   Should we list some or all of the contacts that 
   are currently in the [org list](https://github.com/kubeflow/community/blob/master/member_organizations.yaml#L42)?
 
-* TODO Are there any other partners we should add?
+* TODO Are there any other organizations we should add?
+
+<a id="cloud-support"></a>
+## Support from a cloud provider
+
+If you're using the services of a cloud provider to host Kubeflow, the cloud
+provider may be able to help you diagnose and solve a problem.
+
+Consult the support page for the cloud service that you're using:
+
+* [Amazon Web Services (AWS)](https://aws.amazon.com/contact-us/)
+* [Google Cloud Platform (GCP)](https://cloud.google.com/support-hub/)
+* [IBM Cloud Private](https://www.ibm.com/cloud/support)
+* [Microsoft Azure](https://azure.microsoft.com/en-au/support/options/)
 
 ## Other places to ask questions
 

--- a/content/docs/other-guides/troubleshooting.md
+++ b/content/docs/other-guides/troubleshooting.md
@@ -4,6 +4,8 @@ description = "Finding and fixing problems in your Kubeflow deployment"
 weight = 100
 +++
 
+This page presents some hints for troubleshooting specific problems that you
+may encounter.
 
 ## TensorFlow and AVX
 There are some instances where you may encounter a TensorFlow-related Python installation or a pod launch issue that results in a SIGILL (illegal instruction core dump). Kubeflow uses the pre-built binaries from the TensorFlow project which, beginning with version 1.6, are compiled to make use of the [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) CPU instruction. This is a recent feature and your CPU might not support it. Check the host environment for your node to determine whether it has this support.
@@ -166,3 +168,8 @@ To fix this issue first create GitHub API token using this [guide](https://help.
 ```commandline
 export GITHUB_TOKEN=<< token >>
 ```
+
+## Next steps
+
+Visit the [Kubeflow support page](/docs/other-guides/support/) to find resources
+and community forums where you can ask for help.


### PR DESCRIPTION
This PR adds a page describing **support options** for customers using Kubeflow v1.0 or later.

This PR is now ready for approval.

Preview: https://deploy-preview-1520--competent-brattain-de2d6d.netlify.com/docs/other-guides/support/

Fixes https://github.com/kubeflow/website/issues/1131

Reference: [Kubeflow v1.0 Docs and Processes Design](https://bit.ly/2OX11vw)

DO NOT MERGE UNTIL v1.0.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1520)
<!-- Reviewable:end -->
