### PR TITLE
Change version to v1.0RC in label for website menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -106,12 +106,12 @@ privacy_policy = "https://policies.google.com/privacy"
 gcs_engine_id = "007239566369470735695:624rglujm-w"
 
 # Text label for the version menu in the top bar of the website.
-version_menu = "v0.7"
+version_menu = "v1.0RC"
 
 # The major.minor version tag for the version of the docs represented in this
 # branch of the repository. Used in the "version-banner" partial to display a
 # version number for this doc set.
-version = "v0.7"
+version = "v1.0"
 
 # Flag used in the "version-banner" partial to decide whether to display a 
 # banner on every page indicating that this is an archived version of the docs.
@@ -123,7 +123,7 @@ url_latest_version = "https://kubeflow.org/docs/"
 
 # A variable used in various docs to determine URLs for config files etc.
 # To find occurrences, search the repo for 'params "githubbranch"'.
-githubbranch = "v0.7-branch"
+githubbranch = "v1.0-branch"
 
 # Add new release versions here. These entries appear in the drop-down menu
 # at the top of the website.

--- a/content/docs/gke/customizing-gke.md
+++ b/content/docs/gke/customizing-gke.md
@@ -221,7 +221,7 @@ More detailed instructions follow.
 ### Add VMs with more CPUs or RAM
 
   * Change the machineType.
-  * There are two node pools defined in the GCP Deployment manager:
+  * There are two node pools defined in the GCP Deployment Manager:
       * one for CPU only machines, in [`cluster.jinja`](https://github.com/kubeflow/manifests/tree/{{< params "githubbranch" >}}/gcp/deployment_manager_configs/cluster.jinja#L114).
       * one for GPU machines, in [`cluster.jinja`](https://github.com/kubeflow/manifests/tree/{{< params "githubbranch" >}}/gcp/deployment_manager_configs/cluster.jinja#L140).
   * When making changes to the node pools you also need to bump the `pool-version` in [`cluster-kubeflow.yaml`](https://github.com/kubeflow/manifests/tree/{{< params "githubbranch" >}}/gcp/deployment_manager_configs/cluster-kubeflow.yaml#L46) before you update the deployment.

--- a/content/docs/gke/customizing-gke.md
+++ b/content/docs/gke/customizing-gke.md
@@ -221,10 +221,10 @@ More detailed instructions follow.
 ### Add VMs with more CPUs or RAM
 
   * Change the machineType.
-  * There are two node pools:
-      * one for CPU only machines [here](https://github.com/kubeflow/kubeflow/blob/{{< params "githubbranch" >}}/scripts/gke/deployment_manager_configs/cluster.jinja#L109).
-      * one for GPU machines [here](https://github.com/kubeflow/kubeflow/blob/{{< params "githubbranch" >}}/scripts/gke/deployment_manager_configs/cluster.jinja#L149).
-  * When making changes to the node pools you also need to bump the pool-version [here](https://github.com/kubeflow/kubeflow/blob/{{< params "githubbranch" >}}/scripts/gke/deployment_manager_configs/cluster-kubeflow.yaml#L37) before you update the deployment.
+  * There are two node pools defined in the GCP Deployment manager:
+      * one for CPU only machines, in [`cluster.jinja`](https://github.com/kubeflow/manifests/tree/{{< params "githubbranch" >}}/gcp/deployment_manager_configs/cluster.jinja#L114).
+      * one for GPU machines, in [`cluster.jinja`](https://github.com/kubeflow/manifests/tree/{{< params "githubbranch" >}}/gcp/deployment_manager_configs/cluster.jinja#L140).
+  * When making changes to the node pools you also need to bump the `pool-version` in [`cluster-kubeflow.yaml`](https://github.com/kubeflow/manifests/tree/{{< params "githubbranch" >}}/gcp/deployment_manager_configs/cluster-kubeflow.yaml#L46) before you update the deployment.
 
 ### Add users to Kubeflow
 


### PR DESCRIPTION
Changed relevant version numbers to v1.0 in config, including changing the title of the version menu to **v1.0RC**.

Fixes https://github.com/kubeflow/website/issues/1587

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1589)
<!-- Reviewable:end -->
