### PR TITLE
fix: add ' ' to yq command spec keypath

### DIFF
--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -184,9 +184,9 @@ You can follow the instructions below to have greater control.
 using [yq](https://github.com/mikefarah/yq/releases):
 
     ```
-    yq w -i ${CONFIG_FILE} spec.plugins[0].spec.project ${PROJECT}
-    yq w -i ${CONFIG_FILE} spec.plugins[0].spec.zone ${ZONE}
-    yq w -i ${CONFIG_FILE} metadata.name ${KF_NAME}
+    yq w -i ${CONFIG_FILE} 'spec.plugins[0].spec.project' ${PROJECT}
+    yq w -i ${CONFIG_FILE} 'spec.plugins[0].spec.zone' ${ZONE}
+    yq w -i ${CONFIG_FILE} 'metadata.name' ${KF_NAME}
     ```
 
    * **PROJECT:** The GCP project to deploy in
@@ -335,9 +335,9 @@ The following snippet shows you how to set values in the configuration file
 using [yq](https://github.com/mikefarah/yq/releases):
 
 ```
-yq w -i ${CONFIG_FILE} spec.plugins[0].spec.project ${PROJECT}
-yq w -i ${CONFIG_FILE} spec.plugins[0].spec.zone ${ZONE}
-yq w -i ${CONFIG_FILE} metadata.name ${KF_NAME}
+yq w -i ${CONFIG_FILE} 'spec.plugins[0].spec.project' ${PROJECT}
+yq w -i ${CONFIG_FILE} 'spec.plugins[0].spec.zone' ${ZONE}
+yq w -i ${CONFIG_FILE} 'metadata.name' ${KF_NAME}
 ```
 
 ### Application layout


### PR DESCRIPTION
Because we are using array notation to select the first position in the plugins under spec section, we need to enclose the keypath with ' ' otherwise bash will complain that can't find a match.

For the sake of consistency i have added it to `metadata.name` path.

Reference from yq help: `write       yq w [--inplace/-i] [--script/-s script_file] [--doc/-d index] sample.yaml 'b.e(name==fr*).value' newValue`

Cheers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1699)
<!-- Reviewable:end -->
