### PR TITLE
Specify a minimum version of Microk8s

### DIFF
--- a/content/docs/started/workstation/getting-started-multipass.md
+++ b/content/docs/started/workstation/getting-started-multipass.md
@@ -22,6 +22,8 @@ Here's a summary of the steps involved:
 1. Set up Microk8s
 2. Enable Kubeflow
 
+**Note:** the minimum version of Microk8s needed to enable Kubeflow is 1.18
+
 ### 1. Install and set up Microk8s
 
 Run the following commands to install and setup MicroK8s:


### PR DESCRIPTION
Adds a note about the minimum version of Microk8s required to the `Microk8s for Kubeflow` doc

Fixes #1717 