### PR TITLE
Add Service Management API to the list of APIs

### DIFF
--- a/content/en/docs/gke/deploy/project-setup.md
+++ b/content/en/docs/gke/deploy/project-setup.md
@@ -29,6 +29,7 @@ Follow these steps to set up your GCP project:
     * [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com)
     * [Identity and Access Management (IAM) API](https://console.cloud.google.com/apis/library/iam.googleapis.com)
     * [Deployment Manager API](https://console.cloud.google.com/apis/library/deploymentmanager.googleapis.com)
+    * [Service Management API](https://console.cloud.google.com/apis/api/servicemanagement.googleapis.com)
     * [Cloud Resource Manager API](https://console.developers.google.com/apis/library/cloudresourcemanager.googleapis.com)
     * [Cloud Filestore API](https://console.developers.google.com/apis/library/file.googleapis.com)
     * [AI Platform Training & Prediction API](https://console.developers.google.com/apis/library/ml.googleapis.com)


### PR DESCRIPTION
Service Management API was not in the list of APIs to be enabled. This is required for certificate provisioning for the endpoint URI. Solves #1985.