### PR TITLE
update mxjob doc

### DIFF
--- a/content/docs/components/training/mxnet.md
+++ b/content/docs/components/training/mxnet.md
@@ -50,6 +50,13 @@ You create a training job by defining a MXJob with MXTrain mode and then creatin
 kubectl create -f examples/v1beta1/train/mx_job_dist_gpu.yaml
 ```
 
+As an alternative solution, you can deploy mxnet-operator bypass ksonnect
+
+```
+kubectl create -f manifests/crd-v1beta1.yaml 
+kubectl create -f manifests/rbac.yaml 
+kubectl create -f manifests/deployment.yaml
+```
 
 ## Creating a TVM tuning job (AutoTVM)
 

--- a/content/docs/components/training/mxnet.md
+++ b/content/docs/components/training/mxnet.md
@@ -53,6 +53,8 @@ kubectl create -f examples/v1beta1/train/mx_job_dist_gpu.yaml
 As an alternative solution, you can deploy mxnet-operator bypass ksonnect
 
 ```
+# git clone https://github.com/kubeflow/mxnet-operator.git
+# cd mxnet-operator
 kubectl create -f manifests/crd-v1beta1.yaml 
 kubectl create -f manifests/rbac.yaml 
 kubectl create -f manifests/deployment.yaml


### PR DESCRIPTION
Add an useful way to install MXNet-Operator.
The documentation is from https://github.com/kubeflow/mxnet-operator/blob/master/README.md

Besides, I add the code below to differentiate the repos for users.
```
# git clone https://github.com/kubeflow/mxnet-operator.git
# cd mxnet-operator
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1528)
<!-- Reviewable:end -->
