### PR TITLE
Correct image name in docker inspect

### DIFF
--- a/content/docs/pipelines/sdk/component-development.md
+++ b/content/docs/pipelines/sdk/component-development.md
@@ -161,7 +161,7 @@ docker build -t "${full_image_name}" .
 docker push "$full_image_name"
 
 # Output the strict image name (which contains the sha256 image digest)
-docker inspect --format="{{index .RepoDigests 0}}" "${IMAGE_NAME}"
+docker inspect --format="{{index .RepoDigests 0}}" "${full_image_name}"
 ```
 
 Make your script executable:


### PR DESCRIPTION
Fixes #1827

https://www.kubeflow.org/docs/pipelines/sdk/component-development/

In build_image.sh
current last line:
docker inspect --format="{{index .RepoDigests 0}}" "${IMAGE_NAME}"
should be
docker inspect --format="{{index .RepoDigests 0}}" "${full_image_name}"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1829)
<!-- Reviewable:end -->
