### PR TITLE
Private GKE: Document image mirroring

### DIFF
--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -237,8 +237,8 @@ Since private GKE can only access gcr.io, we need to mirror all images outside g
 
 1. Edit the couldbuild.yaml file
 
-    1. in the `images` section add
-
+    1. In the `images` section add
+    
          ```
           - <registry domain>/<project_id>/docker.io/istio/proxy_init:1.1.6
          ```
@@ -285,7 +285,7 @@ Since private GKE can only access gcr.io, we need to mirror all images outside g
 
 {{% alert title="Coming Soon" color="warning" %}}
 You can follow the issue: [Documentation on how to use Kubeflow with private GKE and VPC service controls](https://github.com/kubeflow/website/issues/1705)
-
+{{% /alert %}}
 
 ## Next steps
 

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -237,6 +237,9 @@ Since private GKE can only access gcr.io, we need to mirror all images outside g
     ./kfctl alpha mirror build mirror.yaml -V -o pipeline.yaml --gcb
     ```
 
+    * If you want to use Tekton rather than Google Cloud Build(GCB) drop `--gcb` to emit a Tekton pipeline
+    * The instructions below assume you are using GCB
+
 1. Edit the couldbuild.yaml file
 
     1. In the `images` section add

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -227,43 +227,43 @@ Since private GKE can only access gcr.io, we need to mirror all images outside g
 
 1. Inside your `${KFAPP}` directory create a local configuration file `mirror.yaml`  based on this [template](https://github.com/kubeflow/manifests/blob/master/experimental/mirror-images/gcp_template.yaml)
 
-   * Change destination to your project gcr registry.
+    1. Change destination to your project gcr registry.
 
-1.  Generate pipeline files to mirror images by running
-
-   ```
-   cd ${KFAPP}
-   ./kfctl alpha mirror build mirror.yaml -V -o pipeline.yaml --gcb
-   ```
+1. Generate pipeline files to mirror images by running
+    
+    ```
+    cd ${KFAPP}
+    ./kfctl alpha mirror build mirror.yaml -V -o pipeline.yaml --gcb
+    ```
 
 1. Edit the couldbuild.yaml file
 
-   i. in the `images` section add
+    1. in the `images` section add
 
-      ```
-      - <registry domain>/<project_id>/docker.io/istio/proxy_init:1.1.6
-      ```
+        1. More 
+        ```
+        - <registry domain>/<project_id>/docker.io/istio/proxy_init:1.1.6
+        ```
 
-      * Replace `<registry domain>/<project_id>` with your registry
+        * Replace `<registry domain>/<project_id>` with your registry
 
-   i. Under `steps` section addd
+    1. Under `steps` section add
 
-      ```
-       - args:
-        - build
-        - -t
-        - <registry domain>/<project id>/docker.io/istio/proxy_init:1.1.6
-        - --build-arg=INPUT_IMAGE=docker.io/istio/proxy_init:1.1.6
-        - .
-        name: gcr.io/cloud-builders/docker
-        waitFor:
-        - '-'  
-      ```
-   i. Remove the mirroring of cos-nvidia-installer:fixed image. You don’t need it to be replicated because this image is privately available through GKE internal repo.
+        ```
+          - args:
+          - build
+          - -t
+          - <registry domain>/<project id>/docker.io/istio/proxy_init:1.1.6
+          - --build-arg=INPUT_IMAGE=docker.io/istio/proxy_init:1.1.6
+          - .
+          name: gcr.io/cloud-builders/docker
+          waitFor:
+          - '-'  
+        ```
+    1. Remove the mirroring of cos-nvidia-installer:fixed image. You don’t need it to be replicated because this image is privately available through GKE internal repo.
 
-      1. Remove the images from the `images` section
-      1. Remove it from the steps section
-
+        1. Remove the images from the `images` section
+        1. Remove it from the steps section
 
 1. Create a cloud build job to do the mirroring
 

--- a/content/docs/gke/private-clusters.md
+++ b/content/docs/gke/private-clusters.md
@@ -215,7 +215,6 @@ export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT} --format='value(proj
 
 ## Mirror Kubeflow Application Images
 
-
 Since private GKE can only access gcr.io, we need to mirror all images outside gcr.io for Kubeflow applications. We will use the `kfctl` tool to accomplish this.
 
 
@@ -240,30 +239,30 @@ Since private GKE can only access gcr.io, we need to mirror all images outside g
 
     1. in the `images` section add
 
-        1. More 
-        ```
-        - <registry domain>/<project_id>/docker.io/istio/proxy_init:1.1.6
-        ```
-
-        * Replace `<registry domain>/<project_id>` with your registry
+         ```
+          - <registry domain>/<project_id>/docker.io/istio/proxy_init:1.1.6
+         ```
+     
+        * Replace `<registry domain>/<project_id>` with your registry      
 
     1. Under `steps` section add
 
-        ```
-          - args:
-          - build
-          - -t
-          - <registry domain>/<project id>/docker.io/istio/proxy_init:1.1.6
-          - --build-arg=INPUT_IMAGE=docker.io/istio/proxy_init:1.1.6
-          - .
-          name: gcr.io/cloud-builders/docker
-          waitFor:
-          - '-'  
-        ```
+          ```
+            - args:
+            - build
+            - -t
+            - <registry domain>/<project id>/docker.io/istio/proxy_init:1.1.6
+            - --build-arg=INPUT_IMAGE=docker.io/istio/proxy_init:1.1.6
+            - .
+            name: gcr.io/cloud-builders/docker
+            waitFor:
+            - '-'  
+          ```
+
     1. Remove the mirroring of cos-nvidia-installer:fixed image. You don’t need it to be replicated because this image is privately available through GKE internal repo.
 
-        1. Remove the images from the `images` section
-        1. Remove it from the steps section
+          1. Remove the images from the `images` section
+          1. Remove it from the steps section
 
 1. Create a cloud build job to do the mirroring
 


### PR DESCRIPTION
* Add instructions for mirroring docker images to private repositories
  * Fix kubeflow/kubeflow#3210

* Delete instructions under private GKE and just link to the doc issue #1705

  * The instructions are outdated. Since managed certificates are used there
    should be no reason to need to update iap-ingress.yaml anymore.
    * Fix #1811

  * Most of the other instructions under the private GKE section are also
    very obsolete.