### PR TITLE
Removed space between [] (url) in ibm iks page

### DIFF
--- a/content/docs/ibm/iks-e2e.md
+++ b/content/docs/ibm/iks-e2e.md
@@ -9,7 +9,7 @@ This is a guide for an end-to-end example of Kubeflow on [IBM Cloud Kubernetes S
 ## Introduction
 ### Overview of IKS
 
-[IBM Cloud Kubernetes Service (IKS)] (https://cloud.ibm.com/docs/containers?topic=containers-getting-started) enables the deployment of containerized applications in Kubernetes clusters with specialized tools for management of the systems.
+[IBM Cloud Kubernetes Service (IKS)](https://cloud.ibm.com/docs/containers?topic=containers-getting-started) enables the deployment of containerized applications in Kubernetes clusters with specialized tools for management of the systems.
 
 The [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cloud-cli-getting-started) can be used for creating, developing, and deploying cloud applications.
 


### PR DESCRIPTION
Ref issue #1891 
Removed the space between [] (url) caused by the restriction of Goldmark renderer.

In https://www.kubeflow.org/docs/ibm/iks-e2e/#overview-of-iks
![image](https://user-images.githubusercontent.com/52723717/79597218-bcd8dc80-8096-11ea-9a29-27ffb9e0579a.png)
