### PR TITLE
Fixed typo in cluster_name to match the instruction

### DIFF
--- a/content/docs/ibm/install-kubeflow.md
+++ b/content/docs/ibm/install-kubeflow.md
@@ -34,7 +34,7 @@ environment variables.
 1.  Set `CLUSTER_NAME`, `CLUSTER_REGION`, and `CLUSTER_ZONE` variables:
 
     ```
-    export CLUSTER_NAME=Kubeflow
+    export CLUSTER_NAME=kubeflow
     export CLUSTER_REGION=us-south
     export CLUSTER_ZONE=dal13
     ```


### PR DESCRIPTION
In https://www.kubeflow.org/docs/ibm/install-kubeflow/#setting-environment-variables, the cluster_name is in uppercase that don't match the description.
![image](https://user-images.githubusercontent.com/52723717/79803131-3fbb9a80-8316-11ea-8039-f4f132386c63.png)

Use this PR to fix the typo in cluster_name to match the description.
