### PR TITLE
Remove space between [] and (url) in TroubleShooting

### DIFF
--- a/content/docs/other-guides/troubleshooting.md
+++ b/content/docs/other-guides/troubleshooting.md
@@ -81,7 +81,7 @@ kubectl -n ${NAMESPACE} get pvc
   * Look for the status of "Bound"
   * PVC requests in "Pending" state indicate that the scheduler was unable to bind the required PVC. 
 
-If you have not configured [dynamic provisioning] (https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) for your cluster, including a default storage class, then you must create a [persistent volume] (https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for each of the PVCs.
+If you have not configured [dynamic provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/) for your cluster, including a default storage class, then you must create a [persistent volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for each of the PVCs.
 
 You can use the example below to create local persistent volumes:
 


### PR DESCRIPTION
Ref : #1870
Remove the invalid space between [] and (url) which cause the [following in upgraded Hugo and Docsy](https://deploy-preview-1870--competent-brattain-de2d6d.netlify.com/docs/other-guides/troubleshooting/#pods-stuck-in-pending-state):

![image](https://user-images.githubusercontent.com/52723717/79250561-a7b04380-7e33-11ea-9252-20723e006762.png)

/assign @sarahmaddox 