### PR TITLE
Kubeflow v0.4 docs: Added logic to create a banner on archived doc sets (#1535)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -107,9 +107,6 @@ twitter = "kubeflow" # add your twitter profile
 copyright = "The Kubeflow Authors."
 privacy_policy = "https://policies.google.com/privacy"
 
-# Docsy: Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "007239566369470735695:624rglujm-w"
-
 # Text label for the version menu in the top bar of the website.
 version_menu = "v0.4"
 

--- a/config.toml
+++ b/config.toml
@@ -107,10 +107,31 @@ twitter = "kubeflow" # add your twitter profile
 copyright = "The Kubeflow Authors."
 privacy_policy = "https://policies.google.com/privacy"
 
-version = "master"
-githubbranch = "master"
+# Docsy: Google Custom Search Engine ID. Remove or comment out to disable search.
+gcs_engine_id = "007239566369470735695:624rglujm-w"
 
-# Add new release versions here
+# Text label for the version menu in the top bar of the website.
+version_menu = "v0.4"
+
+# The major.minor version tag for the version of the docs represented in this
+# branch of the repository. Used in the "version-banner" partial to display a
+# version number for this doc set.
+version = "v0.4"
+
+# Flag used in the "version-banner" partial to decide whether to display a 
+# banner on every page indicating that this is an archived version of the docs.
+archived_version = true
+
+# A link to latest version of the docs. Used in the "version-banner" partial to
+# point people to the main doc site.
+url_latest_version = "https://kubeflow.org/docs/"
+
+# A variable used in various docs to determine URLs for config files etc.
+# To find occurrences, search the repo for 'params "githubbranch"'.
+githubbranch = "v0.4-branch"
+
+# Add new release versions here. These entries appear in the drop-down menu
+# at the top of the website.
 [[params.versions]]
   version = "master"
   githubbranch = "master"

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}" class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+  </head>
+  <body class="td-{{ .Kind }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </div>
+          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
+            {{ partial "toc.html" . }}
+          </div>
+          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+            {{ partial "version-banner.html" . }}
+            {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -3,7 +3,15 @@
 {{ if .Site.Params.archived_version }}
   {{ $color := "primary" }}
   {{ $latest := .Site.Params.url_latest_version }}
-  <div class="pageinfo pageinfo-{{ $color }}">
+  <div style="font-weight: $font-weight-medium;
+              background: $gray-100;
+              color: inherit;
+              border-radius: 0;
+              margin: 2rem;
+              padding: 1.5rem;
+              padding-bottom: 0.5rem;
+              border-style: solid;
+              border-color: $color;">
     {{ with .Site.Params.version }}<p>Version {{ . | markdownify }} of the
       documentation is no longer actively maintained. The site that you are
       currently viewing is an archived snapshot. For up-to-date documentation,

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,14 @@
+<!-- Check the variable that indicates whether this is an archived doc set.
+  If yes, display a banner. -->
+{{ if .Site.Params.archived_version }}
+  {{ $color := "primary" }}
+  {{ $latest := .Site.Params.url_latest_version }}
+  <div class="pageinfo pageinfo-{{ $color }}">
+    {{ with .Site.Params.version }}<p>Version {{ . | markdownify }} of the
+      documentation is no longer actively maintained. The site that you are
+      currently viewing is an archived snapshot. For up-to-date documentation,
+      see the 
+      <a href="{{ $latest | safeURL }}" target="_blank">latest version</a>.</p>
+    {{ end }}
+  </div>
+{{ end }}


### PR DESCRIPTION
v0.4 branch: Added logic to create a banner on archived doc sets (cherry-pick of PR https://github.com/kubeflow/website/pull/1535 plus updates specific to this branch).

Part of issue https://github.com/kubeflow/website/issues/1126

Preview: https://deploy-preview-1558--infallible-hermann-cb44b2.netlify.com/docs/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1558)
<!-- Reviewable:end -->
