### PR TITLE
Clarified and expanded the Slack info

### DIFF
--- a/content/docs/about/community.md
+++ b/content/docs/about/community.md
@@ -44,7 +44,7 @@ Agenda, notes, and a reminder of the next call are sent to the kubeflow-discuss
 mailing list.
 
 <a id="slack"></a>
-### Slack online chat and messaging
+### Slack community and channels
 
 The Kubeflow Slack workspace is 
 [kubeflow.slack.com](https://kubeflow.slack.com/). To join, click this

--- a/content/docs/about/community.md
+++ b/content/docs/about/community.md
@@ -43,24 +43,38 @@ mailing list will automatically send you calendar invitations for the meetings, 
 Agenda, notes, and a reminder of the next call are sent to the kubeflow-discuss
 mailing list.
 
-### Forums and mailing groups
+<a id="slack"></a>
+### Slack online chat and messaging
 
-Summary:
+The Kubeflow Slack workspace is 
+[kubeflow.slack.com](https://kubeflow.slack.com/). To join, click this
+[**invitation to our Slack 
+workspace**](https://join.slack.com/t/kubeflow/shared_invite/enQtNDg5MTM4NTQyNjczLTdkNTVhMjg1ZTExOWI0N2QyYTQ2MTIzNTJjMWRiOTFjOGRlZWEzODc1NzMwNTMwM2EzNjY1MTFhODczNjk4MTk).
 
-* [Invitation to our Slack channel](https://join.slack.com/t/kubeflow/shared_invite/enQtNDg5MTM4NTQyNjczLTdkNTVhMjg1ZTExOWI0N2QyYTQ2MTIzNTJjMWRiOTFjOGRlZWEzODc1NzMwNTMwM2EzNjY1MTFhODczNjk4MTk)
-* [Twitter](http://twitter.com/kubeflow)
-* [Mailing list: kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss)
+The Kubeflow Slack workspace offers several channels. Here are a few examples:
 
-<br>
-More detail:
+| Topic                                                              | Slack channel                                                        |
+| :----                                                              | :------------                                                        |
+| General discussion                                                 | [#general](https://kubeflow.slack.com/messages/C7REE0EHK)            |
+| Community meeting chat                                             | [#community](https://kubeflow.slack.com/messages/C8Q0QJYNB)          |
+| TF Operator ([GitHub](https://github.com/kubeflow/tf-operator))    | [#tf-operator](https://kubeflow.slack.com/messages/C985VJN9F)        |
+| KFServing ([GitHub](https://github.com/kubeflow/kfserving))        | [#kfserving](https://kubeflow.slack.com/messages/CH6E58LNP)          |
+| Pipelines ([GitHub](https://github.com/kubeflow/pipelines))        | [#kfserving](https://kubeflow.slack.com/messages/CE10KS9M4)          |
+| Examples ([GitHub](https://github.com/kubeflow/examples))          | [#kubeflow-examples](https://kubeflow.slack.com/messages/CA30Q9A4U)  |
+| Documentation ([GitHub](https://github.com/kubeflow/website))      | [#website](https://kubeflow.slack.com/messages/CA4M298LD)            |
+| Product management                                                 | [#product-management](https://kubeflow.slack.com/messages/CGP3DKT5E) |
 
-| Topic                                                           | Mailing list                                                                      | Slack                                                                                             |
-| :----                                                           | :------------                                                                     | :-------------                                                                                    |
-| General discussion                                              | [kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss)      | [#general](https://kubeflow.slack.com/messages/C7REE0EHK)                                         |
-| TF Operator ([GitHub](https://github.com/kubeflow/tf-operator)) | [tf-operator](https://groups.google.com/a/kubeflow.org/forum/#!forum/tf-operator) | [#tf-operator](https://kubeflow.slack.com/messages/C985VJN9F) |
-| Community meeting chat                                          | n/a                                                                               | [#community](https://kubeflow.slack.com/messages/C8Q0QJYNB)                                       |
+### Mailing lists
 
-Slack server: [kubeflow.slack.com](https://kubeflow.slack.com/)
+The primary mailing list (email group) is 
+[kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss).
+
+More detail about the Kubeflow mailing lists:
+
+| Topic                                                           | Mailing list                                                                      |
+| :----                                                           | :------------                                                                     |
+| General discussion                                              | [kubeflow-discuss](https://groups.google.com/forum/#!forum/kubeflow-discuss)      |
+| TF Operator ([GitHub](https://github.com/kubeflow/tf-operator)) | [tf-operator](https://groups.google.com/a/kubeflow.org/forum/#!forum/tf-operator) |
 
 ## Who should consider contributing to Kubeflow?
 


### PR DESCRIPTION
Updated Slack info on the [community page](https://www.kubeflow.org/docs/about/community/): Added  a few channels, fixed the Slack terminology (workspace vs channel), and separated the Slack info into a new section, so that we can link to it more easily. In particular, the new v1.0 support page needs to link to the Slack info.

Fixes https://github.com/kubeflow/website/issues/1521

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1522)
<!-- Reviewable:end -->
