### PR TITLE
Removed space between [] (url) in other-guides/troubleshooting

### DIFF
--- a/content/en/docs/other-guides/troubleshooting.md
+++ b/content/en/docs/other-guides/troubleshooting.md
@@ -66,7 +66,7 @@ how RBAC interacts with IAM on GCP.
 
 ## Problems spawning Jupyter pods
 
-This section has been moved to [Jupyter Notebooks Troubleshooting Guide] (/docs/notebooks/troubleshoot/).
+This section has been moved to [Jupyter Notebooks Troubleshooting Guide](/docs/notebooks/troubleshoot/).
 
 
 ## Pods stuck in Pending state


### PR DESCRIPTION
Ref issue #1891 
Removed the space between [] (url) caused by the restriction of Goldmark renderer.

In https://www.kubeflow.org/docs/other-guides/troubleshooting/#problems-spawning-jupyter-pods

![image](https://user-images.githubusercontent.com/52723717/80542931-c7328a80-8962-11ea-92c4-e49403b00bb8.png)

/assign @sarahmaddox 