### PR TITLE
Added stable banner to central dashboard page

### DIFF
--- a/content/docs/components/central-dash/overview.md
+++ b/content/docs/components/central-dash/overview.md
@@ -4,6 +4,8 @@ description = "Overview of the Kubeflow user interfaces (UIs)"
 weight = 10
 +++
 
+{{% stable-status %}}
+
 Your Kubeflow deployment includes a central dashboard that provides quick access
 to the Kubeflow components deployed in your cluster. The dashboard includes the
 following features:


### PR DESCRIPTION
The central dashboard page is new and therefore didn't get a banner in the first round. Added a banner now.

Preview: https://deploy-preview-1606--competent-brattain-de2d6d.netlify.com/docs/components/central-dash/overview/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1606)
<!-- Reviewable:end -->
