### PR TITLE
Moved virtual env installation guides to getting-started section

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -89,8 +89,11 @@ docs/started/requirements/                    /docs/started/getting-started/
 
 # Restructured the getting-started and other-guides sections.
 /docs/started/getting-started-k8s/             /docs/started/k8s/
-/docs/started/getting-started-minikf/          /docs/other-guides/virtual-dev/getting-started-minikf/
-/docs/started/getting-started-multipass/       /docs/other-guides/virtual-dev/getting-started-multipass/
+/docs/started/getting-started-minikf/                      /docs/started/workstation/getting-started-minikf/
+/docs/other-guides/virtual-dev/getting-started-minikf/     /docs/started/workstation/getting-started-minikf/
+/docs/started/getting-started-multipass/                   /docs/started/workstation/getting-started-multipass/
+/docs/other-guides/virtual-dev/getting-started-multipass/  /docs/started/workstation/getting-started-multipass/
+/docs/other-guides/virtual-dev/                            /docs/started/workstation/
 /docs/started/getting-started-aws/             /docs/started/cloud/getting-started-aws/
 /docs/started/getting-started-azure/           /docs/started/cloud/getting-started-azure/
 /docs/started/getting-started-gke/             /docs/started/cloud/getting-started-gke/

--- a/content/docs/other-guides/virtual-dev/_index.md
+++ b/content/docs/other-guides/virtual-dev/_index.md
@@ -1,5 +1,0 @@
-+++
-title = "Virtual Developer Environments"
-description = "Detailed instructions for using VM appliances for Kubeflow"
-weight = 2
-+++

