### PR TITLE
Fix validate urls script: added = and % to HTTP_PATTERN

### DIFF
--- a/scripts/validate-urls.py
+++ b/scripts/validate-urls.py
@@ -39,7 +39,7 @@ parser.add_argument(
 
 # http/https URLs
 HTTP_PATTERN = re.compile(
-    'http[s]?://[a-zA-Z\-_?/*\.#\$][a-zA-Z0-9\-_?/*\.#\$]+')
+    'http[s]?://[a-zA-Z\-_?/*\.#\$][a-zA-Z0-9\-_?/*\.#%=\$]+')
 
 # Patterns in this white list are considered valid.
 WHITE_LIST = [


### PR DESCRIPTION
While working  [issue 1683](https://github.com/kubeflow/website/issues/1683), the current validate-urls.py incorrectly report the following errors (as the urls are truncated):
```
|/community.md | https://calendar.google.com/calendar/embed?src | 400|
|/community.md | https://calendar.google.com/calendar/ical/kubeflow.org_7l5vnbn8suj2se10sen81d9428 | 400|
```
However, inside community.md, the actual/working urls are:

`https://calendar.google.com/calendar/embed?src=kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com` 

`https://calendar.google.com/calendar/ical/kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com/public/basic.ics `

Use this PR to take care = and % in the urls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1704)
<!-- Reviewable:end -->
