### PR TITLE
fix: curl short --output to small case

### DIFF
--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -175,7 +175,7 @@ You can follow the instructions below to have greater control.
 
     ```
     cd ${KF_DIR}
-    curl -L -O ${CONFIG_FILE} {{% config-uri-gcp-iap %}}
+    curl -L -o ${CONFIG_FILE} {{% config-uri-gcp-iap %}}
     ```
 
     * **CONFIG_FILE** should be the name you would like to use for your local config file; e.g. "kfdef.yaml"


### PR DESCRIPTION
The `-O` option is used to download the file using the last path component for the name.
This is just a small change to use the small case option which allows you to specify the output file.

Reference: https://curl.haxx.se/docs/manpage.html#-o

Cheers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1698)
<!-- Reviewable:end -->
