### PR TITLE
update ibmcloud ks cluster config command

### DIFF
--- a/content/docs/ibm/existing-cluster.md
+++ b/content/docs/ibm/existing-cluster.md
@@ -8,6 +8,6 @@ weight = 5
 
 Get the Kubeconfig file:
 
-	ibmcloud cs cluster-config $CLUSTER_NAME
+	ibmcloud cs cluster config $CLUSTER_NAME
 
 From here on, please see [Install Kubeflow](/docs/ibm/deploy/install-kubeflow).

--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -101,7 +101,7 @@ components, the recommended configuration for a cluster is:
 1.  Point `kubectl` to the cluster:
 
     ```
-    ibmcloud cs cluster-config $CLUSTER_NAME
+    ibmcloud cs cluster config $CLUSTER_NAME
     ```
 
     Follow the instructions on the screen to `EXPORT` the correct `KUBECONFIG`


### PR DESCRIPTION
the doc referes to
`ibmcloud ks cluster-config` which is deprecated and will soon be unsupported.

`ibmcloud ks cluster config` is recommended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1752)
<!-- Reviewable:end -->
