### PR TITLE
Fixed broken url in training/mpi page

### DIFF
--- a/content/en/docs/components/training/mpi.md
+++ b/content/en/docs/components/training/mpi.md
@@ -21,7 +21,7 @@ cd mpi-operator
 kubectl create -f deploy/mpi-operator.yaml
 ```
 
-Alternatively, follow the [getting started guide](docs/started/getting-started/) to deploy Kubeflow.
+Alternatively, follow the [getting started guide](https://www.kubeflow.org/docs/started/getting-started/) to deploy Kubeflow.
 
 An alpha version of MPI support was introduced with Kubeflow 0.2.0. You must be using a version of Kubeflow newer than 0.2.0.
 

--- a/content/en/docs/components/training/mpi.md
+++ b/content/en/docs/components/training/mpi.md
@@ -21,7 +21,7 @@ cd mpi-operator
 kubectl create -f deploy/mpi-operator.yaml
 ```
 
-Alternatively, follow the [getting started guide](https://www.kubeflow.org/docs/started/getting-started/) to deploy Kubeflow.
+Alternatively, follow the [getting started guide](/docs/started/getting-started/) to deploy Kubeflow.
 
 An alpha version of MPI support was introduced with Kubeflow 0.2.0. You must be using a version of Kubeflow newer than 0.2.0.
 


### PR DESCRIPTION
In https://www.kubeflow.org/docs/components/training/mpi/#installation:
![image](https://user-images.githubusercontent.com/52723717/80827826-30034800-8b99-11ea-9094-cd42b859df9d.png)

[getting started guide](https://www.kubeflow.org/docs/components/training/mpi/docs/started/getting-started/) -> 404