### PR TITLE
added microk8s links too next steps

### DIFF
--- a/content/docs/other-guides/virtual-dev/getting-started-multipass.md
+++ b/content/docs/other-guides/virtual-dev/getting-started-multipass.md
@@ -56,6 +56,8 @@ Point browser to either:
 
 ## Next steps
 
+* Refer to the [microk8s common issues](https://microk8s.io/docs/troubleshooting)
+* Refer to the [multipass docs](https://multipass.run/docs)
 * Refer to the [user guide](/docs/)
 * Refer to the [components](/docs/components/)
 * Refer to the guide to [Jupyter notebooks in Kubeflow](/docs/notebooks/)


### PR DESCRIPTION
Added documentation links to the next steps of the user guide. I added the multipass docs as well as the microk8s as I thought they might be helpful for people running in this configuration. I can remove if they are not wanted!

Issue: https://github.com/kubeflow/website/issues/1694