### PR TITLE
Docs for blueprints

### DIFF
--- a/content/en/docs/gke/deploy/delete-cli.md
+++ b/content/en/docs/gke/deploy/delete-cli.md
@@ -4,6 +4,12 @@ description = "Deleting Kubeflow from GCP using the command line interface (CLI)
 weight = 6
 +++
 
+{{% alert title="Out of date" color="warning" %}}
+This guide contains outdated information pertaining to Kubeflow 1.0. This guide
+needs to be updated for Kubeflow 1.1.
+{{% /alert %}}
+
+
 This page shows you how to use the CLI to delete a Kubeflow deployment on
 Google Cloud Platform (GCP).
 

--- a/content/en/docs/gke/deploy/delete-ui.md
+++ b/content/en/docs/gke/deploy/delete-ui.md
@@ -4,6 +4,11 @@ description = "Deleting Kubeflow using the Google Cloud Platform (GCP) Console"
 weight = 7
 +++
 
+{{% alert title="Out of date" color="warning" %}}
+This guide contains outdated information pertaining to Kubeflow 1.0. This guide
+needs to be updated for Kubeflow 1.1.
+{{% /alert %}}
+
 This page shows you how to delete your Kubeflow deployment using Deployment 
 Manager in the GCP Console.
 

--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -1,25 +1,24 @@
 +++
-title = "Deploy using CLI"
-description = "Instructions for using the CLI to deploy Kubeflow on Google Cloud Platform (GCP)"
+title = "Deploy using kubectl and kpt"
+description = "Instructions for using kubectl and kpt to deploy Kubeflow on Google Cloud Platform (GCP)"
 weight = 4
 +++
 
