### PR TITLE
Adding new section on managed certificates failure

### DIFF
--- a/content/docs/gke/troubleshooting-gke.md
+++ b/content/docs/gke/troubleshooting-gke.md
@@ -445,6 +445,7 @@ Make sure the certificate status is either `Active` or `Provisioning` which mean
   ```
 
 Make sure of the following:
+
  * `networking.gke.io/managed-certificates` annotation value points to the name of the Kubernetes managed certificate resource and is `gke-certificate`;
  *  public IP address that is displayed in the status is assigned. See the example of IP address below:
 


### PR DESCRIPTION
This is a proposed fix for issue #1568.

I have added a new entry describing the steps on how to troubleshoot the certificate failure provided in the description of [issue](https://github.com/kubeflow/website/issues/1568). 

I also made just a couple of fixes in the section. 

I have a concern about the additional comment by @jlewi to this issue. It sounds too vague for me and most likely needs more detailed investigation and communication with SMEs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1664)
<!-- Reviewable:end -->
