### PR TITLE
Remove space between [] and (url)

### DIFF
--- a/content/docs/started/workstation/minikube-linux.md
+++ b/content/docs/started/workstation/minikube-linux.md
@@ -226,7 +226,7 @@ pip install jupyter
 
 #### Step 3: Create a Docker ID
 In order to build docker images from your notebook, a docker registry is needed where the images will be stored.
-If you don't have a Docker ID, please follow [Docker Documentation] (https://docs.docker.com/docker-id/) to create one.
+If you don't have a Docker ID, please follow [Docker Documentation](https://docs.docker.com/docker-id/) to create one.
 
 
 #### Step 4: Create a namespace to run the MNIST on-prem notebook 


### PR DESCRIPTION
Ref : https://github.com/kubeflow/website/pull/1870
Remove the invalid space between [] and (url) which cause the following in upgraded Hugo and Docsy:

![image](https://user-images.githubusercontent.com/52723717/79165069-3b800200-7d97-11ea-9b55-ffb61adb2fef.png)

/assign @sarahmaddox 