### PR TITLE
Add Feast documentation to components

### DIFF
--- a/content/en/docs/components/feature-store/OWNERS
+++ b/content/en/docs/components/feature-store/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - woop

--- a/content/en/docs/components/feature-store/_index.md
+++ b/content/en/docs/components/feature-store/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Feature Store"
+description = "Feature storage, management, and serving"
+weight = 70
++++

--- a/content/en/docs/components/feature-store/_index.md
+++ b/content/en/docs/components/feature-store/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Feature Store"
-description = "Feature storage, management, and serving"
+description = "Feature storage, management, validation, and serving"
 weight = 70
 +++

--- a/content/en/docs/components/feature-store/getting-started.md
+++ b/content/en/docs/components/feature-store/getting-started.md
@@ -1,10 +1,10 @@
 +++
 title = "Getting started with Feast"
-description = "How to set up Feast"
+description = "How to set up Feast and walk through examples"
 weight = 20
 +++
 
-This page gets you started with Feast. This guide provides the necessary resources to install Feast alongside Kubeflow, desribes its usage with Kubeflow components, and provides examples that users can follow to test their setup.
+This page gets you started with Feast. This guide provides the necessary resources to install Feast alongside Kubeflow, describes its usage with Kubeflow components, and provides examples that users can follow to test their setup.
 
 For an overview of Feast, please read [Introduction to Feast](/docs/components/feature-store/overview/).
 

--- a/content/en/docs/components/feature-store/getting-started.md
+++ b/content/en/docs/components/feature-store/getting-started.md
@@ -4,7 +4,7 @@ description = "How to set up Feast and walk through examples"
 weight = 20
 +++
 
