### PR TITLE
Fixed broken link in serving-scaling-hpa

### DIFF
--- a/content/docs/components/serving/overview.md
+++ b/content/docs/components/serving/overview.md
@@ -117,7 +117,7 @@ KFServing and Seldon Core. A check mark (**&check;**) indicates that the system
         <td></td>
         <td>HPA</td>
         <td><b>&check;</b></td>
-        <td><b>&check;</b> <a href="https://docs.seldon.io/projects/seldon-core/en/latest/graph/autoscaling.html">docs</a></td>
+        <td><b>&check;</b> <a href="https://docs.seldon.io/projects/seldon-core/en/latest/graph/scaling.html#autoscaling-seldon-deployments">docs</a></td>
       </tr>
 
       <tr>


### PR DESCRIPTION
In https://www.kubeflow.org/docs/components/serving/overview/#multi-framework-serving-with-kfserving-or-seldon-core
![image](https://user-images.githubusercontent.com/52723717/79022713-7124b100-7b33-11ea-81c6-1247bbd354b0.png)

[doc](https://docs.seldon.io/projects/seldon-core/en/latest/graph/autoscaling.html) -> Pages does not exist