### PR TITLE
Update invitation link to Kubeflow Slack channel

### DIFF
--- a/content/docs/about/community.md
+++ b/content/docs/about/community.md
@@ -49,7 +49,7 @@ mailing list.
 The Kubeflow Slack workspace is 
 [kubeflow.slack.com](https://kubeflow.slack.com/). To join, click this
 [**invitation to our Slack 
-workspace**](https://join.slack.com/t/kubeflow/shared_invite/enQtNDg5MTM4NTQyNjczLTdkNTVhMjg1ZTExOWI0N2QyYTQ2MTIzNTJjMWRiOTFjOGRlZWEzODc1NzMwNTMwM2EzNjY1MTFhODczNjk4MTk).
+workspace**](https://join.slack.com/t/kubeflow/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ).
 
 The Kubeflow Slack workspace offers several channels. Here are a few examples:
 


### PR DESCRIPTION
The old invitation link had expired. Thanks to @jlewi who provided this new link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1802)
<!-- Reviewable:end -->
