### PR TITLE
Fix broken link to release page

### DIFF
--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -151,7 +151,7 @@ Run the following commands to set up and deploy Kubeflow.
 
 1. Download the kfctl {{% kf-latest-version %}} release from the
   [Kubeflow releases 
-  page](https://github.com/kubeflow/kubeflow/releases/tag/{{% kf-latest-version %}}).
+  page](https://github.com/kubeflow/kfctl/releases/tag/{{% kf-latest-version %}}).
 
 1. Unpack the tar ball
       ```


### PR DESCRIPTION
Currently, in https://www.kubeflow.org/docs/ibm/install-kubeflow/

**Kubeflow installation**
Run the following commands to set up and deploy Kubeflow.
1. Download the kfctl v1.0-rc.4 release from the [Kubeflow releases page](https://github.com/kubeflow/kubeflow/releases/tag/v1.0-rc.4 ).

Follow Kubeflow release page -> 404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1692)
<!-- Reviewable:end -->
