### PR TITLE
Fix YAML dict syntax (use ":" instead of "=")

### DIFF
--- a/content/docs/pipelines/sdk/component-development.md
+++ b/content/docs/pipelines/sdk/component-development.md
@@ -284,10 +284,10 @@ Final version of `component.yaml`:
 name: Do dummy work
 description: Performs some dummy work.
 inputs:
-- {name: Input 1, type: GCSPath, description='Data for Input 1'}
-- {name: Parameter 1, type: Integer, default='100', description='Parameter 1 description'} # The default values must be specified as YAML strings.
+- {name: Input 1, type: GCSPath, description: 'Data for Input 1'}
+- {name: Parameter 1, type: Integer, default: '100', description: 'Parameter 1 description'} # The default values must be specified as YAML strings.
 outputs:
-- {name: Output 1, description='Output 1 data'}
+- {name: Output 1, description: 'Output 1 data'}
 implementation:
   container:
     image: gcr.io/my-org/my-image@sha256:a172..752f


### PR DESCRIPTION
For example, change `{name: Input 1, type: GCSPath, description='Data for Input 1'}` to `{name: Input 1, type: GCSPath, description: 'Data for Input 1'}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1799)
<!-- Reviewable:end -->
