### PR TITLE
Fix tf.Event link in hyperparameter-tunning

### DIFF
--- a/content/docs/components/hyperparameter-tuning/experiment.md
+++ b/content/docs/components/hyperparameter-tuning/experiment.md
@@ -348,7 +348,7 @@ To define the metrics collector for your experiment:
       you specify in the `source` field.
     * `TensorFlowEvent`: Katib collects the metrics from a directory path
       containing a 
-      [tf.Event](https://www.tensorflow.org/api_docs/python/tf/Event). You
+      [tf.Event](https://www.tensorflow.org/api_docs/python/tf/compat/v1/Event). You
       should specify the path in the `source` field.
     * `Custom`: Specify this value if you need to use custom way to collect
       metrics. You must define your custom metrics collector container


### PR DESCRIPTION
Ref: [issue 1683](https://github.com/kubeflow/website/issues/1683)

In https://www.kubeflow.org/docs/components/hyperparameter-tuning/experiment/#metrics-collector
![image](https://user-images.githubusercontent.com/52723717/76806051-a260ca00-679d-11ea-97fa-36d474552443.png)

[tf.Event](https://www.tensorflow.org/api_docs/python/tf/Event) -> 404

/assign @sarahmaddox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1816)
<!-- Reviewable:end -->
