### PR TITLE
Added redirect for Minikube

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -90,7 +90,7 @@ docs/started/requirements/                    /docs/started/getting-started/
 # Restructured the getting-started and other-guides sections.
 /docs/started/getting-started-k8s/             /docs/started/k8s/
 /docs/started/getting-started-minikf/                      /docs/started/workstation/getting-started-minikf/
-/docs/started/getting-started-minikube/        /docs/started/workstation/minikube-linux/
+/docs/started/getting-started-minikube/                    /docs/started/workstation/minikube-linux/
 /docs/other-guides/virtual-dev/getting-started-minikf/     /docs/started/workstation/getting-started-minikf/
 /docs/started/getting-started-multipass/                   /docs/started/workstation/getting-started-multipass/
 /docs/other-guides/virtual-dev/getting-started-multipass/  /docs/started/workstation/getting-started-multipass/

--- a/content/_redirects
+++ b/content/_redirects
@@ -90,6 +90,7 @@ docs/started/requirements/                    /docs/started/getting-started/
 # Restructured the getting-started and other-guides sections.
 /docs/started/getting-started-k8s/             /docs/started/k8s/
 /docs/started/getting-started-minikf/                      /docs/started/workstation/getting-started-minikf/
+/docs/started/getting-started-minikube/        /docs/started/workstation/minikube-linux/
 /docs/other-guides/virtual-dev/getting-started-minikf/     /docs/started/workstation/getting-started-minikf/
 /docs/started/getting-started-multipass/                   /docs/started/workstation/getting-started-multipass/
 /docs/other-guides/virtual-dev/getting-started-multipass/  /docs/started/workstation/getting-started-multipass/


### PR DESCRIPTION
The Minikube page has moved to workstation subdirectory. 
Add redirect to avoid 404.

/assign @sarahmaddox 