### PR TITLE
Fixed format in kfctl-istio-dex.md

### DIFF
--- a/content/en/docs/started/k8s/kfctl-istio-dex.md
+++ b/content/en/docs/started/k8s/kfctl-istio-dex.md
@@ -148,26 +148,26 @@ deploy Kubeflow:
 
 1. Run the `kfctl build` command to set up your configuration:
 
-  ```
-  mkdir -p ${KF_DIR}
-  cd ${KF_DIR}
-  kfctl build -V -f ${CONFIG_URI}
-  ```
+    ```
+    mkdir -p ${KF_DIR}
+    cd ${KF_DIR}
+    kfctl build -V -f ${CONFIG_URI}
+    ```
 
 1. Edit the configuration files, as described in the guide to
   [customizing your Kubeflow deployment](/docs/other-guides/kustomize/).
 
 1. Set an environment variable pointing to your local configuration file:
 
-  ```
-  export CONFIG_FILE=${KF_DIR}/kfctl_istio_dex.yaml
-  ```
+    ```
+    export CONFIG_FILE=${KF_DIR}/kfctl_istio_dex.yaml
+    ```
 
 1. Run the `kfctl apply` command to deploy Kubeflow:
 
-  ```
-  kfctl apply -V -f ${CONFIG_FILE}
-  ```
+    ```
+    kfctl apply -V -f ${CONFIG_FILE}
+    ```
 
 ## Accessing Kubeflow
 


### PR DESCRIPTION
Ref : issue #1891 

In https://www.kubeflow.org/docs/started/k8s/kfctl-istio-dex/#alternatively-set-up-your-configuration-for-later-deployment, the numbered list is borken by the new Goldmark renderer:
![image](https://user-images.githubusercontent.com/52723717/80238199-db008880-8612-11ea-86dc-9847d4c6b8c5.png)


