### PR TITLE
remove Nuclio location-based example

### DIFF
--- a/content/docs/components/misc/nuclio.md
+++ b/content/docs/components/misc/nuclio.md
@@ -191,7 +191,6 @@ Notebook, e.g. we can create `Go` functions if we need performance/concurrency f
 Some useful function example Notebooks:
 
 - [Analyze Real-Time Data Using Spark Streaming, SQL, and ML](https://github.com/v3io/tutorials/blob/master/demos/stocks/02-explore.ipynb)
-- [Real-Time Location-Based Recommendations](https://github.com/v3io/tutorials/blob/master/demos/location-based-recommendations/01-generate-stores-and-customers.ipynb)
 - [Twitter Feed NLP](https://github.com/v3io/tutorials/blob/master/demos/stocks/04-read-tweets.ipynb)
 - [Real-time Stock data reader](https://github.com/v3io/tutorials/blob/master/demos/stocks/03-read-stocks.ipynb)
 


### PR DESCRIPTION
In [Nuclio function example](https://www.kubeflow.org/docs/components/misc/nuclio/#nuclio-function-examples), 
![image](https://user-images.githubusercontent.com/52723717/78522284-b76bc000-7781-11ea-9e46-a83321ed6271.png)

[Real-Time Location-Based Recommendations](https://github.com/v3io/tutorials/blob/master/demos/location-based-recommendations/01-generate-stores-and-customers.ipynb)  -> 404

The target notebook is already [deleted](https://github.com/v3io/tutorials/commit/569f73ea94b0162c497c6385699a548c7d4639d1).
