### PR TITLE
Add link to Katib SDK

### DIFF
--- a/content/en/docs/components/hyperparameter-tuning/overview.md
+++ b/content/en/docs/components/hyperparameter-tuning/overview.md
@@ -121,6 +121,8 @@ You can use the following interfaces to interact with Katib:
     Kubeflow cluster. Read about kubectl in the [Kubernetes 
     documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
+* Katib SDK. See the [Katib SDK documentation on GitHub](https://github.com/kubeflow/katib/tree/master/sdk/python).
+
 ## Katib concepts
 
 This section describes the terms used in Katib.


### PR DESCRIPTION
Part of: https://github.com/kubeflow/katib/issues/1211.

I added link to Katib SDK from website docs.

/assign @jlewi @gaocegege @johnugeorge 