### PR TITLE
use the latest minikube for Linux

### DIFF
--- a/content/docs/other-guides/virtual-dev/getting-started-minikube.md
+++ b/content/docs/other-guides/virtual-dev/getting-started-minikube.md
@@ -153,7 +153,7 @@ $ curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-darw
 ##### Ubuntu or CentOS
 
 ```
-$ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.28.0/minikube-linux-amd64
+$ curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
 $ chmod +x minikube
 $ sudo mv minikube /usr/local/bin/
 ```


### PR DESCRIPTION
0.28.0 not working with a guide https://www.kubeflow.org/docs/other-guides/virtual-dev/getting-started-minikube/

```
Starting local Kubernetes v1.10.0 cluster...
Starting VM...
```
without finish

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1609)
<!-- Reviewable:end -->
