### PR TITLE
Kubeflow v0.2 docs: Added logic to create a banner on archived doc sets (#1535)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,8 +10,26 @@ Paginate = 20
   github = "kubeflow" # add your github profile name
   twitter = "" # add your twitter profile
   email = "myemail@myaddress.xxx"
-  version = "v0.2"
-  githubbranch = "v0.2-branch"
+
+# Text label for the version menu in the top bar of the website.
+version_menu = "v0.2"
+
+# The major.minor version tag for the version of the docs represented in this
+# branch of the repository. Used in the "version-banner" partial to display a
+# version number for this doc set.
+version = "v0.2"
+
+# Flag used in the "version-banner" partial to decide whether to display a 
+# banner on every page indicating that this is an archived version of the docs.
+archived_version = true
+
+# A link to latest version of the docs. Used in the "version-banner" partial to
+# point people to the main doc site.
+url_latest_version = "https://kubeflow.org/docs/"
+
+# A variable used in various docs to determine URLs for config files etc.
+# To find occurrences, search the repo for 'params "githubbranch"'.
+githubbranch = "v0.2-branch"
 
 # Add new release versions here
 [[Params.versions]]

--- a/themes/kf/layouts/docs/single.html
+++ b/themes/kf/layouts/docs/single.html
@@ -11,6 +11,7 @@
   <section id="pageContent">
     <div>
       <h1 id="anchor1"> {{ .Title}} </h1>
+      {{ partial "version-banner.html" . }}
       <p>
            {{  if .Params.bref }}
              {{ .Params.bref | safeHTML }}

--- a/themes/kf/layouts/partials/version-banner.html
+++ b/themes/kf/layouts/partials/version-banner.html
@@ -3,7 +3,16 @@
 {{ if .Site.Params.archived_version }}
   {{ $color := "primary" }}
   {{ $latest := .Site.Params.url_latest_version }}
-  <div class="pageinfo pageinfo-{{ $color }}">
+  <div style="font-weight: $font-weight-medium;
+              background: $gray-100;
+              color: inherit;
+              border-radius: 0;
+              margin: 2rem;
+              padding: 1.5rem;
+              padding-bottom: 0.5rem;
+              border-style: solid;
+              border-color: $color;
+              border-width: medium;">
     {{ with .Site.Params.version }}<p>Version {{ . | markdownify }} of the
       documentation is no longer actively maintained. The site that you are
       currently viewing is an archived snapshot. For up-to-date documentation,

--- a/themes/kf/layouts/partials/version-banner.html
+++ b/themes/kf/layouts/partials/version-banner.html
@@ -1,0 +1,14 @@
+<!-- Check the variable that indicates whether this is an archived doc set.
+  If yes, display a banner. -->
+{{ if .Site.Params.archived_version }}
+  {{ $color := "primary" }}
+  {{ $latest := .Site.Params.url_latest_version }}
+  <div class="pageinfo pageinfo-{{ $color }}">
+    {{ with .Site.Params.version }}<p>Version {{ . | markdownify }} of the
+      documentation is no longer actively maintained. The site that you are
+      currently viewing is an archived snapshot. For up-to-date documentation,
+      see the 
+      <a href="{{ $latest | safeURL }}" target="_blank">latest version</a>.</p>
+    {{ end }}
+  </div>
+{{ end }}


### PR DESCRIPTION
v0.2 branch: Added logic to create a banner on archived doc sets (cherry-pick of PR https://github.com/kubeflow/website/pull/1535 plus updates specific to this branch).

Part of issue https://github.com/kubeflow/website/issues/1126

Preview: https://deploy-preview-1560--eager-nobel-1708cf.netlify.com/docs/about/kubeflow/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1560)
<!-- Reviewable:end -->
