### PR TITLE
Remove onnx link for seldon in overview page

### DIFF
--- a/content/docs/components/serving/overview.md
+++ b/content/docs/components/serving/overview.md
@@ -61,7 +61,7 @@ KFServing and Seldon Core. A check mark (**&check;**) indicates that the system
         <td></td>
         <td>ONNX</td>
         <td><b>&check;</b> <a href="https://github.com/kubeflow/kfserving/tree/master/docs/samples/onnx">sample</a></td>
-        <td><b>&check;</b> <a href="https://docs.seldon.io/projects/seldon-core/en/latest/examples/onnx_resnet.html">docs</a></td>
+        <td></td>
       </tr>
 
       <tr>


### PR DESCRIPTION
The example has been removed as we need to update the available tech here. Will add a new link when available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1822)
<!-- Reviewable:end -->
