### PR TITLE
fixed a typo in getting `Kubeflow Pipelines API Reference`

### DIFF
--- a/content/docs/pipelines/tutorials/api-pipelines.md
+++ b/content/docs/pipelines/tutorials/api-pipelines.md
@@ -136,4 +136,4 @@ The response should be similar to the following one:
 }
 ```
 
-Read [Kubeflow Pipelines API Reference](docs/pipelines/reference/api/kubeflow-pipeline-api-spec/) to learn more about how to use the API.
+Read [Kubeflow Pipelines API Reference](/docs/pipelines/reference/api/kubeflow-pipeline-api-spec/) to learn more about how to use the API.


### PR DESCRIPTION
fixed a typo in getting `Kubeflow Pipelines API Reference`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1810)
<!-- Reviewable:end -->
