### PR TITLE
Add Katib OWNERS file to documentation

### DIFF
--- a/content/en/docs/components/hyperparameter-tuning/OWNERS
+++ b/content/en/docs/components/hyperparameter-tuning/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - andreyvelich
+  - gaocegege
+  - johnugeorge


### PR DESCRIPTION
I added OWNERS file to HP tuning doc section.

/assign @jlewi 
/cc @gaocegege @johnugeorge 