### PR TITLE
Clarified that GCP basic auth is not supported and removed most references

### DIFF
--- a/content/docs/gke/cloud-filestore.md
+++ b/content/docs/gke/cloud-filestore.md
@@ -34,12 +34,6 @@ This guide assumes the following settings:
   export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
-    Or:
-
-  ```
-  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
-  ```
-
 * The `${KF_NAME}` environment variable contains the name of your Kubeflow 
   deployment. You can find the name in your `${CONFIG_FILE}` 
   configuration file, as the value for the `metadata.name` key.

--- a/content/docs/gke/customizing-gke.md
+++ b/content/docs/gke/customizing-gke.md
@@ -46,12 +46,6 @@ This guide assumes the following settings:
   export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
-    Or:
-
-  ```
-  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
-  ```
-
 * The `${KF_NAME}` environment variable contains the name of your Kubeflow 
   deployment. You can find the name in your
   `${CONFIG_FILE}` configuration file, as the value for the `metadata.name` key.

--- a/content/docs/gke/deploy/delete-cli.md
+++ b/content/docs/gke/deploy/delete-cli.md
@@ -26,12 +26,6 @@ This guide assumes the following settings:
   export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
-    Or:
-
-  ```
-  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
-  ```
-
 For further background about the above settings, see the guide to
 [deploying Kubeflow with the CLI](/docs/gke/deploy/deploy-cli).
 

--- a/content/docs/gke/deploy/delete-cli.md
+++ b/content/docs/gke/deploy/delete-cli.md
@@ -26,10 +26,10 @@ This guide assumes the following settings:
   export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
-    Or:	
+    Or:
 
-  ```	
-  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}	
+  ```
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}
   ```
 
 For further background about the above settings, see the guide to

--- a/content/docs/gke/deploy/delete-cli.md
+++ b/content/docs/gke/deploy/delete-cli.md
@@ -26,6 +26,12 @@ This guide assumes the following settings:
   export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-iap %}}
   ```
 
+    Or:	
+
+  ```	
+  export CONFIG_FILE=${KF_DIR}/{{% config-file-gcp-basic-auth %}}	
+  ```
+
 For further background about the above settings, see the guide to
 [deploying Kubeflow with the CLI](/docs/gke/deploy/deploy-cli).
 

