### PR TITLE
Marked the v0.7 archive site as archived

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -115,7 +115,7 @@ version = "v0.7"
 
 # Flag used in the "version-banner" partial to decide whether to display a 
 # banner on every page indicating that this is an archived version of the docs.
-archived_version = false
+archived_version = true
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.


### PR DESCRIPTION
Fixes https://github.com/kubeflow/website/issues/1745

Set `archived_version = true`.
This will add a banner at the top of all the v0.7 docs letting users know they are viewing an archived version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1747)
<!-- Reviewable:end -->
