### PR TITLE
Remove the archived version banner from the v0.7-branch.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -115,7 +115,7 @@ version = "v0.7"
 
 # Flag used in the "version-banner" partial to decide whether to display a 
 # banner on every page indicating that this is an archived version of the docs.
-archived_version = true
+archived_version = false
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.


### PR DESCRIPTION
* We are now redirecting www.kubeflow.org to the v0.7-branch
  this is what users should see until we are ready to publish
  the 1.0 docs.

* Related to kubeflow/website#1581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1585)
<!-- Reviewable:end -->
