### PR TITLE
fix: build the configured manifest file instead of the one from the URI

### DIFF
--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -198,7 +198,7 @@ using [yq](https://github.com/mikefarah/yq/releases):
     ```
     mkdir -p ${KF_DIR}
     cd ${KF_DIR}
-    kfctl build -V -f ${CONFIG_URI}
+    kfctl build -V -f ${CONFIG_FILE}
     ```
 
 1. To customize your GKE cluster modify the deployment manager configuration files


### PR DESCRIPTION
fix for #1700 

Accordingly to @sarahmaddox this is a copy-paste error .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1703)
<!-- Reviewable:end -->