--- a/content/docs/gke/deploy/deploy-cli.md
+++ b/content/docs/gke/deploy/deploy-cli.md
@@ -122,11 +122,12 @@ Notes:
   type you want. See the guide to 
   [customizing your Kubeflow deployment](/docs/gke/customizing-gke/#gpu-config).
 * **${CONFIG_URI}** - The GitHub address of the configuration YAML file that
-  you want to use to deploy Kubeflow. For GCP deployments, the following
-  configurations are available:
+  you want to use to deploy Kubeflow. For GCP deployments, the recommended
+  configuration is:
 
-  * `{{% config-uri-gcp-iap %}}` 
-  * `{{% config-uri-gcp-basic-auth %}}`
+  ```
+  {{% config-uri-gcp-iap %}}
+  ```
 
     When you run `kfctl apply` or `kfctl build` (see the next step), kfctl creates
     a local version of the configuration YAML file which you can further
@@ -350,8 +351,7 @@ directories:
 
   * This file is a copy of the GitHub-based configuration YAML file that
     you used when deploying Kubeflow: 
-      * either `{{% config-uri-gcp-iap %}}`
-      * or `{{% config-uri-gcp-basic-auth %}}`.
+    [kfctl_gcp_iap.v1.0.0.yaml]({{% config-uri-gcp-iap %}}).
   * When you run `kfctl apply` or `kfctl build`, kfctl creates
     a local version of the configuration file, **${CONFIG_FILE}**,
     which you can further customize if necessary.
@@ -392,29 +392,12 @@ The service accounts are:
   account has the minimal permissions needed to send metrics and logs to 
   [Stackdriver](https://cloud.google.com/stackdriver/).
 
-## Basic Auth (Deprecated)
+## Basic authentication (deprecated)
 
-{{% alert title="No Longer Supported" color="warning" %}}
-Basic auth is not supported in Kubeflow V1 and will be removed entirely in the
+{{% alert title="No longer supported" color="warning" %}}
+Basic authentication is not supported in Kubeflow v1.0.0 and will be removed entirely in the
 next version. We highly recommend switching to deploying Kubeflow with IAP.
 {{% /alert %}}
-
-If you still want to use basic auth follow these instructions.
-
-1. Pick a KFDef for basic auth
-
-    ```    
-    export CONFIG_URI="{{% config-uri-gcp-basic-auth %}}"
-    ```
-
-1. Set environment variables containing username and password
-
-    ```
-    export KUBEFLOW_USERNAME=<your username>
-    export KUBEFLOW_PASSWORD=<your password>
-    ```
-
-1. Follow the instructions above to run `kfctl apply` to deploy Kubeflow.
 
 ## Next steps
 

--- a/content/docs/gke/deploy/deploy-ui.md
+++ b/content/docs/gke/deploy/deploy-ui.md
@@ -23,8 +23,7 @@ Check the following requirements before installing Kubeflow:
   IAP)](https://cloud.google.com/iap/docs/) for access control, follow the guide
   to [setting up OAuth credentials](/docs/gke/deploy/oauth-setup/). 
   Cloud IAP is recommended for production deployments or deployments with 
-  access to sensitive data. Alternatively, you can use basic authentication 
-  with a username and password.
+  access to sensitive data.
 
 ## Deploy Kubeflow
 
@@ -58,7 +57,6 @@ Follow these steps to open the deployment UI and deploy Kubeflow on GCP:
         with access to sensitive data. See more details [below](#cloud-iap).
       * **Login with Username Password:** **Warning: This option is deprecated in Kubeflow 1.0 and
         will be removed in the next version. We recommend switching to IAP.**
-        See more details [below](#basic-auth).
 
     * **GKE zone:** Enter the 
       [GCP zone](https://cloud.google.com/compute/docs/regions-zones/) in which 
@@ -109,23 +107,10 @@ accessing your Kubeflow URI.
 <a id="basic-auth"></a>
 ## Authenticating with username and password
 
-{{% alert title="No Longer Supported" color="warning" %}}
-Basic auth is not supported in Kubeflow V1 and will be removed entirely in the
+{{% alert title="No longer supported" color="warning" %}}
+Basic authentication is not supported in Kubeflow v1.0.0 and will be removed entirely in the
 next version. We highly recommend switching to deploying Kubeflow with IAP.
 {{% /alert %}}
-
-This section contains details about using basic authentication (username and
-password) to control access to Kubeflow. 
-
-1. Choose the **Login with Username Password** option on the Kubeflow deployment
-   UI.
-
-1. Enter a **username** and a **password** for use when accessing the UI for
-  your Kubeflow deployment.
-
-1. Complete the rest of the form as described above.
-
-1. Click **Kubeflow Service Endpoint** to access your Kubeflow URI.
 
 ## Next steps
 

--- a/content/docs/gke/deploy/reasons.md
+++ b/content/docs/gke/deploy/reasons.md
@@ -19,12 +19,6 @@ Running Kubeflow on GCP brings you the following features:
   * [Cloud Identity-Aware Proxy (Cloud IAP)](https://cloud.google.com/iap/) 
     makes it easy to securely connect to Jupyter and other
     web apps running as part of Kubeflow.
-  * Kubeflow's basic authentication service supports simple username/password
-    access to your Kubeflow resources. Basic auth is an alternative to Cloud
-    IAP:
-    * We recommend Cloud IAP for production and enterprise workloads.
-    * Consider basic auth only when you want to test Kubeflow and use it 
-      without sensitive data.
   * [Stackdriver](https://cloud.google.com/logging/docs/) provides 
     persistent logs to aid in debugging and troubleshooting.
   * You can use GPUs and [Cloud TPU](https://cloud.google.com/tpu/) to 

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -299,7 +299,7 @@ export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT} --format='value(proj
 
     ```
     cd ${KF_DIR}/kustomize
-    gvim basic-auth-ingress.yaml  # Or iap-ingress.yaml if you are using IAP
+    gvim iap-ingress.yaml
     ```
 
       * Find and set the `privateGKECluster` parameter to true:
@@ -311,7 +311,7 @@ export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT} --format='value(proj
       * Then apply your changes:
 
         ```
-        kubectl apply -f basic-auth-ingress.yaml
+        kubectl apply -f iap-ingress.yaml
         ```
 
 1. Obtain an HTTPS certificate for your ${FQDN} and create a Kubernetes secret with it. 
@@ -327,7 +327,7 @@ export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT} --format='value(proj
 
             ```
             cd ${KF_DIR}/kustomize
-            grep hostname: basic-auth-ingress.yaml
+            grep hostname: iap-ingress.yaml
             ```
 
         * Then create your Kubernetes secret

--- a/content/docs/upgrading/upgrade.md
+++ b/content/docs/upgrading/upgrade.md
@@ -43,7 +43,8 @@ deployment. We'll call this `${KF_DIR}`.
       1. Follow the instructions for [environment preparations](/docs/gke/deploy/deploy-cli/#prepare-your-environment).
           * Make sure that the `${PROJECT}`, `${ZONE}`, and `${KF_NAME}`
             variables match exactly with your deployment.
-          * For `${CONFIG_URI}`, use the `{{% config-file-gcp-iap %}}` file.
+          * For `${CONFIG_URI}`, use the appropriate [YAML configuration 
+            file](/docs/started/getting-started/#configuration-quick-reference).
       1. Create your local deployment files:
           ```
           mkdir -p ${KF_DIR}

--- a/content/docs/upgrading/upgrade.md
+++ b/content/docs/upgrading/upgrade.md
@@ -43,8 +43,7 @@ deployment. We'll call this `${KF_DIR}`.
       1. Follow the instructions for [environment preparations](/docs/gke/deploy/deploy-cli/#prepare-your-environment).
           * Make sure that the `${PROJECT}`, `${ZONE}`, and `${KF_NAME}`
             variables match exactly with your deployment.
-          * For `${CONFIG_URI}`, use the `kfctl_gcp_iap` file if your deployment
-            uses Cloud IAP for authentication. Use the `kfctl_gcp_basic_auth` file if your deployment uses username and password.
+          * For `${CONFIG_URI}`, use the `{{% config-file-gcp-iap %}}` file.
       1. Create your local deployment files:
           ```
           mkdir -p ${KF_DIR}


### PR DESCRIPTION
Fixes https://github.com/kubeflow/website/issues/1764

The basic auth (username/password) option on GCP is already marked as not supported in the docs, but we currently give people instructions on how to use it if they want to. This is leading to problems for some, where the option does not work.

Instead, we should just say it's not supported, without giving usage instructions. In addition, we should remove most references to the basic auth config, leaving only the one in the troubleshooting guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1765)
<!-- Reviewable:end -->
