### PR TITLE
Updating broken link in IBM documentation

### DIFF
--- a/content/docs/ibm/existing-cluster.md
+++ b/content/docs/ibm/existing-cluster.md
@@ -10,4 +10,4 @@ Get the Kubeconfig file:
 
 	ibmcloud cs cluster config $CLUSTER_NAME
 
-From here on, please see [Install Kubeflow](/docs/ibm/deploy/install-kubeflow).
+From here on, please see [Install Kubeflow](/docs/ibm/install-kubeflow).


### PR DESCRIPTION
initial link was broken, this one redirects to the correct page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1795)
<!-- Reviewable:end -->
