### PR TITLE
Add documentation for the Katib config and Katib components env variables

### DIFF
--- a/content/docs/components/hyperparameter-tuning/env-variables.md
+++ b/content/docs/components/hyperparameter-tuning/env-variables.md
@@ -131,13 +131,13 @@ This is the table of environment variables for the [Katib DB Manager](https://gi
       <tr>
         <td><code>DB_NAME</code></td>
         <td>Katib DB Name</td>
-        <td>No default value</td>
+        <td>mysql</td>
         <td>Yes</td>
       </tr>
       <tr>
         <td><code>DB_PASSWORD</code></td>
         <td>Katib DB Password</td>
-        <td>No default value</td>
+        <td>test</td>
         <td>Yes</td>
       </tr>
       <tr>
@@ -170,7 +170,7 @@ This is the table of environment variables for the [Katib DB Manager](https://gi
 
 Currently, Katib DB Manager supports only **MySQL** database. You can use your own DB Manager and Database to report metrics.
 
-To run Katib DB Manager `DB_NAME` **must be equal to `mysql`** and `DB_PASSWORD` **must be set up**. For the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml#L29) we set `DB_PASSWORD` to a value from [katib-mysql-secrets](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/mysql-db/secret.yaml).
+For the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml#L29) you can change `DB_PASSWORD` to a your own MySQL DB password.
 
 Katib DB Manager creates connection to the DB, using `mysql` driver and this data source name:
 
@@ -180,7 +180,7 @@ Katib DB Manager creates connection to the DB, using `mysql` driver and this dat
 
 For the [Katib MySQL](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/mysql-db/deployment.yaml) we set these environment variables:
 
-- `MYSQL_ROOT_PASSWORD` to a value from [katib-mysql-secrets](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/mysql-db/secret.yaml).
+- `MYSQL_ROOT_PASSWORD` to a value from [katib-mysql-secrets](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/mysql-db/secret.yaml), which is equal to "test".
 - `MYSQL_ALLOW_EMPTY_PASSWORD` as `true`
 - `MYSQL_DATABASE` as `katib`.
 

--- a/content/docs/components/hyperparameter-tuning/env-variables.md
+++ b/content/docs/components/hyperparameter-tuning/env-variables.md
@@ -1,0 +1,169 @@
++++
+title = "Katib components environment variables"
+description = "How to set up environment variables for each Katib component"
+weight = 50
++++
+
+This page describes information about environment variables for each Katib component. If you want to change Katib installation, you can modify some of these variables.
+
+## Katib Controller
+
+This is the table of environment variables for the [Katib Controller](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/katib-controller/katib-controller.yaml) deployment with default values.
+
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Variable</th>
+        <th>Description</th>
+        <th>Default Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>KATIB_CORE_NAMESPACE</code></td>
+        <td>Base Namespace for all Katib components and default Experiment</td>
+        <td>kubeflow</td>
+      </tr>
+      <tr>
+        <td><code>KATIB_SUGGESTION_COMPOSER</code></td>
+        <td>Composer for the Katib Suggestions. You can use your own Composer</td>
+        <td>general</td>
+      </tr>
+      <tr>
+        <td><code>KATIB_DB_MANAGER_SERVICE_NAMESPACE</code></td>
+        <td>Katib DB Manager Namespace</td>
+        <td><code>KATIB_CORE_NAMESPACE</code> env variable</td>
+      </tr>
+      <tr>
+        <td><code>KATIB_DB_MANAGER_SERVICE_IP</code></td>
+        <td>Katib DB Manager IP</td>
+        <td>katib-db-manager</td>
+      </tr>
+       <tr>
+        <td><code>KATIB_DB_MANAGER_SERVICE_PORT</code></td>
+        <td>Katib DB Manager Port</td>
+        <td>6789</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+Katib Controller calls Katib DB Manager with this address expression:
+
+**`KATIB_DB_MANAGER_SERVICE_IP.KATIB_DB_MANAGER_SERVICE_NAMESPACE:KATIB_DB_MANAGER_SERVICE_PORT`**
+
+If you set `KATIB_DB_MANAGER_SERVICE_NAMESPACE=""`, Katib Controller calls Katib DB Manager with this address:
+
+**`KATIB_DB_MANAGER_SERVICE_IP:KATIB_DB_MANAGER_SERVICE_PORT`**
+
+If you want to use your own DB Manager to report Katib metrics, you can change `KATIB_DB_MANAGER_SERVICE_NAMESPACE`, `KATIB_DB_MANAGER_SERVICE_IP` and `KATIB_DB_MANAGER_SERVICE_PORT` variables.
+
+## Katib UI
+
+This is the table of environment variables for the [Katib UI](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/ui/deployment.yaml) deployment with default values.
+
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Variable</th>
+        <th>Description</th>
+        <th>Default Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>KATIB_CORE_NAMESPACE</code></td>
+        <td>Base Namespace for all Katib components and default Experiment</td>
+        <td>kubeflow</td>
+      </tr>
+      <tr>
+        <td><code>KATIB_DB_MANAGER_SERVICE_NAMESPACE</code></td>
+        <td>Katib DB Manager Namespace</td>
+        <td><code>KATIB_CORE_NAMESPACE</code> env variable</td>
+      </tr>
+      <tr>
+        <td><code>KATIB_DB_MANAGER_SERVICE_IP</code></td>
+        <td>Katib DB Manager IP</td>
+        <td>katib-db-manager</td>
+      </tr>
+       <tr>
+        <td><code>KATIB_DB_MANAGER_SERVICE_PORT</code></td>
+        <td>Katib DB Manager Port</td>
+        <td>6789</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+Katib UI calls Katib DB Manager with the same address expression as Katib Controller.
+
+## Katib DB Manager
+
+This is the table of environment variables for the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml) deployment with default values.
+
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Variable</th>
+        <th>Description</th>
+        <th>Default Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>DB_NAME</code></td>
+        <td>Katib DB Name</td>
+        <td>No default value</td>
+      </tr>
+      <tr>
+        <td><code>DB_PASSWORD</code></td>
+        <td>Katib DB Password</td>
+        <td>No default value</td>
+      </tr>
+      <tr>
+        <td><code>DB_USER</code></td>
+        <td>Katib DB User</td>
+        <td>root</td>
+      </tr>
+       <tr>
+        <td><code>KATIB_MYSQL_DB_HOST</code></td>
+        <td>Katib MySQL Host</td>
+        <td>katib-mysql</td>
+      </tr>
+      <tr>
+        <td><code>KATIB_MYSQL_DB_PORT</code></td>
+        <td>Katib MySQL Port</td>
+        <td>3306</td>
+      </tr>
+      <tr>
+        <td><code>KATIB_MYSQL_DB_DATABASE</code></td>
+        <td>Katib MySQL Database name</td>
+        <td>katib</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+To run Katib DB Manager `DB_NAME` **must be equal to `mysql`** and `DB_PASSWORD` **must be set up**. For the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml#L29) we set `DB_PASSWORD` to a value from [katib-mysql-secrets](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/mysql-db/secret.yaml).
+
+Katib DB Manager creates connection to the DB, using `mysql` driver and this data source name:
+
+**`DB_USER:DB_PASSWORD@tcp(KATIB_MYSQL_DB_HOST:KATIB_MYSQL_DB_PORT)/KATIB_MYSQL_DB_DATABASE?timeout=5s`**
+
+## Katib MySQL DB
+
+For the [Katib MySQL](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/mysql-db/deployment.yaml) we set these environment variables:
+
+- `MYSQL_ROOT_PASSWORD` to a value from [katib-mysql-secrets](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/mysql-db/secret.yaml).
+- `MYSQL_ALLOW_EMPTY_PASSWORD` as `true`
+- `MYSQL_DATABASE` as `katib`.
+
+Check [here](https://github.com/docker-library/docs/tree/master/mysql#environment-variables) about all environment variables for the MySQL Docker image.
+
+Katib MySQL environment variables must be matched with the Katib DB Manager environment variables, it means:
+
+1. `MYSQL_ROOT_PASSWORD` = `DB_PASSWORD`
+2. `MYSQL_DATABASE` = `KATIB_MYSQL_DB_DATABASE`

--- a/content/docs/components/hyperparameter-tuning/env-variables.md
+++ b/content/docs/components/hyperparameter-tuning/env-variables.md
@@ -6,7 +6,7 @@ weight = 50
 
 This page describes information about environment variables for each Katib component. If you want to change Katib installation, you can modify some of these variables.
 
-If the tables below you can see description, default values and mandatory property for all environment variables in each Katib component.
+In the tables below you can see description, default values and mandatory property for all environment variables in each Katib component.
 If variable has mandatory property, appropriate Katib component's manifest must have this environment variable.
 
 ## Katib Controller

--- a/content/docs/components/hyperparameter-tuning/env-variables.md
+++ b/content/docs/components/hyperparameter-tuning/env-variables.md
@@ -170,7 +170,7 @@ This is the table of environment variables for the [Katib DB Manager](https://gi
 
 Currently, Katib DB Manager supports only **MySQL** database. You can use your own DB Manager and Database to report metrics.
 
-For the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml#L29) you can change `DB_PASSWORD` to a your own MySQL DB password.
+For the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml#L29) you can change `DB_PASSWORD` to your own MySQL DB password.
 
 Katib DB Manager creates connection to the DB, using `mysql` driver and this data source name:
 

--- a/content/docs/components/hyperparameter-tuning/env-variables.md
+++ b/content/docs/components/hyperparameter-tuning/env-variables.md
@@ -1,5 +1,5 @@
 +++
-title = "Katib components environment variables"
+title = "Environment Variables for Katib Components"
 description = "How to set up environment variables for each Katib component"
 weight = 50
 +++
@@ -166,4 +166,4 @@ Check [here](https://github.com/docker-library/docs/tree/master/mysql#environmen
 Katib MySQL environment variables must be matched with the Katib DB Manager environment variables, it means:
 
 1. `MYSQL_ROOT_PASSWORD` = `DB_PASSWORD`
-2. `MYSQL_DATABASE` = `KATIB_MYSQL_DB_DATABASE`
+1. `MYSQL_DATABASE` = `KATIB_MYSQL_DB_DATABASE`

--- a/content/docs/components/hyperparameter-tuning/env-variables.md
+++ b/content/docs/components/hyperparameter-tuning/env-variables.md
@@ -6,9 +6,12 @@ weight = 50
 
 This page describes information about environment variables for each Katib component. If you want to change Katib installation, you can modify some of these variables.
 
+If the tables below you can see description, default values and mandatory property for all environment variables in each Katib component.
+If variable has mandatory property, you must add this environment variable to the appropriate Katib component's manifest.
+
 ## Katib Controller
 
-This is the table of environment variables for the [Katib Controller](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/katib-controller/katib-controller.yaml) deployment with default values.
+This is the table of environment variables for the [Katib Controller](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/katib-controller/katib-controller.yaml) deployment.
 
 <div class="table-responsive">
   <table class="table table-bordered">
@@ -17,33 +20,39 @@ This is the table of environment variables for the [Katib Controller](https://gi
         <th>Variable</th>
         <th>Description</th>
         <th>Default Value</th>
+        <th>Mandatory</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td><code>KATIB_CORE_NAMESPACE</code></td>
         <td>Base Namespace for all Katib components and default Experiment</td>
-        <td>kubeflow</td>
+        <td><code>metadata.namespace</code></td>
+        <td>Yes</td>
       </tr>
       <tr>
         <td><code>KATIB_SUGGESTION_COMPOSER</code></td>
         <td>Composer for the Katib Suggestions. You can use your own Composer</td>
         <td>general</td>
+        <td>No</td>
       </tr>
       <tr>
         <td><code>KATIB_DB_MANAGER_SERVICE_NAMESPACE</code></td>
         <td>Katib DB Manager Namespace</td>
         <td><code>KATIB_CORE_NAMESPACE</code> env variable</td>
+        <td>No</td>
       </tr>
       <tr>
         <td><code>KATIB_DB_MANAGER_SERVICE_IP</code></td>
         <td>Katib DB Manager IP</td>
         <td>katib-db-manager</td>
+        <td>No</td>
       </tr>
        <tr>
         <td><code>KATIB_DB_MANAGER_SERVICE_PORT</code></td>
         <td>Katib DB Manager Port</td>
         <td>6789</td>
+        <td>No</td>
       </tr>
     </tbody>
   </table>
@@ -61,7 +70,7 @@ If you want to use your own DB Manager to report Katib metrics, you can change `
 
 ## Katib UI
 
-This is the table of environment variables for the [Katib UI](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/ui/deployment.yaml) deployment with default values.
+This is the table of environment variables for the [Katib UI](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/ui/deployment.yaml) deployment.
 
 <div class="table-responsive">
   <table class="table table-bordered">
@@ -70,28 +79,33 @@ This is the table of environment variables for the [Katib UI](https://github.com
         <th>Variable</th>
         <th>Description</th>
         <th>Default Value</th>
+        <th>Mandatory</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td><code>KATIB_CORE_NAMESPACE</code></td>
         <td>Base Namespace for all Katib components and default Experiment</td>
-        <td>kubeflow</td>
+        <td><code>metadata.namespace</code></td>
+        <td>Yes</td>
       </tr>
       <tr>
         <td><code>KATIB_DB_MANAGER_SERVICE_NAMESPACE</code></td>
         <td>Katib DB Manager Namespace</td>
         <td><code>KATIB_CORE_NAMESPACE</code> env variable</td>
+        <td>No</td>
       </tr>
       <tr>
         <td><code>KATIB_DB_MANAGER_SERVICE_IP</code></td>
         <td>Katib DB Manager IP</td>
         <td>katib-db-manager</td>
+        <td>No</td>
       </tr>
        <tr>
         <td><code>KATIB_DB_MANAGER_SERVICE_PORT</code></td>
         <td>Katib DB Manager Port</td>
         <td>6789</td>
+        <td>No</td>
       </tr>
     </tbody>
   </table>
@@ -101,7 +115,7 @@ Katib UI calls Katib DB Manager with the same address expression as Katib Contro
 
 ## Katib DB Manager
 
-This is the table of environment variables for the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml) deployment with default values.
+This is the table of environment variables for the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml) deployment.
 
 <div class="table-responsive">
   <table class="table table-bordered">
@@ -110,6 +124,7 @@ This is the table of environment variables for the [Katib DB Manager](https://gi
         <th>Variable</th>
         <th>Description</th>
         <th>Default Value</th>
+        <th>Mandatory</th>
       </tr>
     </thead>
     <tbody>
@@ -117,35 +132,43 @@ This is the table of environment variables for the [Katib DB Manager](https://gi
         <td><code>DB_NAME</code></td>
         <td>Katib DB Name</td>
         <td>No default value</td>
+        <td>Yes</td>
       </tr>
       <tr>
         <td><code>DB_PASSWORD</code></td>
         <td>Katib DB Password</td>
         <td>No default value</td>
+        <td>Yes</td>
       </tr>
       <tr>
         <td><code>DB_USER</code></td>
         <td>Katib DB User</td>
         <td>root</td>
+        <td>No</td>
       </tr>
        <tr>
         <td><code>KATIB_MYSQL_DB_HOST</code></td>
         <td>Katib MySQL Host</td>
         <td>katib-mysql</td>
+        <td>No</td>
       </tr>
       <tr>
         <td><code>KATIB_MYSQL_DB_PORT</code></td>
         <td>Katib MySQL Port</td>
         <td>3306</td>
+        <td>No</td>
       </tr>
       <tr>
         <td><code>KATIB_MYSQL_DB_DATABASE</code></td>
         <td>Katib MySQL Database name</td>
         <td>katib</td>
+        <td>No</td>
       </tr>
     </tbody>
   </table>
 </div>
+
+Currently, Katib DB Manager supports only **MySQL** database. You can use your own DB Manager and Database to report metrics.
 
 To run Katib DB Manager `DB_NAME` **must be equal to `mysql`** and `DB_PASSWORD` **must be set up**. For the [Katib DB Manager](https://github.com/andreyvelich/katib/blob/doc-katib-config/manifests/v1alpha3/db-manager/deployment.yaml#L29) we set `DB_PASSWORD` to a value from [katib-mysql-secrets](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/mysql-db/secret.yaml).
 

--- a/content/docs/components/hyperparameter-tuning/env-variables.md
+++ b/content/docs/components/hyperparameter-tuning/env-variables.md
@@ -7,7 +7,7 @@ weight = 50
 This page describes information about environment variables for each Katib component. If you want to change Katib installation, you can modify some of these variables.
 
 If the tables below you can see description, default values and mandatory property for all environment variables in each Katib component.
-If variable has mandatory property, you must add this environment variable to the appropriate Katib component's manifest.
+If variable has mandatory property, appropriate Katib component's manifest must have this environment variable.
 
 ## Katib Controller
 

--- a/content/docs/components/hyperparameter-tuning/experiment.md
+++ b/content/docs/components/hyperparameter-tuning/experiment.md
@@ -25,7 +25,7 @@ documentation](https://kubernetes.io/docs/concepts/containers/images/).
  
 To create a hyperparameter tuning or NAS experiment in Katib, you define the
 experiment in a YAML configuration file. The YAML file defines the range of 
-potential values (the search space) for the paramaters that you want to 
+potential values (the search space) for the parameters that you want to 
 optimize, the objective metric to use when determining optimal values, the 
 search algorithm to use during optimization, and other configurations.
 
@@ -63,7 +63,7 @@ These are the fields in the experiment configuration spec:
   or minimized based on `type`) and the corresponding hyperparameter set
   in `Experiment.status`. If the `objectiveMetricName` metric for a set of
   hyperparameters reaches the `goal`, Katib stops trying more hyperparameter 
-  combinations. See the [ObjectiveSpec 
+  combinations. See the [`ObjectiveSpec` 
   type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/common/v1alpha3/common_types.go#L47).
 
 * **algorithm**: The search algorithm that you want Katib to use to find the
@@ -86,13 +86,14 @@ These are the fields in the experiment configuration spec:
     * [Kubeflow PyTorchJob](/docs/guides/components/pytorch/) (supports 
       distributed execution).
     
-    See the [TrialTemplate 
+    See the [`TrialTemplate` 
     type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1alpha3/experiment_types.go#L180-L194).
     The template 
     uses the [Go template format](https://golang.org/pkg/text/template/).
     
     You can define the job in raw string format or you can use a 
-    [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/).
+    [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/). 
+    [Here](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/katib-controller/trialTemplateConfigmapLabeled.yaml) is an example how to create ConfigMap with trial templates.
 
 * **parallelTrialCount**: The maximum number of hyperparameter sets that Katib
   should train in parallel.
@@ -117,23 +118,27 @@ These are the fields in the experiment configuration spec:
   You can specify the configurations of the neural network design that you want
   to optimize, including the number of layers in the network, the types of
   operations, and more.
-  See the [NasConfig type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1alpha3/experiment_types.go#L220).
-  As an example, see the YAML file for the
-  [nasjob-example-RL-gpu](https://github.com/kubeflow/katib/blob/master/examples/v1alpha3/nasjob-example-RL-gpu.yaml).
-  The example aims to show all the possible operations. Due to the large search 
-  space, the example is not likely to generate a good result.
+  See the [`NasConfig` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1alpha3/experiment_types.go#L220).
+
+* **operations**: The range of operations that you want to tune for your ML model. 
+  For each neural network layer NAS algorithm selects one of the operation to build neural network. 
+  Each operation has sets of **parameters** which described above. See the [`Operation` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1alpha3/experiment_types.go#L232-L236).
+
+    As a NAS example, see the YAML file for the
+    [nasjob-example-RL-gpu](https://github.com/kubeflow/katib/blob/master/examples/v1alpha3/nasjob-example-RL-gpu.yaml).
+    The example aims to show all the possible operations. Due to the large search 
+    space, the example is not likely to generate a good result.
 
 *Background information about Katib's `Experiment` type:* In Kubernetes 
 terminology, Katib's
-[`Experiment`](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1alpha3/experiment_types.go#L202)
-type is a [custom resource 
+[`Experiment` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1alpha3/experiment_types.go#L202) is a [custom resource 
 (CR)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 The YAML file that you create for your experiment is the CR specification.
 
 <a id="search-algorithms"></a>
 ### Search algorithms in detail 
   
-Katib currently supports several search algorithms. See the [AlgorithmSpec
+Katib currently supports several search algorithms. See the [`AlgorithmSpec`
 type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/common/v1alpha3/common_types.go#L23-L33).
 
 Here's a list of the search algorithms available in Katib. The links lead to
@@ -171,7 +176,7 @@ The algorithm name in Katib is `random`.
 
 Random sampling is an alternative to grid search, useful when the number of 
 discrete variables to optimize is large and the time required for each 
-evaluation is logn. When all parameters are discrete, random search performs
+evaluation is long. When all parameters are discrete, random search performs
 sampling without replacement. Random search is therefore the best algorithm to
 use when combinatorial exploration is not possible. If the number of continuous
 variables is high, you should use quasi random sampling instead.
@@ -204,7 +209,7 @@ Katib supports the following algorithm settings:
 <a id="bayesian"></a>
 #### Bayesian optimization
 
-The algorithm name in Katib is `skopt-bayesian-optimization`.
+The algorithm name in Katib is `bayesianoptimization`.
 
 The [Bayesian optimization](https://arxiv.org/pdf/1012.2599.pdf) method uses
 gaussian process regression to model the search space. This technique calculates
@@ -268,7 +273,7 @@ Katib supports the following algorithm settings:
       <tr>
         <td>acq_optimizer</td>
         <td>[string, “sampling” or “lbfgs”, default=“auto”]: The method to 
-          minimize the acquistion function. The system updates the fit model
+          minimize the acquisition function. The system updates the fit model
           with the optimal value obtained by optimizing <code>acq_func</code>
           with <code>acq_optimizer</code>. See more information in the
           <a href="https://scikit-optimize.github.io/#skopt.Optimizer">skopt
@@ -294,7 +299,7 @@ Katib supports the [HYPERBAND](https://arxiv.org/pdf/1603.06560.pdf)
 optimization framework.
 Instead of using Bayesian optimization to select configurations, HYPERBAND
 focuses on early stopping as a strategy for optimizing resource allocation and
-thus for maximixing the number of configurations that it can evaluate.
+thus for maximizing the number of configurations that it can evaluate.
 HYPERBAND also focuses on the speed of the search.
 
 <a id="tpe-search"></a>
@@ -331,7 +336,7 @@ reinforcement learning](https://github.com/kubeflow/katib/tree/master/pkg/sugges
 
 In the `metricsCollectorSpec` section of the YAML configuration file, you can
 define how Katib should collect the metrics from each trial, such as the 
-accuracy and loss metrics.
+accuracy and loss metrics. See the [`MetricsCollectorSpec` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/common/v1alpha3/common_types.go#L81-L150)
 
 Your training code can record the metrics into `stdout` or into arbitrary output
 files. Katib collects the metrics using a *sidecar* container. A sidecar is
@@ -357,8 +362,8 @@ To define the metrics collector for your experiment:
       collector. For example, your training code may handle the persistent
       storage of its own metrics.
 
-1. Specify the metrics output location in the `source` field. See the 
-  [MetricsCollectorSpec type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/common/v1alpha3/common_types.go#L81-L150) for default values.
+1. Specify the metrics output location in the `source` field. See [const](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/common/v1alpha3/common_types.go#L123-L143) for default values.
+
 1. Write code in your training container to print metrics in the format
    specified in the `metricsCollectorSpec.source.filter.metricsFormat`
    field. The default format is `([\w|-]+)\s*=\s*((-?\d+)(\.\d+)?)`.
@@ -488,3 +493,8 @@ View the results of the experiment in the Katib UI:
 * For an overview of the concepts involved in hyperparameter tuning and
   neural architecture search, read the [introduction to 
   Katib](/docs/components/hyperparameter-tuning/overview/).
+
+* For a detailed instruction of the Katib Configuration file, 
+  read the [Katib config page](/docs/components/hyperparameter-tuning/katib-config/).
+
+* See how you can change installation of Katib component in the [environment variables guide](/docs/components/hyperparameter-tuning/env-variables/).

--- a/content/docs/components/hyperparameter-tuning/hyperparameter.md
+++ b/content/docs/components/hyperparameter-tuning/hyperparameter.md
@@ -17,6 +17,7 @@ Katib](/docs/components/hyperparameter-tuning/overview/).
 This section describes some configurations that you may need to add to your
 Kubernetes cluster, depending on the way you're using Kubeflow and Katib.
 
+<a id="katib-install"></a>
 ### Installing Katib
 
 You can skip this step if you have already installed Kubeflow. Your Kubeflow
@@ -35,6 +36,8 @@ bash ./katib/scripts/v1alpha3/deploy.sh
 ```
 
 ### Setting up persistent volumes
+
+If you used [above script](#katib-install) to deploy Katib, you can skip this step. This script deploys PVC and PV on your cluster.
 
 You can skip this step if you're using Kubeflow on Google Kubernetes Engine 
 (GKE) or if your Kubernetes cluster includes a StorageClass for dynamic volume 
@@ -102,8 +105,7 @@ This example uses the [YAML file for the
 random algorithm example](https://github.com/kubeflow/katib/blob/master/examples/v1alpha3/random-example.yaml).
 
 The random algorithm example uses an MXNet neural network to train an image
-classification model using the MNIST dataset. The experiment runs three 
-training jobs with various hyperparameters and saves the results.
+classification model using the MNIST dataset. You can check training container source code [here](https://github.com/kubeflow/katib/tree/master/examples/v1alpha3/mxnet-mnist). The experiment runs three training jobs with various hyperparameters and saves the results.
 
 Run the following commands to launch an experiment using the random algorithm
 example:
@@ -349,13 +351,12 @@ Delete the installed components:
 bash ./scripts/v1alpha3/undeploy.sh
 ```
 
-If you created a PV for Katib, delete it:
-
-```
-kubectl delete -f https://raw.githubusercontent.com/kubeflow/katib/master/manifests/v1alpha3/pv/pv.yaml
-```
-
 ## Next steps
 
-For details of how to configure and run your experiment, see the guide to 
-[running an experiment](/docs/components/hyperparameter-tuning/experiment/).
+* For details of how to configure and run your experiment, see the guide to 
+  [running an experiment](/docs/components/hyperparameter-tuning/experiment/).
+
+* For a detailed instruction of the Katib Configuration file, 
+  read the [Katib config page](/docs/components/hyperparameter-tuning/katib-config/).
+
+* See how you can change installation of Katib component in the [environment variables guide](/docs/components/hyperparameter-tuning/env-variables/).

--- a/content/docs/components/hyperparameter-tuning/katib-config.md
+++ b/content/docs/components/hyperparameter-tuning/katib-config.md
@@ -1,6 +1,6 @@
 +++
-title = "Katib config overview"
-description = "How to make changes in Katib config"
+title = "Katib Configuration Overview"
+description = "How to make changes in Katib configuration"
 weight = 40
 +++
 
@@ -9,7 +9,7 @@ This page describes information about [Katib config](https://github.com/kubeflow
 Katib config is the Kubernetes [Config Map](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) that contains information about:
 
 1. Current [Metrics Collectors](/docs/components/hyperparameter-tuning/experiment/#metrics-collector) (`key = metrics-collector-sidecar`)
-2. Current [Algorithms](/docs/components/hyperparameter-tuning/experiment/#search-algorithms-in-detail) (Suggestions) (`key = suggestion`).
+1. Current [Algorithms](/docs/components/hyperparameter-tuning/experiment/#search-algorithms-in-detail) (Suggestions) (`key = suggestion`).
 
 Katib Config Map must be deployed in [`KATIB_CORE_NAMESPACE`](/docs/components/hyperparameter-tuning/env-variables/#katib-controller) namespace with `katib-config` name. Katib controller parses Katib config when you submit Experiment.
 
@@ -55,25 +55,25 @@ All of these settings except **`image`** can be omitted. If you don't specify an
 
 1. `image` - Docker image name for the `File` Metrics Collector.
 
-   **Must be specified**.
+    **Must be specified**.
 
-2. `imagePullPolicy` - `File` Metrics Collector container [image pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).
+1. `imagePullPolicy` - `File` Metrics Collector container [image pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).
 
-   Default value is `IfNotPresent`.
+    Default value is `IfNotPresent`.
 
-3. `resources` - `File` Metrics Collector [container resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container). In the above example you can see how to specify `limits` and `requests`. Currently, you can specify only `memory`, `cpu` and `ephemeral-storage` resource.
+1. `resources` - `File` Metrics Collector [container resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container). In the above example you can see how to specify `limits` and `requests`. Currently, you can specify only `memory`, `cpu` and `ephemeral-storage` resource.
 
-   Default values for the `requests` are:
+    Default values for the `requests` are:
 
-   - `memory = 10Mi`.
-   - `cpu = 50m`.
-   - `ephemeral-storage = 500Mi`.
+    - `memory = 10Mi`.
+    - `cpu = 50m`.
+    - `ephemeral-storage = 500Mi`.
 
-   Default values for the `limits` are:
+    Default values for the `limits` are:
 
-   - `memory = 100Mi`.
-   - `cpu = 500m`.
-   - `ephemeral-storage = 5Gi`.
+    - `memory = 100Mi`.
+    - `cpu = 500m`.
+    - `ephemeral-storage = 5Gi`.
 
 ## Suggestion settings
 
@@ -114,26 +114,26 @@ All of these settings except **`image`** can be omitted. If you don't specify an
 
 1. `image` - Docker image name for the `random` suggestion.
 
-   **Must be specified**.
+    **Must be specified**.
 
-2. `imagePullPolicy` - `Random` suggestion container [image pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).
+1. `imagePullPolicy` - `Random` suggestion container [image pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).
 
-   Default value is `IfNotPresent`.
+    Default value is `IfNotPresent`.
 
-3. `resources` - `Random` suggestion [container resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container). In the above example you can see how to specify `limits` and `requests`. Currently, you can specify only `memory`, `cpu` and `ephemeral-storage` resource.
+1. `resources` - `Random` suggestion [container resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container). In the above example you can see how to specify `limits` and `requests`. Currently, you can specify only `memory`, `cpu` and `ephemeral-storage` resource.
 
-   Default values for the `requests` are:
+    Default values for the `requests` are:
 
-   - `memory = 10Mi`.
-   - `cpu = 50m`.
-   - `ephemeral-storage = 500Mi`.
+    - `memory = 10Mi`.
+    - `cpu = 50m`.
+    - `ephemeral-storage = 500Mi`.
 
-   Default values for the `limits` are:
+    Default values for the `limits` are:
 
-   - `memory = 100Mi`.
-   - `cpu = 500m`.
-   - `ephemeral-storage = 5Gi`.
+    - `memory = 100Mi`.
+    - `cpu = 500m`.
+    - `ephemeral-storage = 5Gi`.
 
-4. `serviceAccountName` - `Random` suggestion container [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/). In the above example, `suggestion-serviceaccount` service account is used for each Experiment with `random` algorithm, until you change or delete this service account from the Katib config.
+1. `serviceAccountName` - `Random` suggestion container [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/). In the above example, `suggestion-serviceaccount` service account is used for each Experiment with `random` algorithm, until you change or delete this service account from the Katib config.
 
-   By default suggestion pod doesn't have specific service account. In that case, Suggestion pod uses [default](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server) service account.
+    By default suggestion pod doesn't have specific service account. In that case, Suggestion pod uses [default](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server) service account.

--- a/content/docs/components/hyperparameter-tuning/katib-config.md
+++ b/content/docs/components/hyperparameter-tuning/katib-config.md
@@ -1,0 +1,139 @@
++++
+title = "Katib config overview"
+description = "How to make changes in Katib config"
+weight = 40
++++
+
+This page describes information about [Katib config](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/katib-controller/katib-config.yaml).
+
+Katib config is the Kubernetes [Config Map](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) that contains information about:
+
+1. Current [Metrics Collectors](/docs/components/hyperparameter-tuning/experiment/#metrics-collector) (`key = metrics-collector-sidecar`)
+2. Current [Algorithms](/docs/components/hyperparameter-tuning/experiment/#search-algorithms-in-detail) (Suggestions) (`key = suggestion`).
+
+Katib Config Map must be deployed in [`KATIB_CORE_NAMESPACE`](/docs/components/hyperparameter-tuning/env-variables/#katib-controller) namespace with `katib-config` name. Katib controller parses Katib config when you submit Experiment.
+
+You can edit this Config Map even after deploying Katib.
+
+If you deploy Katib in Kubeflow namespace, to edit Katib config run this:
+
+`kubectl edit configMap katib-config -n kubeflow`
+
+## Metrics Collector Sidecar settings
+
+These settings are related to Katib Metrics Collectors, where:
+
+- key = `metrics-collector-sidecar`
+- value = corresponding settings JSON for each Metrics Collector.
+
+Example for the `File` Metrics Collector with all settings:
+
+```json
+metrics-collector-sidecar: |-
+{
+  "File": {
+    "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector",
+    "imagePullPolicy": "Always",
+    "resources": {
+      "requests": {
+        "memory": "200Mi",
+        "cpu": "250m",
+        "ephemeral-storage": "200Mi"
+      },
+      "limits": {
+        "memory": "1Gi",
+        "cpu": "500m",
+        "ephemeral-storage": "2Gi"
+      }
+    }
+  },
+  ...
+}
+```
+
+All of these settings except **`image`** can be omitted. If you don't specify any other settings, default value is be set.
+
+1. `image` - Docker image name for the `File` Metrics Collector.
+
+   **Must be specified**.
+
+2. `imagePullPolicy` - `File` Metrics Collector container [image pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).
+
+   Default value is `IfNotPresent`.
+
+3. `resources` - `File` Metrics Collector [container resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container). In the above example you can see how to specify `limits` and `requests`. Currently, you can specify only `memory`, `cpu` and `ephemeral-storage` resource.
+
+   Default values for the `requests` are:
+
+   - `memory = 10Mi`.
+   - `cpu = 50m`.
+   - `ephemeral-storage = 500Mi`.
+
+   Default values for the `limits` are:
+
+   - `memory = 100Mi`.
+   - `cpu = 500m`.
+   - `ephemeral-storage = 5Gi`.
+
+## Suggestion settings
+
+These settings are related to Katib suggestions, where:
+
+- key = `suggestion`
+- value = corresponding settings JSON for each algorithm.
+
+If you want to use new algorithm, you must update Katib config with the new suggestion.
+
+Example for the `random` suggestion with all settings:
+
+```json
+suggestion: |-
+{
+  "random": {
+    "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt",
+    "imagePullPolicy": "Always",
+    "resources": {
+      "requests": {
+        "memory": "100Mi",
+        "cpu": "100m",
+        "ephemeral-storage": "100Mi"
+      },
+      "limits": {
+        "memory": "500Mi",
+        "cpu": "500m",
+        "ephemeral-storage": "3Gi"
+      }
+    },
+    "serviceAccountName": "suggestion-serviceaccount"
+  },
+  ...
+}
+```
+
+All of these settings except **`image`** can be omitted. If you don't specify any other settings, default value is be set.
+
+1. `image` - Docker image name for the `random` suggestion.
+
+   **Must be specified**.
+
+2. `imagePullPolicy` - `Random` suggestion container [image pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).
+
+   Default value is `IfNotPresent`.
+
+3. `resources` - `Random` suggestion [container resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container). In the above example you can see how to specify `limits` and `requests`. Currently, you can specify only `memory`, `cpu` and `ephemeral-storage` resource.
+
+   Default values for the `requests` are:
+
+   - `memory = 10Mi`.
+   - `cpu = 50m`.
+   - `ephemeral-storage = 500Mi`.
+
+   Default values for the `limits` are:
+
+   - `memory = 100Mi`.
+   - `cpu = 500m`.
+   - `ephemeral-storage = 5Gi`.
+
+4. `serviceAccountName` - `Random` suggestion container [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/). In the above example, `suggestion-serviceaccount` service account is used for each Experiment with `random` algorithm, until you change or delete this service account from the Katib config.
+
+   By default suggestion pod doesn't have specific service account. In that case, Suggestion pod uses [default](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server) service account.

--- a/content/docs/components/hyperparameter-tuning/overview.md
+++ b/content/docs/components/hyperparameter-tuning/overview.md
@@ -96,7 +96,7 @@ is a good starting point for developers who want to contribute to the project.
 
 ## Katib interfaces
 
-You can use the following interaces to interact with Katib:
+You can use the following interfaces to interact with Katib:
 
 * A web UI that you can use to submit experiments and to monitor your results.
   See the [getting-started 


### PR DESCRIPTION
I added documentation about Katib config and about all environment variables that can be set in Katib components.
I hope, I added everything.

I am not sure that we need DB_NAME variable, since we support only mysql https://github.com/kubeflow/katib/blob/master/pkg/db/v1alpha3/db.go#L12 @johnugeorge.

/assign @sarahmaddox 
/cc @richardsliu @gaocegege @hougangliu 