### PR TITLE
docs: Update kfp sdk version

### DIFF
--- a/content/en/docs/reference/version-policy.md
+++ b/content/en/docs/reference/version-policy.md
@@ -170,7 +170,7 @@ documentation for that application.
           (<a href="https://github.com/kubeflow/pipelines">GitHub</a>)
         </td>
         <td>Beta</td>
-        <td>0.2.0</td>
+        <td>0.2.5</td>
       </tr>
       <tr>
         <td><a href="/docs/components/multi-tenancy/">Profile 
@@ -249,7 +249,7 @@ one of the following Kubeflow SDKs and command-line interfaces
           (<a href="https://github.com/kubeflow/pipelines">GitHub</a>)
         </td>
         <td>Beta</td>
-        <td>{{% pipelines/latest-version %}}</td>
+        <td>0.2.5</td>
       </tr>
     </tbody>
   </table>

--- a/content/en/docs/reference/version-policy.md
+++ b/content/en/docs/reference/version-policy.md
@@ -249,7 +249,7 @@ one of the following Kubeflow SDKs and command-line interfaces
           (<a href="https://github.com/kubeflow/pipelines">GitHub</a>)
         </td>
         <td>Beta</td>
-        <td>0.2.0</td>
+        <td>{{% pipelines/latest-version %}}</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
/assign @joeliedtke 
Found a place with outdated kfp version number.

KFP 0.2.5 was used in KF 1.0.2