### PR TITLE
Added new videos to the list

### DIFF
--- a/content/docs/examples/videos.md
+++ b/content/docs/examples/videos.md
@@ -6,6 +6,90 @@ weight = 40
 
 The following tutorials and overviews published in video format. Be aware that a video describes the interfaces at the time of publication of the video. Some interfaces are under rapid development and therefore may change frequently.
 
+{{% blocks/content-item title="Keynote: Machine Learning using Kubeflow and Kubernetes"
+  date="February 26, 2020"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=t5zJm1D_a04" %}}
+Presenter: Arun Gupta.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Enabling Kubeflow with Enterprise-Grade Auth for On-Prem Deployments"
+  date="November 22, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=qyUyYLvmKHY" %}}
+Presenters: Yannis Zarkadas & Krishna Durai.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Supercharge Kubeflow Performance on GPU Clusters"
+  date="November 22, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=UYhBaXzD0hA" %}}
+Presenters: Meenakshi Kaushik and Neelima Mukiri, Cisco.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Towards Continuous Computer Vision Model Improvement with Kubeflow"
+  date="November 22, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=9UPnCo-LG04" %}}
+Presenters: Derek Hao Hu and Yanjia Li.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Measuring and Optimizing Kubeflow Clusters at Lyft"
+  date="November 22, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=IKubDSIivR8" %}}
+Presenters: Konstantin Gizdarski and Richard Liu.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Tutorial: From Notebook to Kubeflow Pipelines: An End-to-End Data Science Workflow"
+  date="November 22, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=C9rJzTzVzvQ" %}}
+Presenters: Michelle Casbon, Google; Stefano Fioravanzo, Fondazione Bruno Kessler, and Ilias Katsakioris, Arrikto.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Building a Medical AI with Kubernetes and Kubeflow"
+  date="November 22, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=nD_GXaW_A-s" %}}
+Presenter: Jeremie Vallee, Babylon Health.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Panel: Enterprise-grade, On-prem Kubeflow in the Financial Sector"
+  date="November 21, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=SmrW_RyQM1c" %}}
+Panel: Laura Schornack, JPMorgan Chase; Jeff Fogarty, US Bank; Josh Bottum, Arrikto; and Thea Lamkin, Google.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Advanced Model Inferencing Leveraging KNative, Istio & Kubeflow Serving"
+  date="November 21, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=YaGASyU88dQ" %}}
+Presenters: Animesh Singh and Clive Cox.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Building and Managing a Centralized Kubeflow Platform at Spotify"
+  date="November 21, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=m9XhsnNSMAI" %}}
+Presenters: Keshi Dai and Ryan Clough, Spotify.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Hyperparameter Tuning Using Kubeflow"
+  date="July 5, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=OkAoiA6A2Ac" %}}
+Presenters: Richard Liu, Google and Johnu George, Cisco Systems.
+{{% /blocks/content-item %}}
+
+{{% blocks/content-item title="Managing Machine Learning in Production with Kubeflow and DevOps"
+  date="May 31, 2019"
+  url_text="Watch"
+  url="https://www.youtube.com/watch?v=lu5zHvpQeSI" %}}
+Presenters: David Aronchick, Microsoft.
+{{% /blocks/content-item %}}
+
 {{% blocks/content-item title="Machine Learning as Code: and Kubernetes with Kubeflow"
   date="December 15, 2018"
   url_text="Watch"


### PR DESCRIPTION
This is in response to the issue at https://github.com/kubeflow/kubeflow/issues/4904

I have added the videos to the list, in reverse chronological order. I have removed the start times from the URLs, as I think these may have been a mistake.