--- a/content/docs/started/workstation/getting-started-linux.md
+++ b/content/docs/started/workstation/getting-started-linux.md
@@ -17,7 +17,7 @@ GCP, AWS and Azure.
 
 [MicroK8s](https://microk8s.io) runs natively on most Linux distributions. 
 
-Follow the installation guide for [Kubeflow with MicroK8s](/docs/other-guides/virtual-dev/getting-started-multipass/) to set up MicroK8s and enable Kubeflow.
+Follow the installation guide for [Kubeflow with MicroK8s](/docs/started/workstation/getting-started-multipass/) to set up MicroK8s and enable Kubeflow.
 
 ## Linux desktop
 
@@ -35,7 +35,7 @@ The only following applications are required to use MiniKF:
 - Install [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
 
 The full set of instructions are available on the
-[MiniKF getting started](/docs/other-guides/virtual-dev/getting-started-minikf/) page.
+[MiniKF getting started](/docs/started-workstation/getting-started-minikf/) page.
 
 ### Linux appliance
 
@@ -45,7 +45,7 @@ of flexibility. You only need to install a single application to follow this pat
 
 - Install [Multipass](https://multipass.run/#install)
 
-The instructions on [Multipass and MicroK8s getting started](/docs/other-guides/virtual-dev/getting-started-multipass/)
+The instructions on [Multipass and MicroK8s getting started](/docs/started-workstation/getting-started-multipass/)
 page will complete this path.
 
 ### Kubernetes appliance

--- a/content/docs/started/workstation/getting-started-linux.md
+++ b/content/docs/started/workstation/getting-started-linux.md
@@ -35,7 +35,7 @@ The only following applications are required to use MiniKF:
 - Install [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
 
 The full set of instructions are available on the
-[MiniKF getting started](/docs/started-workstation/getting-started-minikf/) page.
+[MiniKF getting started](/docs/started/workstation/getting-started-minikf/) page.
 
 ### Linux appliance
 
@@ -45,7 +45,7 @@ of flexibility. You only need to install a single application to follow this pat
 
 - Install [Multipass](https://multipass.run/#install)
 
-The instructions on [Multipass and MicroK8s getting started](/docs/started-workstation/getting-started-multipass/)
+The instructions on [Multipass and MicroK8s getting started](/docs/started/workstation/getting-started-multipass/)
 page will complete this path.
 
 ### Kubernetes appliance

--- a/content/docs/started/workstation/getting-started-macos.md
+++ b/content/docs/started/workstation/getting-started-macos.md
@@ -4,13 +4,6 @@ description = "Install Kubeflow on macOS"
 weight = 20
 +++
 
-<!--
-  TODO: Create a table that summarizes the options below, helping the user choose
-        more quickly
-  TODO: Surface the mac specific instructions here .. for instance, installing
-        vagrant and virtualbox through brew / brew cask
--->
-
 For macOS systems you have multiple options for getting started. The options range
 from fully-assembled Kubeflow stacks, to stacks that require some assembly.
 
@@ -28,7 +21,7 @@ The only following applications are required to use MiniKF:
 - Install [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
 
 The full set of instructions are available on the
-[MiniKF getting started](/docs/other-guides/virtual-dev/getting-started-minikf/) page.
+[MiniKF getting started](/docs/started-workstation/getting-started-minikf/) page.
 
 ## Linux appliance
 
@@ -38,7 +31,7 @@ of flexibility. You only need to install a single application to follow this pat
 
 - Install [Multipass](https://multipass.run/#install)
 
-The instructions on [Multipass and MicroK8s getting started](/docs/other-guides/virtual-dev/getting-started-multipass/)
+The instructions on [Multipass and MicroK8s getting started](/docs/started-workstation/getting-started-multipass/)
 page will complete this path.
 
 ## Kubernetes appliance

--- a/content/docs/started/workstation/getting-started-macos.md
+++ b/content/docs/started/workstation/getting-started-macos.md
@@ -21,7 +21,7 @@ The only following applications are required to use MiniKF:
 - Install [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
 
 The full set of instructions are available on the
-[MiniKF getting started](/docs/started-workstation/getting-started-minikf/) page.
+[MiniKF getting started](/docs/started/workstation/getting-started-minikf/) page.
 
 ## Linux appliance
 
@@ -31,7 +31,7 @@ of flexibility. You only need to install a single application to follow this pat
 
 - Install [Multipass](https://multipass.run/#install)
 
-The instructions on [Multipass and MicroK8s getting started](/docs/started-workstation/getting-started-multipass/)
+The instructions on [Multipass and MicroK8s getting started](/docs/started/workstation/getting-started-multipass/)
 page will complete this path.
 
 ## Kubernetes appliance

--- a/content/docs/started/workstation/getting-started-minikf.md
+++ b/content/docs/started/workstation/getting-started-minikf.md
@@ -1,7 +1,7 @@
 +++
 title = "MiniKF"
 description = "A fast and easy way to deploy Kubeflow on your laptop"
-weight = 2
+weight = 35
 +++
 
 ![MiniKF latest

--- a/content/docs/started/workstation/getting-started-multipass.md
+++ b/content/docs/started/workstation/getting-started-multipass.md
@@ -1,7 +1,7 @@
 +++
 title = "Microk8s for Kubeflow"
 description = "Quickly get Kubeflow running locally on native hypervisors"
-weight = 2
+weight = 60
 +++
 
 {{% alpha-status 

--- a/content/docs/started/workstation/getting-started-windows.md
+++ b/content/docs/started/workstation/getting-started-windows.md
@@ -4,13 +4,6 @@ description = "Install Kubeflow on Windows"
 weight = 30
 +++
 
-<!--
-  TODO: Create a table that summarizes the options below, helping the user choose
-        more quickly
-  TODO: Surface the windows specific instructions here. For instance, when WSL2 is
-        available more broadly, add instructions here.
--->
-
 For Windows systems you have multiple options for getting started. The options range
 from fully-assembled Kubeflow stacks, to stacks that require some assembly.
 In addition, with the recent announcement of
@@ -32,11 +25,13 @@ The following applications are required to use MiniKF:
 - Install [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
 
 The full set of instructions are available on the
-[MiniKF getting started](/docs/other-guides/virtual-dev/getting-started-minikf/) page.
+[MiniKF getting started](/docs/started-workstation/getting-started-minikf/) page.
 
 ## Multipass Ubuntu
 
-Windows users can get Kubeflow with [Multipass](https://multipass.run/#install) by following the instructions on the [Multipass and MicroK8s getting started](/docs/other-guides/virtual-dev/getting-started-multipass/)
+Windows users can get Kubeflow with [Multipass](https://multipass.run/#install) 
+by following the instructions on the 
+[Multipass and MicroK8s getting started](/docs/started-workstation/getting-started-multipass/)
 page.
 
 ## Kubernetes appliance
@@ -44,4 +39,3 @@ page.
 Similar to the Kubeflow appliance, the Kubernetes appliance is a virtual machine has a
 Kubernetes cluster already installed. After starting the virtual machine you will need
 to install Kubeflow. This option gives you full control over your Kubeflow setup.
-

--- a/content/docs/started/workstation/getting-started-windows.md
+++ b/content/docs/started/workstation/getting-started-windows.md
@@ -25,13 +25,13 @@ The following applications are required to use MiniKF:
 - Install [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
 
 The full set of instructions are available on the
-[MiniKF getting started](/docs/started-workstation/getting-started-minikf/) page.
+[MiniKF getting started](/docs/started/workstation/getting-started-minikf/) page.
 
 ## Multipass Ubuntu
 
 Windows users can get Kubeflow with [Multipass](https://multipass.run/#install) 
 by following the instructions on the 
-[Multipass and MicroK8s getting started](/docs/started-workstation/getting-started-multipass/)
+[Multipass and MicroK8s getting started](/docs/started/workstation/getting-started-multipass/)
 page.
 
 ## Kubernetes appliance

--- a/content/docs/started/workstation/minikf-gcp.md
+++ b/content/docs/started/workstation/minikf-gcp.md
@@ -1,6 +1,6 @@
 +++
 title = "Deploy using MiniKF on GCP"
-description = "Instructions for using the Google Cloud Marketplace to deploy MiniKF (mini Kubeflow) on Google Cloud Platform (GCP)."
+description = "Using Google Cloud Marketplace to deploy MiniKF (mini Kubeflow) on Google Cloud Platform (GCP)"
 weight = 40
 +++
 


### PR DESCRIPTION
The [section on virtual dev environments](https://www.kubeflow.org/docs/other-guides/virtual-dev/) is misplaced and incomplete. We've moved other docs around in the time since that section was created. The docs in that section belong better with the getting-started docs than in the "further configuration" section.

Eventually we plan to re-org the entire left-hand nav, but for now I think it's best to move the two remaining "virtual dev environment" docs into the getting-started section. 

Fixes https://github.com/kubeflow/website/issues/1856