### PR TITLE
Fixed broken links in serving component

### DIFF
--- a/content/docs/components/serving/overview.md
+++ b/content/docs/components/serving/overview.md
@@ -124,7 +124,7 @@ KFServing and Seldon Core. A check mark (**&check;**) indicates that the system
         <td>Custom</td>
         <td>Container</td>
         <td><b>&check;</b> <a href="https://github.com/kubeflow/kfserving/tree/master/docs/samples/custom">sample</a></td>
-        <td><b>&check;</b> <a href="https://docs.seldon.io/projects/seldon-core/en/latest/wrappers/README.html">docs</a></td>
+        <td><b>&check;</b> <a href="https://docs.seldon.io/projects/seldon-core/en/latest/wrappers/language_wrappers.html">docs</a></td>
       </tr>
 
       <tr>

--- a/content/docs/components/serving/seldon.md
+++ b/content/docs/components/serving/seldon.md
@@ -10,7 +10,7 @@ Seldon Core comes installed with Kubeflow. The [Seldon Core documentation site](
 
 If you have a saved model in a PersistentVolume (PV), Google Cloud Storage bucket or Amazon S3 Storage you can use one of the [prepackaged model servers provided by Seldon Core](https://docs.seldon.io/projects/seldon-core/en/latest/servers/overview.html).
 
-Seldon Core also provides [language specific model wrappers](https://docs.seldon.io/projects/seldon-core/en/latest/wrappers/README.html) to wrap your inference code for it to run in Seldon Core.
+Seldon Core also provides [language specific model wrappers](https://docs.seldon.io/projects/seldon-core/en/latest/wrappers/language_wrappers.html) to wrap your inference code for it to run in Seldon Core.
 
 ## Kubeflow specifics
 


### PR DESCRIPTION
Ref : [issue 1683](https://github.com/kubeflow/website/issues/1683)

1. In https://www.kubeflow.org/docs/components/serving/overview/#multi-framework-serving-with-kfserving-or-seldon-core
![image](https://user-images.githubusercontent.com/52723717/76924330-40828c00-6893-11ea-808c-56820545e9bb.png)
Click [doc](https://docs.seldon.io/projects/seldon-core/en/latest/wrappers/README.html)  --> page does not exist


2. In https://www.kubeflow.org/docs/components/serving/seldon/
![image](https://user-images.githubusercontent.com/52723717/76924461-96efca80-6893-11ea-8f35-b2230ae3a149.png)
[language specific model wrappers](https://docs.seldon.io/projects/seldon-core/en/latest/wrappers/README.html) --> page does not exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1818)
<!-- Reviewable:end -->
