### PR TITLE
document API Server flags for istio_dex config

### DIFF
--- a/content/docs/started/k8s/kfctl-istio-dex.md
+++ b/content/docs/started/k8s/kfctl-istio-dex.md
@@ -37,6 +37,11 @@ Configuring your installation with {{% config-file-istio-dex %}} has a few optio
   1.3.1 with SDS enabled, which requires you to use Kubernetes 1.13 or later. You may need
   to add extra configurations to your Kubernetes as mentioned in
   [Istio's blog](https://istio.io/blog/2019/trustworthy-jwt-sds/).
+  The Istio community runs their test-infrastructure with the following API Server flags:
+  ```
+  "service-account-issuer": "kubernetes.default.svc"
+  "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+  ```
 
 * **Default password in static file configuration for Dex** - The configuration file 
   {{% config-file-istio-dex %}} contains a default 

--- a/content/docs/started/k8s/kfctl-istio-dex.md
+++ b/content/docs/started/k8s/kfctl-istio-dex.md
@@ -34,15 +34,16 @@ Configuring your installation with {{% config-file-istio-dex %}} has a few optio
   {{% config-file-istio-dex %}}.
 
 * **Istio configuration for trustworthy JWTs** - This configuration uses Istio version
-  1.3.1 with SDS enabled, which requires you to use Kubernetes 1.13 or later. You may need
-  to add extra configurations to your Kubernetes as mentioned in
-  [Istio's blog](https://istio.io/blog/2019/trustworthy-jwt-sds/).
-  The Istio community runs their test-infrastructure with the following API Server flags:
+  1.3.1 with SDS enabled, which requires Kubernetes 1.13 or later.
+  Follow [Istio's blog](https://istio.io/blog/2019/trustworthy-jwt-sds/) to add API server configurations to your Kubernetes cluster.
+  Ensure that the `TokenRequest` feature flag is set to `true` in the cluster.
+  For `kubeadm` created clusters, set the API server flags in the pod manifest at `/etc/kubernetes/manifests/kube-api-server.yaml`.
+  For example, the Istio community runs their test-infrastructure with the following API server flags:
   ```
   "service-account-issuer": "kubernetes.default.svc"
   "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
   ```
-
+  
 * **Default password in static file configuration for Dex** - The configuration file 
   {{% config-file-istio-dex %}} contains a default 
   [staticPasswords](https://github.com/dexidp/dex/blob/0f8c4db9f61476a8f80e60f5950992149a1cc0cb/examples/config-dev.yaml#L91-L95)


### PR DESCRIPTION
Fixes: #1778

Why is this needed?
It saves people a click and gives a sample config to follow during deployment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1779)
<!-- Reviewable:end -->
