### PR TITLE
Correct the get storageclass command

### DIFF
--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -157,7 +157,7 @@ get the best experience from Kubeflow.
     ```
     
 1. Verify that the storage classes for Block Storage were added to your cluster.
-    ```shell
+    ```
     kubectl get storageclasses | grep block
     ```
 


### PR DESCRIPTION
In https://www.kubeflow.org/docs/ibm/install-kubeflow/#ibm-cloud-block-storage-setup
![image](https://user-images.githubusercontent.com/52723717/78619044-06bcf980-7831-11ea-9e53-4e047cbc63cf.png)

The correct command should be 
`kubectl get storageclasses | grep block`

(w/o shell in the front)