### PR TITLE
Update the Slack invitation link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -196,7 +196,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubeflow/website/is
         desc = "Development takes place here!"
 [[params.links.user]]
 	name = "Slack"
-	url = "https://kubeflow.slack.com/join/shared_invite/enQtNDg5MTM4NTQyNjczLTdkNTVhMjg1ZTExOWI0N2QyYTQ2MTIzNTJjMWRiOTFjOGRlZWEzODc1NzMwNTMwM2EzNjY1MTFhODczNjk4MTk"
+	url = "https://kubeflow.slack.com/join/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ"
 	icon = "fab fa-slack"
         desc = "Chat with other project contributors"
 [[params.links.user]]

--- a/content/_index.html
+++ b/content/_index.html
@@ -155,7 +155,7 @@ title = "Kubeflow"
           <p class="card-text text-white">
             We are an open and welcoming community of software developers, data
             scientists, and organizations! Join our <a target="_blank" rel="noopener"
-		    href="https://kubeflow.slack.com/join/shared_invite/enQtNDg5MTM4NTQyNjczLTdkNTVhMjg1ZTExOWI0N2QyYTQ2MTIzNTJjMWRiOTFjOGRlZWEzODc1NzMwNTMwM2EzNjY1MTFhODczNjk4MTk">Slack workspace</a> 
+		    href="https://kubeflow.slack.com/join/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ">Slack workspace</a> 
             for help with any issues you may face, and read <a target="_blank" rel="noopener" href="/docs/about/community/">more about the community</a>.
           </p>
         </div>

--- a/content/docs/other-guides/virtual-dev/getting-started-minikf.md
+++ b/content/docs/other-guides/virtual-dev/getting-started-minikf.md
@@ -27,7 +27,7 @@ Join the discussion on the
 ask questions, request features, and get support for MiniKF.
 
 To join the Kubeflow Slack workspace, please [request an
-invite](https://kubeflow.slack.com/join/shared_invite/enQtNDg5MTM4NTQyNjczLTdkNTVhMjg1ZTExOWI0N2QyYTQ2MTIzNTJjMWRiOTFjOGRlZWEzODc1NzMwNTMwM2EzNjY1MTFhODczNjk4MTk).
+invite](https://kubeflow.slack.com/join/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ).
 
 ### System requirements
 For a smooth experience we recommend that your system meets the

--- a/content/docs/started/k8s/kfctl-istio-dex.md
+++ b/content/docs/started/k8s/kfctl-istio-dex.md
@@ -774,7 +774,7 @@ If the Kubeflow dashboard is not available at `https://<kubeflow address>` ensur
     < server: istio-envoy
     ```
     
-Please join the [Kubeflow Slack](https://kubeflow.slack.com/join/shared_invite/enQtNDg5MTM4NTQyNjczLWUyZGI1ZmExZWExYWY4YzlkOWI4NjljNjJhZjhjMjEwNGFjNmVkNjg2NTg4M2I0ZTM5NDExZWI5YTIyMzVmNzM) to report any issues, request help, and give us feedback on this config.
+Please join the [Kubeflow Slack](https://kubeflow.slack.com/join/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ) to report any issues, request help, and give us feedback on this config.
 
 Some additional debugging information:
 


### PR DESCRIPTION
We had updated the Slack invitation link, but only on the community
page. This PR fixes 4 more pages that use this link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1807)
<!-- Reviewable:end -->
