### PR TITLE
Add block storage instructions to IBM Cloud

### DIFF
--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -118,12 +118,12 @@ components, the recommended configuration for a cluster is:
     Istio into your cluster.
     
 ## IBM Cloud Block Storage Setup
-By default, IBM Cloud Kubernetes cluster uses [IBM Cloud File Storage](https://www.ibm.com/cloud/file-storage) as the default storageclass. File Storage is designed to run RWX (read-write multiple nodes) workloads with proper security build around it. Therefore, File Storage [does not allow `fsGroup` securityContext](https://cloud.ibm.com/docs/containers?topic=containers-security#container) which is needed for DEX and Jupyter Server.
+By default, IBM Cloud Kubernetes cluster uses [IBM Cloud File Storage](https://www.ibm.com/cloud/file-storage) based on NFS as the default storage class. File Storage is designed to run RWX (read-write multiple nodes) workloads with proper security built around it. Therefore, File Storage [does not allow `fsGroup` securityContext](https://cloud.ibm.com/docs/containers?topic=containers-security#container) which is needed for DEX and Kubeflow Jupyter Server.
 
 [IBM Cloud Block Storage](https://www.ibm.com/cloud/block-storage) provides a fast way to store data and
 satisfy many of the Kubeflow persistent volume requirements such as `fsGroup` out of the box and optimized RWO (read-write single node) which is used on all Kubeflow's persistent volume claim. 
 
-Therefore, we strongly recommend to set up IBM Cloud Block Storage as the default storageclass so that you can
+Therefore, we strongly recommend to set up [IBM Cloud Block Storage](https://cloud.ibm.com/docs/containers?topic=containers-block_storage#add_block) as the default storage class so that you can
 get the best experience from Kubeflow.
 
 1. [Follow the instructions](https://helm.sh/docs/intro/install/) to install the Helm version 3 client on your local machine.

--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -160,8 +160,8 @@ get the best experience from Kubeflow.
 
 1. Set the Block Storage as the default storageclass.
     ```shell
-    kubectl patch storageclass ibmc-file-bronze -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
     kubectl patch storageclass ibmc-block-gold -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+    kubectl patch storageclass ibmc-file-bronze -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
     
     # Check the default storageclass is block storage
     kubectl get storageclass | grep \(default\)

--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -117,10 +117,10 @@ components, the recommended configuration for a cluster is:
     Make sure all the nodes are in `Ready` state. You are now ready to install
     Istio into your cluster.
     
-## Setup IBM Cloud Block Storage
-[IBM Cloud Block Storage](https://www.ibm.com/cloud/block-storage) provides fast way to store data and
-satisfy many of the Kubeflow persistent volume requirement such as `fsGroup` out of the box. Therefore,
-we strongly recommend to setup IBM Cloud Block Storage as the default storageclass so that you can
+## IBM Cloud Block Storage Setup
+[IBM Cloud Block Storage](https://www.ibm.com/cloud/block-storage) provides a fast way to store data and
+satisfy many of the Kubeflow persistent volume requirements such as `fsGroup` out of the box. Therefore,
+we strongly recommend to set up IBM Cloud Block Storage as the default storageclass so that you can
 get the best experience from Kubeflow.
 
 1. [Follow the instructions](https://helm.sh/docs/intro/install/) to install the Helm version 3 client on your local machine.

--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -101,7 +101,7 @@ components, the recommended configuration for a cluster is:
 1.  Point `kubectl` to the cluster:
 
     ```
-    ibmcloud cs cluster-config $CLUSTER_NAME
+    ibmcloud cs cluster config $CLUSTER_NAME
     ```
 
     Follow the instructions on the screen to `EXPORT` the correct `KUBECONFIG`

--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -118,9 +118,12 @@ components, the recommended configuration for a cluster is:
     Istio into your cluster.
     
 ## IBM Cloud Block Storage Setup
+By default, IBM Cloud Kubernetes cluster uses [IBM Cloud File Storage](https://www.ibm.com/cloud/file-storage) as the default storageclass. File Storage is designed to run RWX (read-write multiple nodes) workloads with proper security build around it. Therefore, File Storage [does not allow `fsGroup` securityContext](https://cloud.ibm.com/docs/containers?topic=containers-security#container) which is needed for DEX and Jupyter Server.
+
 [IBM Cloud Block Storage](https://www.ibm.com/cloud/block-storage) provides a fast way to store data and
-satisfy many of the Kubeflow persistent volume requirements such as `fsGroup` out of the box. Therefore,
-we strongly recommend to set up IBM Cloud Block Storage as the default storageclass so that you can
+satisfy many of the Kubeflow persistent volume requirements such as `fsGroup` out of the box and optimized RWO (read-write single node) which is used on all Kubeflow's persistent volume claim. 
+
+Therefore, we strongly recommend to set up IBM Cloud Block Storage as the default storageclass so that you can
 get the best experience from Kubeflow.
 
 1. [Follow the instructions](https://helm.sh/docs/intro/install/) to install the Helm version 3 client on your local machine.


### PR DESCRIPTION
IBM Cloud Block storage are recommended to use on RWO storage such as database. Therefore, we want to add the instructions for setting up IBM Cloud Block storage as the default storage class before installing Kubeflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1753)
<!-- Reviewable:end -->
