### PR TITLE
Use dedicated service principals on Azure

### DIFF
--- a/content/docs/fairing/azure/_index.md
+++ b/content/docs/fairing/azure/_index.md
@@ -46,10 +46,10 @@ The above command has output like this:
 
 ```
 {
-  "appId": "<id>",
+  "appId": "<client-id>",
   "displayName": "<name>",
   "name": "http://<name>",
-  "password": "<password>",
+  "password": "<client-secret>",
   "tenant": "<tenant-id>"
 }
 ```
@@ -96,8 +96,7 @@ Run the following commands to set up your credentials as a Kubernetes secret.
 
     * **AZ_CLIENT_ID:** The service principal client ID. You can get the
       `client_id` property from ~/.azure/aksServicePrincipal.json.
-    * **AZ_CLIENT_SECRET:** The service principal secret. You can get the
-      `client_secret` property from ~/.azure/aksServicePrincipal.json.
+    * **AZ_CLIENT_SECRET:** The service principal secret.
     * **AZ_TENANT_ID:** The Azure Tenant ID of your account. You can get the
       Tenant ID from the `tenantId` field in the output of `az account show`.
     * **AZ_SUBSCRIPTION:** The Azure Subscription ID of your account. You can

--- a/content/docs/fairing/azure/_index.md
+++ b/content/docs/fairing/azure/_index.md
@@ -34,24 +34,43 @@ information, see the documentation for [ACR][az-container-reg] and
 [Storage][az-storage].
 
 After you have created your ACR and Storage resources, you must configure a
-service principal with access to these resources. If you want to use the same
-service principal as your AKS cluster, you can get the service principal ID
-with the following command:
+service principal with access to these resources.
+
+You can create a new service principal with the following command:
 
 ```
-az aks show -g <resource-group-name> -n <name>
+az ad sp create-for-rbac --name <name>
 ```
 
 The above command has output like this:
 
 ```
-  "servicePrincipalProfile": {
-    "clientId": "<id>"
-  },
+{
+  "appId": "<id>",
+  "displayName": "<name>",
+  "name": "http://<name>",
+  "password": "<password>",
+  "tenant": "<tenant-id>"
+}
 ```
 
 The role you grant must have at least read and write permissions to ACR and
-Storage.
+Storage. We recommend using the `AcrPush` role and the `Storage Account Contributor` role scoped to a resource group.
+
+You can perform the role assignment for ACR like this:
+
+```
+az role assignment create --assignee <id> \
+  --scope /subscriptions/<azure-subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.ContainerRegistry/registries/<acr-name> \
+  --role "AcrPush"
+```
+
+You can grant full storage rights at a resource group level like this:
+```
+az role assignment create --assignee <id> \
+  --scope /subscriptions/<azure-subscription-id>/resourceGroups/<resource-group-name> \
+  --role "Storage Account Contributor"
+```
 
 To learn more about how to grant the service principal access, follow the
 [Azure role-based authentication documentation][az-roles].


### PR DESCRIPTION
The Azure instructions were reusing the AKS cluster's internal service principal. These instructions no longer work reliably and do not follow best practices. I have updated the instructions to create a dedicated Azure service principal for use with Kubeflow Fairing only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1792)
<!-- Reviewable:end -->
