### PR TITLE
Fixed the format in kfctl-k8s-istio

### DIFF
--- a/content/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/docs/started/k8s/kfctl-k8s-istio.md
@@ -108,26 +108,26 @@ deploy Kubeflow:
 
 1. Run the `kfctl build` command to set up your configuration:
 
-  ```
-  mkdir -p ${KF_DIR}
-  cd ${KF_DIR}
-  kfctl build -V -f ${CONFIG_URI}
-  ```
+    ```
+    mkdir -p ${KF_DIR}
+    cd ${KF_DIR}
+    kfctl build -V -f ${CONFIG_URI}
+    ```
 
 1. Edit the configuration files, as described in the guide to
   [customizing your Kubeflow deployment](/docs/other-guides/kustomize/).
 
 1. Set an environment variable pointing to your local configuration file:
 
-  ```
-  export CONFIG_FILE=${KF_DIR}/{{% config-file-k8s-istio %}}
-  ```
+    ```
+    export CONFIG_FILE=${KF_DIR}/{{% config-file-k8s-istio %}}
+    ```
 
 1. Run the `kfctl apply` command to deploy Kubeflow:
 
-  ```
-  kfctl apply -V -f ${CONFIG_FILE}
-  ```
+    ```
+    kfctl apply -V -f ${CONFIG_FILE}
+    ```
 
 ## Access the Kubeflow user interface (UI)
 


### PR DESCRIPTION
Ref issue #1891 
Fixed the format in[ ktctl-k8s-istio](https://www.kubeflow.org/docs/started/k8s/kfctl-istio-dex/#alternatively-set-up-your-configuration-for-later-deployment) caused by change to Goldmark renderer
![image](https://user-images.githubusercontent.com/52723717/79506917-a590e500-7feb-11ea-9e17-920e89451fcb.png)
