### PR TITLE
Update kfctl-istio-dex.md

### DIFF
--- a/content/docs/started/k8s/kfctl-istio-dex.md
+++ b/content/docs/started/k8s/kfctl-istio-dex.md
@@ -366,6 +366,7 @@ This section focuses on setting up Dex to authenticate with an existing LDAP dat
         <details>
         
         <summary>LDAP Seed Users and Groups</summary>
+        
         ```ldif
         # If you used the OpenLDAP Server deployment in step 1,
         # then this object already exists.


### PR DESCRIPTION
fix "LDAP Seed Users and Groups" dropdown

just one line break that caused the whole text to be rendered incorrectly, tutorial to seed users and groups cannot be followed properly.