### PR TITLE
Updating cluster config for IBM Cloud

### DIFF
--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -56,7 +56,7 @@ environment variables.
 To make sure the cluster is large enough to host all the Knative and Istio
 components, the recommended configuration for a cluster is:
 
-- Kubernetes version 1.15 or later
+- Kubernetes version 1.15 
 - 4 vCPU nodes with 16GB memory (`b2c.4x16`)
 
 1.  Set `ibmcloud` to the appropriate region:


### PR DESCRIPTION
Per https://www.kubeflow.org/docs/started/k8s/overview/: "Kubeflow does not work on Kubernetes 1.16" (assuming this is the case for 1.17 and 1.18 too).