### PR TITLE
Fixed broken link in about/style-guide

### DIFF
--- a/content/en/docs/about/style-guide.md
+++ b/content/en/docs/about/style-guide.md
@@ -302,7 +302,7 @@ image show up nicely on the page:
 To see some examples of styled images, take a look at the
 [OAuth setup page](/docs/gke/deploy/oauth-setup/).
 To see the markup, search for `.png` in the [page 
-source](https://raw.githubusercontent.com/kubeflow/website/master/content/docs/gke/deploy/oauth-setup.md).
+source](https://raw.githubusercontent.com/kubeflow/website/master/content/en/docs/gke/deploy/oauth-setup.md).
 
 For more help, see the guide to
 [Bootstrap image styling](https://getbootstrap.com/docs/4.0/content/images/)


### PR DESCRIPTION
In https://www.kubeflow.org/docs/about/style-guide/#style-your-images
![image](https://user-images.githubusercontent.com/52723717/80655193-e7ca1580-8a32-11ea-98a1-1346ddc6ea54.png)

page source -> https://raw.githubusercontent.com/kubeflow/website/master/content/docs/gke/deploy/oauth-setup.md
->404

It seems this is caused by restructure of the directory for translation: PR #1909 