-This guide describes how to use the `kfctl` command line interface (CLI) to
-deploy Kubeflow on GCP. The command line deployment gives you more control over
-the deployment process and configuration than you get if you use the deployment 
-UI. If you're looking for a simpler deployment procedure, see how to deploy 
-Kubeflow [using the deployment UI](/docs/gke/deploy/deploy-ui).
+This guide describes how to use `kubectl` and [kpt](https://googlecontainertools.github.io/kpt/) to
+deploy Kubeflow on GCP.
 
 ## Before you start
 
 Before installing Kubeflow on the command line:
 
-1. Ensure you have installed the following tools:
-  
-   * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-   * [gcloud](https://cloud.google.com/sdk/). If you already have `gcloud`
-    installed, run `gcloud components update` to
-     get the latest version of all your installed Cloud SDK components.
+
+1. You must have created a management cluster and installed Config Connector. 
+
+   * If you don't have a management cluster follow the [instructions](../management-setup/)
+
+   * Your management cluster must have a namespace setup to administer the GCP project where
+Kubeflow will be deployed. Follow the [instructions](../management-setup/) to create
+one if you haven't already.
 
 1. If you're using
   [Cloud Shell](https://cloud.google.com/shell/), enable 
@@ -33,20 +32,35 @@ Before installing Kubeflow on the command line:
   to create OAuth credentials for [Cloud Identity-Aware Proxy (Cloud 
   IAP)](https://cloud.google.com/iap/docs/).
 
+
+### Install the required tools
+
+1. Install [gcloud](https://cloud.google.com/sdk/).
+
+1. Install gcloud components
+
+   ```
+   gcloud components install kpt anthoscli beta
+   gcloud components update
+   ```
+
+1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+   
+1. Install [yq](https://github.com/mikefarah/yq)
+
+   ```
+   GO111MODULE=on go get github.com/mikefarah/yq/v3
+   ```
+
+   * If you don't have go installed you can download
+     a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
+
+1. Follow these [instructions](https://cloud.google.com/service-mesh/docs/gke-install-new-cluster#download_the_installation_file) to
+   install istioctl
+
+
 <a id="prepare-environment"></a>
 ## Prepare your environment
-
-Follow these steps to download the kfctl binary for the Kubeflow CLI and set
-some handy environment variables:
-
-1. Download the kfctl {{% kf-latest-version %}} release from the
-  [kfctl releases page](https://github.com/kubeflow/kfctl/releases/tag/{{% kf-latest-version %}}).
-
-1. Unpack the tar ball:
-
-    ```
-    tar -xvf kfctl_{{% kf-latest-version %}}_<platform>.tar.gz
-    ```
 
 1. Log in. You only need to run this command once:
 
@@ -60,178 +74,101 @@ some handy environment variables:
     gcloud auth application-default login
     ```
 
-1. Configure gcloud default values for zone and project
+## Fetch packages using kpt
 
+1. Fetch the blueprint
+
+   ```
+   kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/kubeflow@master ./${KFDIR}
+   ```
+
+   * You can choose any name you would like for the directory ${KFDIR}
+
+1. Change to the kubeflow directory
+
+   ```
+   cd ${KFDIR}
+   ```
+
+1. Fetch Kubeflow manifests
+
+   ```
+   make get-pkg
+   ```
+
+  * This generates an error like the one below but you can ignore it;
+
+    ```  
+    kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
+    fetching package / from https://github.com/jlewi/manifests to upstream/manifests
+    Error: resources must be annotated with config.kubernetes.io/index to be written to files    
     ```
-    # Set your GCP project ID and the zone where you want to create 
-    # the Kubeflow deployment:
-    export PROJECT=<your GCP project ID>
-    export ZONE=<your GCP zone>
-
-    gcloud config set project ${PROJECT}    
-    gcloud config set compute/zone ${ZONE}
-    ```
-
-    * `kfctl` by default uses the gcloud defaults for zone and project
-    * You can override this by explicitly setting zone and project in your `KFDef`
-      file
-
-1. Select the KFDef spec to use as the basis for your deployment
-
-    ```
-    export CONFIG_URI="{{% config-uri-gcp-iap %}}"
-    ```
-
-1. Create environment variables containing the OAuth client ID and secret that you created earlier
-
-    ```
-    export CLIENT_ID=<CLIENT_ID from OAuth page>
-    export CLIENT_SECRET=<CLIENT_SECRET from OAuth page>
-    ```
-
-    * The CLIENT_ID and CLIENT_SECRET can be obtained from the Cloud Console by selecting
-      **APIs & Services -> Credentials**
-
-1. Pick a name **KF_NAME** for your Kubeflow deployment and directory for
-   your configuration.
-
-    ```
-    export KF_NAME=<your choice of name for the Kubeflow deployment>
-    export BASE_DIR=<path to a base directory>
-    export KF_DIR=${BASE_DIR}/${KF_NAME}
-    ```
-
-   * For example, your kubeflow deployment name might be 'my-kubeflow' or 'kf-test'.
-   * Set base directory where you want to store one or more Kubeflow deployments. 
-     For example, ${HOME}/kf_deployments.
-    
-1. (Optional) Add the kfctl binary to your path. If you don't add kfctl to your path, you must use the full path
-    each time you run kfctl.
-
-    ```
-    export PATH=$PATH:<path to your kfctl file>
-    ```
-Notes:
-
-* **${PROJECT}** - The project ID of the GCP project where you want Kubeflow 
-  deployed.
-* **${ZONE}** - The GCP zone where you want to create the Kubeflow deployment.
-  You can see a list of zones in the 
-  [Compute Engine documentation](https://cloud.google.com/compute/docs/regions-zones/#available).
-  If you plan to use accelerators, you must choose a zone that supports the
-  type you want. See the guide to 
-  [customizing your Kubeflow deployment](/docs/gke/customizing-gke/#gpu-config).
-* **${CONFIG_URI}** - The GitHub address of the configuration YAML file that
-  you want to use to deploy Kubeflow. For GCP deployments, the recommended
-  configuration is:
-
-  ```
-  {{% config-uri-gcp-iap %}}
-  ```
-
-    When you run `kfctl apply` or `kfctl build` (see the next step), kfctl creates
-    a local version of the configuration YAML file which you can further
-    customize if necessary.
-
-* **${KF_NAME}** - The name of your Kubeflow deployment.
-  If you want a custom deployment name, specify that name here.
-  For example,  `my-kubeflow` or `kf-test`.
-  The value of KF_NAME must consist of lower case alphanumeric characters or
-  '-', and must start and end with an alphanumeric character.
-  The value of this variable cannot be greater than 25 characters. It must
-  contain just a name, not a directory path.
-  You also use this value as directory name when creating the directory where 
-  your Kubeflow  configurations are stored, that is, the Kubeflow application 
-  directory. 
   
-* **${KF_DIR}** - The full path to your Kubeflow application directory.
+    * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) 
+
+## Configure Kubeflow
+
+There are certain parameters that you must define in order to configure how and where
+kubeflow is defined. These are described in the table below.
+
+kpt setter | Description |
+-----------|-------------|
+mgmt-ctxt | This is the name of the KUBECONFIG context for the management cluster; this kubecontext will be used to create CNRM resources for your Kubeflow deployment. **The context must set the namespace to the namespace in your CNRM cluster where you are creating CNRM resources for the managed project.**|
+gcloud.core.project| The project you want to deploy in |
+location | The zone or region you want to deploy in |
+gcloud.compute.region | The region you are deploying in |
+gcloud.compute.zone | The zone to use for zonal resources; must be in gcloud.compute.region |
+
+* Location can be a zone or a region depending on whether you want a regional cluster
+  
+  * Kubeflow pipelines currently doesn't work with regional deployments see [kubeflow/gcp-blueprints#6](https://github.com/kubeflow/gcp-blueprints/issues/6)
+
+* The **Makefile** contains a rule `set-values` with appropriate `kpt cfg` commands to set the values
+  of the parameters
+
+* You need to edit the makefile to set the parameters to the desired values.
+
+   * Note there are multiple invocations of `kpt cfg set` on different directories to
+     work around [GoogleContainerTools/kpt#541](https://github.com/GoogleContainerTools/kpt/issues/541)      
+
+* If you haven't previously created an OAuth client for IAP then follow
+  the [directions](https://www.kubeflow.org/docs/gke/deploy/oauth-setup/) to setup
+  your consent screen and oauth client. 
+
+  * Unfortunately [GKE's BackendConfig](https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig)
+    currently doesn't support creating [IAP OAuth clients programmatically](https://cloud.google.com/iap/docs/programmatic-oauth-clients).
+
+*  Set environment variables with OAuth Client ID and Secret for IAP
+
+   ```
+   export CLIENT_ID=<Your CLIENT_ID>
+   export CLIENT_SECRET=<Your CLIENT_SECRET>
+   ```
+
+* Invoke the make rule to set the kpt setters
+
+  ```
+  make set-values
+  ```
 
 <a id="set-up-and-deploy"></a>
-## Deploying Kubeflow
+## Deploy Kubeflow
 
-To deploy Kubeflow using the **default settings**,
-run the `kfctl apply` command:
+To deploy kubeflow just run
 
-```
-mkdir -p ${KF_DIR}
-cd ${KF_DIR}
-kfctl apply -V -f ${CONFIG_URI}
-```
+   ```
+   make apply
+   ```
 
-kfctl will try to populate the KFDef spec with various defaults automatically
+   * If resources can't be created because `webhook.cert-manager.io` is unavailable wait and
+     then rerun `make apply`
 
-  * **project** and **zone** will be set based on your gcloud config defaults
-  * the name for the deployment will be inferred from the directory ${KF_DIR}
-  * You can override these values by modifying your KFDef spec before running the `build` and `apply`
-    commands
-
-You can follow the instructions in the next section to override these defaults.
-
-## Customizing your Kubeflow deployment
-
-The process outlined in the previous step configures Kubeflow with various defaults. 
-You can follow the instructions below to have greater control.
-
-1. Download the KFDef file to your local directory to allow modifications
-
-    ```
-    mkdir -p ${KF_DIR}
-    cd ${KF_DIR}
-    curl -L -o ${CONFIG_FILE} {{% config-uri-gcp-iap %}}
-    ```
-
-    * **CONFIG_FILE** should be the name you would like to use for your local config file; e.g. "kfdef.yaml"
-
-1. Edit the KFDef spec in the yaml file. The following snippet shows you how to set values in the configuration file
-using [yq](https://github.com/mikefarah/yq/releases):
-
-    ```
-    yq w -i ${CONFIG_FILE} 'spec.plugins[0].spec.project' ${PROJECT}
-    yq w -i ${CONFIG_FILE} 'spec.plugins[0].spec.zone' ${ZONE}
-    yq w -i ${CONFIG_FILE} 'metadata.name' ${KF_NAME}
-    ```
-
-   * **PROJECT:** The GCP project to deploy in
-   * **ZONE:** The zone to deploy in
-   * **KF_NAME**: The name used for your deployment.
-
-1. Run the `kfctl build` command to generate kustomize and GCP Deployment manager configuration files for your deployment:
-
-    ```
-    cd ${KF_DIR}
-    kfctl build -V -f ${CONFIG_FILE}
-    ```
-
-1. To customize your GKE cluster modify the deployment manager configuration files
-   in the directory `${KF_DIR}/gcp_config`. 
-
-   * For more information refer to:
-     * [customizing your Kubeflow deployment](/docs/gke/customizing-gke/)
-     * [deployment manager docs](https://cloud.google.com/deployment-manager/docs).
-
-1. To customize individual Kubeflow applications modify the Kustomize manifests in the directory
-   `${KF_DIR}/kustomize`
-
-   * For more information please refer to the [kustomize docs](https://github.com/kubernetes-sigs/kustomize/tree/master/docs).
-
-1. Run the `kfctl apply` command to deploy Kubeflow:
-
-    ```
-    kfctl apply -V -f ${CONFIG_FILE}
-    ```
+     * This issue is being tracked in [kubeflow/manifests#1234](https://github.com/kubeflow/manifests/issues/1234)
+    
 
 ## Check your deployment
 
 Follow these steps to verify the deployment:
-
-1. The deployment process creates a separate deployment for your data storage. 
-   After running `kfctl apply` you should notice two new 
-   [deployments](https://console.cloud.google.com/dm/deployments):
-   * **{KF_NAME}-storage**: This deployment has persistent volumes for your
-     pipelines.
-   * **{KF_NAME}**: This deployment has all the components of Kubeflow, including 
-     a [GKE cluster](https://console.cloud.google.com/kubernetes/list) 
-     named **${KF_NAME}** with Kubeflow installed.
 
 1. When the deployment finishes, check the resources installed in the namespace
    `kubeflow` in your new cluster.  To do this from the command line, first set 
@@ -285,95 +222,69 @@ Notes:
   then you can configure this process to be much faster.
   See [kubeflow/kubeflow#731](https://github.com/kubeflow/kubeflow/issues/731).
 
+
+## Update Kubeflow
+
+To update Kubeflow
+
+1. Edit the Makefile and change `MANIFESTS_URL` to point at the version of Kubeflow manifests you
+   want to use
+
+   * Refer to the [kpt docs](https://googlecontainertools.github.io/kpt/reference/pkg/) for
+     more info about supported dependencies
+
+1. Update the local copies
+   
+   ```
+   make update
+   ```
+
+1. Redeploy
+
+   ```
+   make apply
+   ```
+
+To evaluate the changes before deploying them you can run `make hydrate` and then compare the contents
+of `.build` to what is currently deployed.
+
 ## Understanding the deployment process
 
 This section gives you more details about the kfctl configuration and 
 deployment process, so that you can customize your Kubeflow deployment if
 necessary.
 
-### kfctl process and configuration
-
-The kfctl deployment process includes the following commands:
-
-* `kfctl build` - (Optional) Creates configuration files defining the various 
-  resources in your deployment. You only need to run `kfctl build` if you want 
-  to edit the resources before running `kfctl apply`. See the guide to
-  [customizing your Kubeflow deployment](/docs/gke/customizing-gke/).
-* `kfctl apply` - Creates or updates the resources.
-* `kfctl delete` - Deletes the resources.
-
-The kfctl deployment process applies default values to certain properties
-as follows:
-
-* **Email address:** kfctl attempts to fetch your email address from your
-  Cloud SDK configuration. You can run `gcloud config list` to see the default 
-  email address, which the command output lists as the **account**.
-  If kfctl can't find a valid email address, you must use the
-  flag `--email <your email address>` to pass a valid email address. This email 
-  address becomes an administrator in the configuration of your Kubeflow 
-  deployment.
-
-* **GCP project ID:** kfctl attempts to fetch your project ID from your
-  Cloud SDK configuration. You can run `gcloud config list` to see your 
-  active project ID.
-
-* **GCP zone:** kfctl attempts to fetch the zone from your Cloud SDK
-  configuration. You can run `gcloud config list` to see your active zone.
-
-* **Kubeflow deployment name:** kfctl defaults to the name of the directory
-  where you run the `kfctl build` or `kfctl apply` command.
-
-You can also explicitly set the following values in your `${CONFIG_FILE}`
-configuration file:
-
-* Kubeflow deployment name
-* GCP project
-* GCP zone
-* Email address
-
-
-The following snippet shows you how to set values in the configuration file
-using [yq](https://github.com/mikefarah/yq/releases):
-
-```
-yq w -i ${CONFIG_FILE} 'spec.plugins[0].spec.project' ${PROJECT}
-yq w -i ${CONFIG_FILE} 'spec.plugins[0].spec.zone' ${ZONE}
-yq w -i ${CONFIG_FILE} 'metadata.name' ${KF_NAME}
-```
-
 ### Application layout
 
-Your Kubeflow application directory **${KF_DIR}** contains the following files and 
+Your Kubeflow application directory **${KFDIR}** contains the following files and 
 directories:
 
-* **${CONFIG_FILE}** is a YAML file that defines configurations related to your 
-  Kubeflow deployment.
+* **upstream** is a directory containing kustomize packages for deploying Kubeflow
 
-  * This file is a copy of the GitHub-based configuration YAML file that
-    you used when deploying Kubeflow: 
-    [kfctl_gcp_iap.v1.0.0.yaml]({{% config-uri-gcp-iap %}}).
-  * When you run `kfctl apply` or `kfctl build`, kfctl creates
-    a local version of the configuration file, **${CONFIG_FILE}**,
-    which you can further customize if necessary.
+  * This directory contains the upstream configurations on which your deployment
+    is based
+   
+* **instance** is a directory that defines overlays that are applied to the upstream
+  configurations in order to customize Kubeflow for your use case.
 
-* **gcp_config** is a directory that contains 
-  [Deployment Manager configuration files](https://cloud.google.com/deployment-manager/docs/configuration/) 
-  defining your GCP infrastructure.
+  * **gcp_config** is a kustomize package defining all the GCP resources needed for Kubeflow
+    using [Cloud Config Connector](https://cloud.google.com/config-connector/docs/overview)
 
-  * The directory is created when you run `kfctl build` or `kfctl apply`.
-  * You can modify these configurations to customize your GCP infrastructure.
-    After modifying a configuration, run `kfctl apply` again.
+    * You can edit this kustomize package in order to customize the GCP resources for 
+      your purposes
 
-* **kustomize** is a directory that contains the kustomize packages for Kubeflow 
-  applications. See 
-  [how Kubeflow uses kustomize](/docs/other-guides/kustomize/).
+  * **kustomize** contains kustomize packages for the various Kubernetes applications
+    to be installed on your Kubeflow cluster
 
-  * The directory is created when you run `kfctl build` or `kfctl apply`.
-  * You can customize the Kubernetes resources by modifying the manifests and 
-    running `kfctl apply` again.
+* **.build** is a directory that will contain the hydrated manifests outputted by
+  the `make` rules
 
-We recommend that you check in the contents of your **${KF_DIR}** directory
-into source control.
+### Source Control
+
+It is recommended that you check in your entire **${KFDIR}** into source control.
+
+Checking in **.build** is recommended so you can easily see differences in manifests before applying them.
+
 
 ### GCP service accounts
 
@@ -392,12 +303,6 @@ The service accounts are:
   account has the minimal permissions needed to send metrics and logs to 
   [Stackdriver](https://cloud.google.com/stackdriver/).
 
-## Basic authentication (deprecated)
-
-{{% alert title="No longer supported" color="warning" %}}
-Basic authentication is not supported in Kubeflow v1.0.0 and will be removed entirely in the
-next version. We highly recommend switching to deploying Kubeflow with IAP.
-{{% /alert %}}
 
 ## Next steps
 

--- a/content/en/docs/gke/deploy/deploy-ui.md
+++ b/content/en/docs/gke/deploy/deploy-ui.md
@@ -4,6 +4,11 @@ description = "Instructions for using the UI to deploy Kubeflow on Google Cloud 
 weight = 3
 +++
 
+{{% alert title="Out of date" color="warning" %}}
+This guide contains outdated information pertaining to Kubeflow 1.0. This guide
+needs to be updated for Kubeflow 1.1.
+{{% /alert %}}
+
 This page provides instructions for using the Kubeflow deployment web app to
 deploy Kubeflow on GCP. The deployment web app currently supports
 **Kubeflow {{% kf-deployment-ui-version %}}**.

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -1,0 +1,164 @@
++++
+title = "Management cluster setup"
+description = "Instructions for setting up a management cluster on (GCP)"
+weight = 3
++++
+
+This guide describes how to setup a management cluster which you will use to deploy one or more instances of Kubeflow.
+
+While the management cluster can be deployed in the same project as your Kubeflow cluster, typically you will want to deploy
+it in a separate project used for administering one or more Kubeflow instances.
+
+The management cluster is used to run [Cloud Config Connector](https://cloud.google.com/config-connector/docs/overview).
+
+Optionally, the cluster can be configured with [Anthos Config Managmenet](https://cloud.google.com/anthos-config-management/docs) 
+to manage GCP infrastructure using GitOps.
+
+## Install the required tools
+
+1. Install gcloud components
+
+   ```
+   gcloud components install kpt anthoscli beta
+   gcloud components update
+   ```
+
+## Setting up the management cluster
+
+
+1. Fetch the management blueprint
+
+   ```
+   kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/management@master ./
+   ```
+
+1. Fetch the upstream manifests
+
+   ```
+   cd ./management
+   make get-pkg
+   ```
+
+  * This generates an error like the one below but you can ignore it;
+
+    ```  
+    kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
+    fetching package / from https://github.com/jlewi/manifests to upstream/manifests
+    Error: resources must be annotated with config.kubernetes.io/index to be written to files    
+    ```
+  
+    * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) 
+
+1. Pick a name for the management cluster
+
+   ```
+   export MGMT_NAME=<some name>
+   ```
+
+1. Pick a location for the Kubeflow deployment
+
+   ```
+   export LOCATION=<zone or region>
+   export PROJECT=<project>   
+   ```
+
+1. Set the name for the management resources in the upstream kustomize package
+
+   ```
+   kpt cfg set ./upstream name ${MGMT_NAME}
+   ```
+
+1. Set the same names in the instance kustomize package defining patches
+
+   ```   
+   
+   kpt cfg set ./instance name ${MGMT_NAME} 
+   kpt cfg set ./instance location ${LOCATION}
+   kpt cfg set ./instance gcloud.core.project ${PROJECT}
+   ```
+
+   * This directory defines kustomize overlays applied to `upstream/management`
+
+   * The names of the CNRM resources need to be set in both the base 
+     package and the overlays
+
+1. Hydrate and apply the manifests to create the cluster
+
+   ```
+   make apply
+   ```
+
+1. Create a kubeconfig context for the cluster
+
+   ```
+   make create-ctxt
+   ```
+
+1. Install the CNRM system components
+
+   ```
+   make apply-kcc
+   ```
+
+### Setup KCC Namespace For Each Project
+
+You will configure Config Connector in [Namespaced Mode](https://cloud.google.com/config-connector/docs/concepts/installation-types#namespaced_mode). This means
+
+* There will be a separate namespace for each GCP project under management
+* CNRM resources will be created in the namespace matching the GCP project
+  in which the resource lives.
+* There will be multiple instances of the CNRM controller each managing
+  resources in a different namespace
+* Each CNRM controller can use a different K8s account which can be bound
+  through workload identity to a different GCP Service Account with permissions to manage the project
+
+For each project you want to setup follow the instructions below.
+
+1. Create a copy of the per namespace/project resources
+
+   ```
+   cp -r ./instance/cnrm-install-per-namespace ./instance/cnrm-install-${MANAGED_PROJECT}
+   ```
+1. Set the project to be mananged
+
+   ```
+   kpt cfg set ./instance/cnrm-install-${MANAGED_PROJECT} managed_project ${MANAGED_PROJECT}
+   ```
+
+1. Set the host project where kcc is running
+
+   ```
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} managed_gsa_name ${MANAGED_GSA_NAME}
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} host_project ${HOST_PROJECT}
+   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} host_id_pool ${HOST_PROJECT}.svc.id.goog
+   ```
+
+   * **MANAGED_SA_NAME** Name for the Google Service Account (GSA) to create to be used
+     with Cloud Config Connector to create resources in the managed project
+   * host_id_pool should be the workload identity pool used for the host project
+
+1. Apply this manifest to the mgmt cluster
+
+
+   ```
+   kubectl --context=${MGMTCTXT} apply -f ./instance/cnrm-install-${PROJECT}/per-namespace-components.yaml
+   ```
+
+1. Create the GSA and workload identity binding
+
+   ```
+   anthoscli apply --project=${MANAGED_PROJECT} -f ./instance/cnrm-install-${PROJECT}/service_account.yaml
+   ```
+
+1. anthoscli doesn't support IAMPolicyMember resources yet so we use this as a workaround
+   to make the newly created GSA an owner of the hosted project
+
+   ```
+   gcloud projects add-iam-policy-binding ${MANAGED_PROJECT} \
+    --member=serviceAccount:${MANAGED_GSA_NAME}@${MANAGED_PROJECT}.iam.gserviceaccount.com  \
+    --role roles/owner
+   ```
+
+## References
+
+[CNRM Reference Documentation](https://cloud.google.com/config-connector/docs/reference/resources) 


### PR DESCRIPTION
Initial docs for blueprints

* Update the CLI instructions to explain how to deploy Kubeflow using
  blueprints.

* Add a page for setting up the management cluster

* Add banners to some of the pages that still need to be updated indicating
  the docs are out of date.
* Related to kubeflow/website#1960