### PR TITLE
Fixed broken links in pipeline sdk-overview

### DIFF
--- a/content/docs/pipelines/sdk/sdk-overview.md
+++ b/content/docs/pipelines/sdk/sdk-overview.md
@@ -384,7 +384,7 @@ You can also choose to share your pipeline as follows:
 
 {{% alert title="More about the above workflow" color="info" %}}
 For an example of the above workflow, see the
-Jupyter notebook titled [KubeFlow Pipelines basic component build](https://github.com/kubeflow/pipelines/blob/master/samples/core/component_build/component_build.ipynb) on GitHub.
+Jupyter notebook titled [KubeFlow Pipelines basic component build](https://github.com/kubeflow/pipelines/blob/master/samples/core/container_build/container_build.ipynb) on GitHub.
 {{% /alert %}}
 
 <a id="lightweight-component"></a>
@@ -560,7 +560,7 @@ Below is a more detailed explanation of the above diagram:
     ```
 {{% alert title="More about the above workflow" color="info" %}}
 For an example, see the
-[`xgboost-training-cm.py`](https://github.com/kubeflow/pipelines/blob/master/samples/core/xgboost-spark/xgboost-training-cm.py)
+[`xgboost-training-cm.py`](https://github.com/kubeflow/pipelines/blob/master/samples/core/xgboost_training_cm/xgboost_training_cm.py)
 pipeline sample on GitHub. The pipeline creates an XGBoost model using 
 structured data in CSV format.
 {{% /alert %}}

--- a/content/docs/pipelines/sdk/sdk-overview.md
+++ b/content/docs/pipelines/sdk/sdk-overview.md
@@ -384,7 +384,7 @@ You can also choose to share your pipeline as follows:
 
 {{% alert title="More about the above workflow" color="info" %}}
 For an example of the above workflow, see the
-Jupyter notebook titled [KubeFlow Pipelines basic component build](https://github.com/kubeflow/pipelines/blob/master/samples/core/container_build/container_build.ipynb) on GitHub.
+Jupyter notebook titled [KubeFlow Pipelines container building](https://github.com/kubeflow/pipelines/blob/master/samples/core/container_build/container_build.ipynb) on GitHub.
 {{% /alert %}}
 
 <a id="lightweight-component"></a>


### PR DESCRIPTION
Part of fixes for[ issue 1683](https://github.com/kubeflow/website/issues/1683).

In the following page: https://www.kubeflow.org/docs/pipelines/sdk/sdk-overview/
![image](https://user-images.githubusercontent.com/52723717/75811755-dcfc4880-5d41-11ea-9f08-ddf4fa8169bf.png)

KubeFlow Pipelines basic component build -> https://github.com/kubeflow/pipelines/blob/master/samples/core/component_build/component_build.ipynb
-> 404

Under **4th** "More about the above workflow"
![image](https://user-images.githubusercontent.com/52723717/75811858-074e0600-5d42-11ea-99c4-56fae3a4c953.png)

xgboost-training-cm.py->https://github.com/kubeflow/pipelines/blob/master/samples/core/xgboost-spark/xgboost-training-cm.py -> 404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1768)
<!-- Reviewable:end -->
