### PR TITLE
Fixed broken link for katib/suggestion-nasrl dockerfile

### DIFF
--- a/content/en/docs/reference/images.md
+++ b/content/en/docs/reference/images.md
@@ -17,7 +17,7 @@ weight = 10
 | katib/suggestion-chocolate |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/chocolate/v1alpha3/Dockerfile> |
 | katib/suggestion-hyperopt |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/hyperopt/v1alpha3/Dockerfile> |
 | katib/suggestion-hyperband |     <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/hyperband/v1alpha3/Dockerfile> |
-| katib/suggestion-nasrl |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/nasrl/v1alpha3/Dockerfile> |
+| katib/suggestion-nasrl |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/nas/enas/v1alpha3/Dockerfile> |
 | katib/file-metricscollector |    <https://github.com/kubeflow/katib/blob/master/cmd/metricscollector/v1alpha3/file-metricscollector/Dockerfile> |
 | katib/tfevent-metricscollector |    <https://github.com/kubeflow/katib/blob/master/cmd/metricscollector/v1alpha3/tfevent-metricscollector/Dockerfile> |
 | datawire/ambassador    | <https://github.com/datawire/ambassador/blob/master/builder/Dockerfile> |


### PR DESCRIPTION
In https://www.kubeflow.org/docs/reference/images/

![image](https://user-images.githubusercontent.com/52723717/80644793-16d68c00-8a1f-11ea-8543-2c9035911991.png)


Dockerfile location for **katib/suggestion-nasrl**:
https://github.com/kubeflow/katib/blob/master/cmd/suggestion/nasrl/v1alpha3/Dockerfile
-> 404

This may be caused by recent directory/folder restructure in [PR 1143](https://github.com/kubeflow/katib/pull/1143)