### PR TITLE
add a pointer to our example script of creating runs using pipeline

### DIFF
--- a/content/en/docs/pipelines/tutorials/sdk-examples.md
+++ b/content/en/docs/pipelines/tutorials/sdk-examples.md
@@ -82,3 +82,7 @@ find a pipeline's ID:
 <img src="/docs/images/sdk-examples-snapshot-1.png"
 alt="Pipeline ID in Summary Card"
 class="mt-3 mb-3 border border-info rounded">
+
+## Creating a run from a pipeline version using the SDK
+
+An example of creating a run from a pipeline version is at [Kubeflow Pipelines Github repository](https://github.com/kubeflow/pipelines/blob/master/tools/benchmarks/run_service_api.ipynb).

--- a/content/en/docs/pipelines/tutorials/sdk-examples.md
+++ b/content/en/docs/pipelines/tutorials/sdk-examples.md
@@ -83,6 +83,6 @@ find a pipeline's ID:
 alt="Pipeline ID in Summary Card"
 class="mt-3 mb-3 border border-info rounded">
 
-## Creating a run from a pipeline version using the SDK
+## Creating a run using a pipeline version
 
-An example of creating a run from a pipeline version is at [Kubeflow Pipelines Github repository](https://github.com/kubeflow/pipelines/blob/master/tools/benchmarks/run_service_api.ipynb).
+Examine the run_service_api.ipynb notebook to [learn more about creating a run using a pipeline version](https://github.com/kubeflow/pipelines/blob/master/tools/benchmarks/run_service_api.ipynb).


### PR DESCRIPTION
Add a pointer for users to find out an example on creating a run from a pipeline version. The code example is on github.

Fixes https://github.com/kubeflow/pipelines/issues/3249