### PR TITLE
Rename IBM Cloud default cluster name to Kubeflow

### DIFF
--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -34,7 +34,7 @@ environment variables.
 1.  Set `CLUSTER_NAME`, `CLUSTER_REGION`, and `CLUSTER_ZONE` variables:
 
     ```
-    export CLUSTER_NAME=knative
+    export CLUSTER_NAME=Kubeflow
     export CLUSTER_REGION=us-south
     export CLUSTER_ZONE=dal13
     ```
@@ -46,7 +46,7 @@ environment variables.
       [IBM Cloud documentation](https://console.bluemix.net/docs/containers/cs_regions.html#regions-and-zones)
       or via `ibmcloud cs regions`.
     - `CLUSTER_ZONE` can be any zone that is available in the specified region
-      above. You can get a list of all avaible locations from the
+      above. You can get a list of all available locations from the
       [IBM Cloud documentation](https://console.bluemix.net/docs/containers/cs_regions.html#zones)
       or by using `ibmcloud cs zones` after you set the region by using
       `ibmcloud cs region-set $CLUSTER_REGION`.


### PR DESCRIPTION
Rename IBM Cloud default cluster name from knative to Kubeflow.
Fixing minor typos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1711)
<!-- Reviewable:end -->
