### PR TITLE
added get-credentials command to configures kubectl on Azure

### DIFF
--- a/content/docs/azure/deploy/install-kubeflow.md
+++ b/content/docs/azure/deploy/install-kubeflow.md
@@ -111,7 +111,7 @@ Run the following commands to set up and deploy Kubeflow.
     # Set the configuration file to use, such as the file specified below:
     export CONFIG_URI="{{% config-uri-k8s-istio %}}"
 
-    # Set Azure CLI and kubctl to point to the new cluster
+    # Set Azure CLI and kubctl to point and set cerdentials to the new cluster
     az aks get-credentials -n  ${NAME} -g ${RESOURCE_GROUP_NAME} 
     
     # Generate and deploy Kubeflow:

--- a/content/docs/azure/deploy/install-kubeflow.md
+++ b/content/docs/azure/deploy/install-kubeflow.md
@@ -111,6 +111,9 @@ Run the following commands to set up and deploy Kubeflow.
     # Set the configuration file to use, such as the file specified below:
     export CONFIG_URI="{{% config-uri-k8s-istio %}}"
 
+    # Set Azure CLI and kubctl to poimnt to the new cluster
+    az aks get-credentials -n  ${NAME} -g ${RESOURCE_GROUP_NAME} 
+    
     # Generate and deploy Kubeflow:
     mkdir -p ${KF_DIR}
     cd ${KF_DIR}

--- a/content/docs/azure/deploy/install-kubeflow.md
+++ b/content/docs/azure/deploy/install-kubeflow.md
@@ -111,7 +111,7 @@ Run the following commands to set up and deploy Kubeflow.
     # Set the configuration file to use, such as the file specified below:
     export CONFIG_URI="{{% config-uri-k8s-istio %}}"
 
-    # Set Azure CLI and kubctl to poimnt to the new cluster
+    # Set Azure CLI and kubctl to point to the new cluster
     az aks get-credentials -n  ${NAME} -g ${RESOURCE_GROUP_NAME} 
     
     # Generate and deploy Kubeflow:


### PR DESCRIPTION
To configure kubectl to connect to Kubernetes cluster, az aks get-credentials command is used. This command downloads credentials and configures the Kubernetes CLI to use them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1785)
<!-- Reviewable:end -->
