### PR TITLE
Simple typo fix for SDK example

### DIFF
--- a/content/docs/pipelines/sdk/component-development.md
+++ b/content/docs/pipelines/sdk/component-development.md
@@ -338,7 +338,7 @@ def my_pipeline():
     # ! The output names are converted to pythonic ("snake_case") names.
 
 # This pipeline can be compiled, uploaded and submitted for execution.
-kfp.Client().create_run_from_pipeline_func(my_pipeline, arguuments={})
+kfp.Client().create_run_from_pipeline_func(my_pipeline, arguments={})
 ```
 
 ## Organizing the component files


### PR DESCRIPTION
`kfp.Client().create_run_from_pipeline_func(my_pipeline, arguuments={})` changed to `kfp.Client().create_run_from_pipeline_func(my_pipeline, arguments={})`.

[kfp.Client.create_run_from_pipeline_func docs for reference](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.client.html#kfp.Client.create_run_from_pipeline_func)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/website/1830)
<!-- Reviewable:end -->
