### PR TITLE
Removed space between [](url) in AWS storage page

### DIFF
--- a/content/en/docs/aws/storage.md
+++ b/content/en/docs/aws/storage.md
@@ -119,7 +119,7 @@ Use Amazon EFS as a notebook volume when you create Jupyter notebooks.
 
 ## Amazon FSx for Lustre
 
-Amazon FSx for Lustre provides a high-performance file system optimized for fast processing of workloads such as machine learning and high performance computing (HPC) workloads. [AWS FSx for Lustre CSI Driver] (https://github.com/kubernetes-sigs/aws-fsx-csi-driver) can help Kubernetes users easily leverage this service.
+Amazon FSx for Lustre provides a high-performance file system optimized for fast processing of workloads such as machine learning and high performance computing (HPC) workloads. [AWS FSx for Lustre CSI Driver](https://github.com/kubernetes-sigs/aws-fsx-csi-driver) can help Kubernetes users easily leverage this service.
 
 Lustre is another file system that supports `ReadWriteMany`. Once difference between Amazon EFS and Lustre is that Lustre could be used as training data caching layer using S3 as backend storage. You don't need to transfer data before using the volume. By default, the Amazon FSx CSI driver is not enabled and you need to follow steps to install it.
 


### PR DESCRIPTION
Ref issue #1891 
Removed the space between [] (url) caused by the restriction of Goldmark renderer.

In https://www.kubeflow.org/docs/aws/storage/#amazon-fsx-for-lustre:
![image](https://user-images.githubusercontent.com/52723717/80673447-20ceae00-8a64-11ea-8ec2-d869d02794e2.png)

/assign @sarahmaddox 