-This page gets you started with Feast. This guide provides the necessary resources to install Feast alongside Kubeflow, describes its usage with Kubeflow components, and provides examples that users can follow to test their setup.
+This guide provides the necessary resources to install [Feast](http://feast.dev/) alongside Kubeflow, describes the usage of Feast with Kubeflow components, and provides examples that users can follow to test their setup.
 
 For an overview of Feast, please read [Introduction to Feast](/docs/components/feature-store/overview/).
 

--- a/content/en/docs/components/feature-store/getting-started.md
+++ b/content/en/docs/components/feature-store/getting-started.md
@@ -8,14 +8,12 @@ This guide provides the necessary resources to install [Feast](http://feast.dev/
 
 For an overview of Feast, please read [Introduction to Feast](/docs/components/feature-store/overview/).
 
-## Install Kubeflow
+## Installing Feast with Kubeflow
 
 This guide assumes that you have a running Kubeflow cluster already. If you don't have Kubeflow installed, then head on over to the 
 [Kubeflow installation guide](/docs/started/getting-started/).
 
-## Installing Feast with Kubeflow
-
-Feast can be installed into a running Kubeflow deployment. The process of installing Feast into Kubernetes is documented in the [Deploying Feast into Kubernetes](https://docs.feast.dev/getting-started/deploying-feast/kubernetes) guide.
+Feast can be installed into a running Kubeflow deployment. The process of installing Feast into Kubernetes is documented in the [Deploying Feast into Kubernetes](https://docs.feast.dev/getting-started/deploying-feast/kubernetes) guide. Please follow this guide to install Feast into the same Kubernetes cluster as Kubeflow.
 
 ## Accessing Feast from Kubeflow
 

--- a/content/en/docs/components/feature-store/getting-started.md
+++ b/content/en/docs/components/feature-store/getting-started.md
@@ -1,0 +1,48 @@
++++
+title = "Getting started with Feast"
+description = "How to set up Feast"
+weight = 20
++++
+
+This page gets you started with Feast. This guide provides the necessary resources to install Feast alongside Kubeflow, desribes its usage with Kubeflow components, and provides examples that users can follow to test their setup.
+
+For an overview of Feast, please read [Introduction to Feast](/docs/components/feature-store/overview/).
+
+## Install Kubeflow
+
+This guide assumes that you have a running Kubeflow cluster already. If you don't have Kubeflow installed, then head on over to the 
+[Kubeflow installation guide](/docs/started/getting-started/)
+
+## Installing Feast with Kubeflow
+
+Feast can be installed into a running Kubeflow deployment. The process of installing Feast into Kubernetes is documented in the [Deploying Feast into Kubernetes](https://docs.feast.dev/getting-started/deploying-feast/kubernetes) guide.
+
+## Accessing Feast from Kubeflow
+
+Once Feast is installed within the same Kubernetes cluster as Kubeflow, users can access its APIs directly without any additional steps.
+
+Feast APIs can roughly be grouped in the following section
+* __Feature definition and management__: Feast provides both a [Python SDK](https://docs.feast.dev/getting-started/connecting-to-feast-1) and [CLI](https://docs.feast.dev/getting-started/connecting-to-feast-1) for interacting with [Feast Core](https://docs.feast.dev/user-guide/architecture#feast-core). Feast Core allows users to define and register features and entities and their associated metadata and schemas. The Python SDK is typically used from within a Jupyter notebook by end users to administer Feast, but ML teams also typically version control feature specifications in order to follow a GitOps approach.
+
+* __Model training__: The Feast Python SDK can be used to trigger the [creation of training datasets](https://docs.feast.dev/user-guide/feature-retrieval#3-historical-feature-retrieval) and generation of statistics through [Feast Serving](https://docs.feast.dev/user-guide/architecture#feast-serving). The most natural place to use this SDK is to create a training dataset as part of a [Kubeflow Pipeline](/docs/pipelines/pipelines-overview) prior to model training.
+
+* __Model serving__: Feast provides three different SDKs for [online feature serving](https://docs.feast.dev/user-guide/feature-retrieval#online-feature-retrieval), a [Python SDK](https://api.docs.feast.dev/python/), [Java SDK](https://javadoc.io/doc/dev.feast/feast-sdk), and [Go SDK](https://godoc.org/github.com/feast-dev/feast/sdk/go). These clients are used prior to inference with [Model Serving](/docs/pipelines/pipelines-overview) systems like KFServing, TFX, or Seldon. 
+
+All of the above clients interact with Feast through gRPC endpoints. These APIs allow users to directly interface with Feast without using any SDK, and allow for access from any client environment.
+
+## Examples
+
+Feast also comes with example notebooks that users can use to get up to speed.
+* [Introductory Notebook with Feast](https://nbviewer.jupyter.org/github/feast-dev/feast/blob/master/examples/basic/basic.ipynb)
+* [Telecom Churn Prediction with XGBoost and Feast](https://nbviewer.jupyter.org/github/feast-dev/feast/blob/master/examples/feast-xgboost-churn-prediction-tutorial/Telecom%20Customer%20Churn%20Prediction%20%28with%20Feast%20and%20XGBoost%29.ipynb)
+
+## Next steps
+
+* For more details on Feast concepts please see the [Feast documentation](https://docs.feast.dev/)
+
+* Please see our [changelog](https://github.com/feast-dev/feast/blob/master/CHANGELOG.md) and [roadmap](https://docs.feast.dev/roadmap) for new or upcoming functionality.
+
+* Please use [GitHub issues](https://github.com/feast-dev/feast/issues) for any feedback, issues, or feature requests.
+
+* If you would like to get involved with Feast, come and visit us in [#Feast](https://kubeflow.slack.com/archives/CE0L8T267) in the [Kubeflow Slack](https://join.slack.com/t/kubeflow/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ), or join our [community calls](https://docs.feast.dev/getting-help#community-call), [mailing list](https://docs.feast.dev/getting-help#mailing-list), or have a look at our [contribution process](https://docs.feast.dev/contributing/contributing) 
+

--- a/content/en/docs/components/feature-store/getting-started.md
+++ b/content/en/docs/components/feature-store/getting-started.md
@@ -11,7 +11,7 @@ For an overview of Feast, please read [Introduction to Feast](/docs/components/f
 ## Install Kubeflow
 
 This guide assumes that you have a running Kubeflow cluster already. If you don't have Kubeflow installed, then head on over to the 
-[Kubeflow installation guide](/docs/started/getting-started/)
+[Kubeflow installation guide](/docs/started/getting-started/).
 
 ## Installing Feast with Kubeflow
 
@@ -21,19 +21,19 @@ Feast can be installed into a running Kubeflow deployment. The process of instal
 
 Once Feast is installed within the same Kubernetes cluster as Kubeflow, users can access its APIs directly without any additional steps.
 
-Feast APIs can roughly be grouped in the following section
-* __Feature definition and management__: Feast provides both a [Python SDK](https://docs.feast.dev/getting-started/connecting-to-feast-1) and [CLI](https://docs.feast.dev/getting-started/connecting-to-feast-1) for interacting with [Feast Core](https://docs.feast.dev/user-guide/architecture#feast-core). Feast Core allows users to define and register features and entities and their associated metadata and schemas. The Python SDK is typically used from within a Jupyter notebook by end users to administer Feast, but ML teams also typically version control feature specifications in order to follow a GitOps approach.
+Feast APIs can roughly be grouped into the following sections:
+* __Feature definition and management__: Feast provides both a [Python SDK](https://docs.feast.dev/getting-started/connecting-to-feast-1) and [CLI](https://docs.feast.dev/getting-started/connecting-to-feast-1) for interacting with [Feast Core](https://docs.feast.dev/user-guide/architecture#feast-core). Feast Core allows users to define and register features and entities and their associated metadata and schemas. The Python SDK is typically used from within a Jupyter notebook by end users to administer Feast, but ML teams may opt to version control feature specifications in order to follow a GitOps based approach.
 
 * __Model training__: The Feast Python SDK can be used to trigger the [creation of training datasets](https://docs.feast.dev/user-guide/feature-retrieval#3-historical-feature-retrieval) and generation of statistics through [Feast Serving](https://docs.feast.dev/user-guide/architecture#feast-serving). The most natural place to use this SDK is to create a training dataset as part of a [Kubeflow Pipeline](/docs/pipelines/pipelines-overview) prior to model training.
 
 * __Model serving__: Feast provides three different SDKs for [online feature serving](https://docs.feast.dev/user-guide/feature-retrieval#online-feature-retrieval), a [Python SDK](https://api.docs.feast.dev/python/), [Java SDK](https://javadoc.io/doc/dev.feast/feast-sdk), and [Go SDK](https://godoc.org/github.com/feast-dev/feast/sdk/go). These clients are used prior to inference with [Model Serving](/docs/pipelines/pipelines-overview) systems like KFServing, TFX, or Seldon. 
 
-All of the above clients interact with Feast through gRPC endpoints. These APIs allow users to directly interface with Feast without using any SDK, and allow for access from any client environment.
+All of the above clients interact with Feast through gRPC endpoints ([Core](https://api.docs.feast.dev/grpc/feast.core.pb.html), [Serving](https://api.docs.feast.dev/grpc/feast.serving.pb.html)). These APIs allow users to directly interface with Feast services if they do not wish to use an SDK.
 
 ## Examples
 
 Feast also comes with example notebooks that users can use to get up to speed.
-* [Introductory Notebook with Feast](https://nbviewer.jupyter.org/github/feast-dev/feast/blob/master/examples/basic/basic.ipynb)
+* [Introductory Notebook for Feast](https://nbviewer.jupyter.org/github/feast-dev/feast/blob/master/examples/basic/basic.ipynb)
 * [Telecom Churn Prediction with XGBoost and Feast](https://nbviewer.jupyter.org/github/feast-dev/feast/blob/master/examples/feast-xgboost-churn-prediction-tutorial/Telecom%20Customer%20Churn%20Prediction%20%28with%20Feast%20and%20XGBoost%29.ipynb)
 
 ## Next steps

--- a/content/en/docs/components/feature-store/overview.md
+++ b/content/en/docs/components/feature-store/overview.md
@@ -7,7 +7,7 @@ weight = 10
 {{% alpha-status 
   feedbacklink="https://github.com/feast-dev/feast/issues" %}}
   
-Use Feast for defining, managing, discovering, validating, and serving features to your models during training and inference.
+Use [Feast](http://feast.dev/) for defining, managing, discovering, validating, and serving features to your models during training and inference.
 
 This page introduces feature store concepts as well as Feast as a component of Kubeflow.
 
@@ -15,39 +15,39 @@ This page introduces feature store concepts as well as Feast as a component of K
 
 Feature stores are systems that help to address some of the key challenges that ML teams face when productionizing features
 
-* __Feature sharing and reuse__: Engineering features is one of the most time consuming activities in building an end-to-end ML system, yet many teams continue to develop features in silos. This leads to a high amount of redevelopment and duplication of work across teams and projects.
+* __Feature sharing and reuse__: Engineering features is one of the most time consuming activities in building an end-to-end ML system, yet many teams continue to develop features in silos. This leads to a high amount of re-development and duplication of work across teams and projects.
 
-* __Serving features at scale__: Models need data that can come from a variety of sources, including event streams, data lakes, warehouses, or notebooks. ML teams need to be able to store and serve all these data sources to their models in a performant and reliable way. The challenge is scalably producing massive datasets of features for model training and providing access to real-time feature data at low latency and high throughput in serving.
+* __Serving features at scale__: Models need data that can come from a variety of sources, including event streams, data lakes, warehouses, or notebooks. ML teams need to be able to store and serve all these data sources to their models in a performant and reliable way. The challenge is scalably producing massive datasets of features for model training, and providing access to real-time feature data at low latency and high throughput in serving.
 
-* __Consistency between training and serving__: The separation between data scientists and engineering teams often lead to the redevelopment of feature transformations when moving from training to online serving. Inconsistencies that arise due to discrepancies between training and serving systems often leads to a drop in model performance in production.
+* __Consistency between training and serving__: The separation between data scientists and engineering teams often lead to the re-development of feature transformations when moving from training to online serving. Inconsistencies that arise due to discrepancies between training and serving implementations frequently leads to a drop in model performance in production.
 
 * __Point-in-time correctness__:  General purpose data systems are not built with ML use cases in mind and by extension don't provide point-in-time correct lookups of feature data. Without a point-in-time correct view of data, models are trained on datasets that are not representative of what is found in production, leading to a drop in accuracy.
 
-* __Data quality and validation__: Features are business critical inputs to ML systems. Teams need to ensure the quality of data that is served in production, and that they are informed if there is any drift in the underlying data during training or serving.
+* __Data quality and validation__: Features are business critical inputs to ML systems. Teams need to be confident in the quality of data that is served in production and need to be able to react when there is any drift in the underlying data.
 
 ## Feast as a feature store
 
-Feast is an open-source feature store that helps teams operate ML systems at scale by allowing them to define, manage, validate, and serve features to models in production. 
+[Feast](http://feast.dev/) is an [open-source](https://github.com/feast-dev/feast) feature store that helps teams operate ML systems at scale by allowing them to define, manage, validate, and serve features to models in production. 
 
 Feast provides the following functionality:
 
-* __Load streams and batch data__: Feast is built to be able to ingest data from a variety of bounded or unbounded sources. Feast allows users to ingest data from streams, object stores, databases, or notebooks. Data that is ingested into Feast is persisted in both online store and historical stores, which in turn is used for the creation of training datasets and serving features to online systems.
+* __Load streaming and batch data__: Feast is built to be able to ingest data from a variety of bounded or unbounded sources. Feast allows users to ingest data from streams, object stores, databases, or notebooks. Data that is ingested into Feast is persisted in both online store and historical stores, which in turn is used for the creation of training datasets and serving features to online systems.
 
-* __Standardized definitions__: Feast becomes the single source of truth for all feature data for all models within an organization. Teams are able to capture documentation, metadata, and metrics about features. This allows teams to communicate clearly about features, test features data, and determine if a feature is both safe and important to their use case. 
+* __Standardized definitions__: Feast becomes the single source of truth for all feature definitions and data within an organization. Teams are able to capture documentation, metadata, and metrics about features. This allows teams to communicate clearly about features, test feature data, and determine if a feature is both safe and relevant to their use cases. 
 
-* __Historical serving__: Features that are persisted in Feast can be retrieved through its feature serving APIs to produce training datasets. These datasets are built from any amount of sources in a point-in-time correct way, thus ensuring the quality and consistency of data reaching models.
+* __Historical serving__: Features that are persisted in Feast can be retrieved through its feature serving APIs to produce training datasets. Feast is able to produce massive training datasets that are agnostics of the data source that was used to ingest the data originally. Feast is also able to ensure point-in-time correctness when joining these data sources, which in turn ensures the quality and consistency of features reaching models.
 
-* __Online serving__: Feast also exposes low latency serving APIs for all data that has been ingested into the system. This allows all production ML systems to use Feast as the source of data when doing inference at scale.
+* __Online serving__: Feast exposes low latency serving APIs for all data that has been ingested into the system. This allows all production ML systems to use Feast as the primary data source when looking up real-time features.
 
-* __Consistency between training and serving__: Feast provides a consistent view of feature data through the use of a unified ingestion layer, unified serving API and canonical feature references. By building ML systems on feature references, teams abstract away the underlying data infrastructure and make it possible to safely move models between training and serving.
+* __Consistency between training and serving__: Feast provides a consistent view of feature data through the use of a unified ingestion layer, unified serving API and canonical feature references. By building ML systems on feature references, teams abstract away the underlying data infrastructure and make it possible to safely move models between training and serving without a drop in data consistency.
  
 * __Feature sharing and reuse__: Feast provides a discovery and metadata API that allows teams to track, share, and reuse features across projects. Feast also decouples the process of creating features from the process of consumption, meaning teams that start new projects can begin by simply consuming features that already exist in the store, instead of starting from scratch. 
 
-* __Statistics and validation__: Feast allows for the generation of statistics based on features within the systems. Feast has compatibility with TFDV, meaning statistics that are generated can be validated using TFDV by clients. Feast also allows teams to capture TFDV schemas as part of feature definitions, allowing domain experts to define data properties that can be used for validating in production.
+* __Statistics and validation__: Feast allows for the generation of statistics based on features within the systems. Feast has compatibility with TFDV, meaning statistics that are generated by Feast can be validated using TFDV. Feast also allows teams to capture TFDV schemas as part of feature definitions, allowing domain experts to define data properties that can be used for validating these features in other production settings like training, ingestion, or serving.
 
 ## Next steps
 
-Follow the [Getting Started with Feast](/docs/components/feature-store/getting-started/) guide to set up Feast and run walk through our tutorials.
+Please follow the [Getting Started with Feast](/docs/components/feature-store/getting-started/) guide to set up Feast and run walk through our tutorials.
 
 ## Resources
 

--- a/content/en/docs/components/feature-store/overview.md
+++ b/content/en/docs/components/feature-store/overview.md
@@ -51,6 +51,7 @@ Please follow the [Getting Started with Feast](/docs/components/feature-store/ge
 
 ## Resources
 
+* [Feast: Documentation](http://docs.feast.dev/)
 * [Feast: Source Code](https://github.com/feast-dev/feast)
 * [Google Cloud - Introducing Feast: An open source feature store for machine learning](https://cloud.google.com/blog/products/ai-machine-learning/introducing-feast-an-open-source-feature-store-for-machine-learning)
 * [Medium - Feast: Bridging ML Models and Data](https://blog.gojekengineering.com/feast-bridging-ml-models-and-data-efd06b7d1644)

--- a/content/en/docs/components/feature-store/overview.md
+++ b/content/en/docs/components/feature-store/overview.md
@@ -1,0 +1,57 @@
++++
+title = "Introduction to Feast"
+description = "Overview of Feast for feature storage, management, and serving"
+weight = 10
++++
+
+{{% alpha-status 
+  feedbacklink="https://github.com/feast-dev/feast/issues" %}}
+  
+Use Feast for defining, managing, discovering, validating, and serving features to your models during training and inference.
+
+This page introduces feature store concepts as well as Feast as a component of Kubeflow.
+
+## Introduction to feature stores
+
+Feature stores are systems that help to address some of the key challenges that ML teams face when productionizing features
+
+* __Feature sharing and reuse__: Engineering features is one of the most time consuming activities in building an end-to-end ML system, yet many teams continue to develop features in silos. This leads to a high amount of redevelopment and duplication of work across teams and projects.
+
+* __Serving features at scale__: Models need data that can come from a variety of sources, including event streams, data lakes, warehouses, or notebooks. ML teams need to be able to store and serve all these data sources to their models in a performant, and reliable way. The challenge is scalably producing massive datasets of features for model training and providing access to real-time feature data at low latency and high throughput in serving.
+
+* __Consistency between training and serving__: The separation between data scientists and engineering teams often lead to the redevelopment of feature transformations when moving from training to online serving. Inconsistencies that arise due to discrepancies between training and serving systems often leads to a drop in model performance in production.
+
+* __Point-in-time correctness__:  General purpose data systems are not built with ML use cases in mind and by extension don't provide point-in-time correct lookups of feature data. Without a point-in-time correct view of data, models are trained on datasets that are not representative of what is found in production, leading to a drop in accuracy.
+
+* __Data quality and validation__: Features are business critical inputs to ML systems. Teams need to ensure the quality of data that is served in production, and that they are informed if there is any drift in the underlying data during training or serving.
+
+## Feast as a feature store
+
+Feast is an open-source feature store that helps teams operate ML systems at scale by allowing them to define, manage, validate, and serve features to models in production. 
+
+Feast provides the following functionality:
+
+* __Load streams and batch data__: Feast is built to be able to ingest data from a variety of bounded or unbounded sources. Feast allows users to ingest data from streams, object stores, databases, or notebooks. Data that is ingested into Feast is persisted in both online store and historical stores, which in turn is used for the creation of training datasets and serving features to online systems.
+
+* __Standardized definitions__: Feast becomes the single source of truth for all feature data for all models within an organization. Teams are able to capture documentation, metadata, and metrics about features. This allows teams to communicate clearly about features, test features data, and determine if a feature is both safe and important to their use case. 
+
+* __Historical serving__: Features that are persisted in Feast can be retrieved through its feature serving APIs to produce training datasets. These datasets are build from any amount of sources in a point-in-time correct way, thus ensuring the quality and consistency of data reaching models.
+
+* __Online serving__: Feast also exposes low latency serving APIs for all data that has been ingested into the system. This allows all production ML systems to use Feast as the source of data when doing inference at scale.
+
+* __Consistency between training and serving__: Feast provides a consistent view of feature data through the use of a unified ingestion layer, unified serving API and canonical feature references. By building ML systems on feature references, teams abstract away the underlying data infrastructure and make it possible to safely move models between training and serving.
+ 
+* __Feature sharing and reuse__: Feast provides a discovery and metadata API that allows teams to track, share, and reuse features across projects. Feast also decouples the process of creating features from the process of consumption, meaning teams that start new projects can begin by simply consuming features that already exist in the store, instead of starting from scratch. 
+
+* __Statistics and validation__: Feast allows for the generation of statistics based on features within the systems. Feast has compatibility with TFDV, meaning statistics that are generated can be validated using TFDV by clients. Feast also allows teams to capture TFDV schemas as part of feature definitions, allowing domain experts to define data properties that can be used for validating in production.
+
+## Next steps
+
+Follow the [Getting Started with Feast](/docs/components/feature-store/getting-started/) guide to set up
+Feast and run walk through our tutorials.
+
+## Resources
+
+* [Feast: Source Code](https://github.com/feast-dev/feast)
+* [Google Cloud - Introducing Feast: An open source feature store for machine learning](https://cloud.google.com/blog/products/ai-machine-learning/introducing-feast-an-open-source-feature-store-for-machine-learning)
+* [Medium - Feast: Bridging ML Models and Data](https://blog.gojekengineering.com/feast-bridging-ml-models-and-data-efd06b7d1644)

--- a/content/en/docs/components/feature-store/overview.md
+++ b/content/en/docs/components/feature-store/overview.md
@@ -47,8 +47,7 @@ Feast provides the following functionality:
 
 ## Next steps
 
-Follow the [Getting Started with Feast](/docs/components/feature-store/getting-started/) guide to set up
-Feast and run walk through our tutorials.
+Follow the [Getting Started with Feast](/docs/components/feature-store/getting-started/) guide to set up Feast and run walk through our tutorials.
 
 ## Resources
 

--- a/content/en/docs/components/feature-store/overview.md
+++ b/content/en/docs/components/feature-store/overview.md
@@ -17,7 +17,7 @@ Feature stores are systems that help to address some of the key challenges that 
 
 * __Feature sharing and reuse__: Engineering features is one of the most time consuming activities in building an end-to-end ML system, yet many teams continue to develop features in silos. This leads to a high amount of redevelopment and duplication of work across teams and projects.
 
-* __Serving features at scale__: Models need data that can come from a variety of sources, including event streams, data lakes, warehouses, or notebooks. ML teams need to be able to store and serve all these data sources to their models in a performant, and reliable way. The challenge is scalably producing massive datasets of features for model training and providing access to real-time feature data at low latency and high throughput in serving.
+* __Serving features at scale__: Models need data that can come from a variety of sources, including event streams, data lakes, warehouses, or notebooks. ML teams need to be able to store and serve all these data sources to their models in a performant and reliable way. The challenge is scalably producing massive datasets of features for model training and providing access to real-time feature data at low latency and high throughput in serving.
 
 * __Consistency between training and serving__: The separation between data scientists and engineering teams often lead to the redevelopment of feature transformations when moving from training to online serving. Inconsistencies that arise due to discrepancies between training and serving systems often leads to a drop in model performance in production.
 
@@ -35,7 +35,7 @@ Feast provides the following functionality:
 
 * __Standardized definitions__: Feast becomes the single source of truth for all feature data for all models within an organization. Teams are able to capture documentation, metadata, and metrics about features. This allows teams to communicate clearly about features, test features data, and determine if a feature is both safe and important to their use case. 
 
-* __Historical serving__: Features that are persisted in Feast can be retrieved through its feature serving APIs to produce training datasets. These datasets are build from any amount of sources in a point-in-time correct way, thus ensuring the quality and consistency of data reaching models.
+* __Historical serving__: Features that are persisted in Feast can be retrieved through its feature serving APIs to produce training datasets. These datasets are built from any amount of sources in a point-in-time correct way, thus ensuring the quality and consistency of data reaching models.
 
 * __Online serving__: Feast also exposes low latency serving APIs for all data that has been ingested into the system. This allows all production ML systems to use Feast as the source of data when doing inference at scale.
 

--- a/content/en/docs/reference/version-policy.md
+++ b/content/en/docs/reference/version-policy.md
@@ -97,10 +97,17 @@ documentation for that application.
         </td>
         <td>Stable</td>
         <td>1.0.0</td>
-      </tr>
+      </tr>      
       <tr>
         <td><a href="/docs/components/training/chainer/">Chainer operator</a>
         (<a href="https://github.com/kubeflow/chainer-operator">GitHub</a>)
+        </td>
+        <td>Alpha</td>
+        <td></td>
+      </tr>      
+      <tr>
+        <td><a href="/docs/components/feature-store/overview">Feature store: Feast</a>
+        (<a href="https://github.com/feast-dev/feast">GitHub</a>)
         </td>
         <td>Alpha</td>
         <td></td>


### PR DESCRIPTION
Adds Feast as a component to Kubeflow. This is a first cut of documentation for 1.1

Fixes #1981 

The documentation roughly includes the following sections:
* Feature store concepts and introduction to Feast
* Getting started with Feast
    * Reference to Kubernetes installation guide
    * How Feast can be used with Kubeflow components
    * Links to examples
    * Links to other Feast resources