### PR TITLE
updated docs for self registration disable, resource quota spec sample, manage contributor manually

### DIFF
--- a/content/en/docs/components/multi-tenancy/getting-started.md
+++ b/content/en/docs/components/multi-tenancy/getting-started.md
@@ -110,6 +110,14 @@ Kubeflow {{% kf-latest-version %}} provides automatic profile creation:
   - The Kubeflow deployment process automatically creates a profile for the user
     performing the deployment. When the user access the Kubeflow central dashboard
     they see their profile in the dropdown list.
+  - The automatic profile creation can be disabled as part of the deployment by setting the registration-flow env variable to false. And an admin can manually create profiles per user or per project and add collaborators through YAML files. 
+   Modify the kustomize/centraldashboard/base/parama.env to set the registration variable to false
+   ```
+   clusterDomain=cluster.local
+   userid-header=kubeflow-userid
+   userid-prefix=
+   registration-flow=false
+   ```
   - When an authenticated user logs into the system and visits the central
     dashboard for the first time, they trigger a profile creation automatically.
       - A brief message introduces profiles: <img
@@ -137,11 +145,21 @@ spec:
   owner:
     kind: User
     name: userid@email.com   # replace with the email of the user
+  
+  resourceQuotaSpec:    # resource quota can be set optionally 
+   hard:  
+     cpu: "2"
+     memory: 2Gi
+     nvidia.com/gpu: "1"
+     persistentvolumeclaims: "1"
+     requests.storage: "5Gi"  
 ```
 Run the following command to create the corresponding profile resource:
 
 ```
 kubectl create -f profile.yaml
+
+kubectl apply -f profile.yaml  #if you are modifying the profile 
 ```
 
 The above command creates a profile named *profileName*. The profile owner is
@@ -160,7 +178,7 @@ The following resources are created as part of the profile creation:
     therefore access services in the namespace.
   - Namespace-scoped service-accounts *editor* and *viewer* to be used by
     user-created pods in the namespace.
-
+  - Namespace scoped resource quota limits will be placed.
 
 **Note**: Due to a one-to-one correspondence of profiles with Kubernetes
 namespaces, the terms *profile* and *namespace* are sometimes used interchangably in the
@@ -195,6 +213,8 @@ spec:
 Run the following command to apply the namespaces to the Kubernetes cluster:
 ```
 kubectl create -f profile.yaml
+
+kubectl apply -f profile.yaml  #if you are modifying the profiles
 ```
 
 This will create multiple profiles, one for each individual listed in the sections
@@ -265,3 +285,65 @@ profiles in the system along with their contributors.
 The contributors have access to all the Kubernetes resources in the
 namespace and can create notebook servers as well as access
 existing notebooks.
+
+## Managing contributors manually
+
+An administrator can manually add contributors to an existing profile as described below.
+
+Create a rolebinding.yaml file with the following content on your local machine:
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: userid@email.com   # replace with the email of the user from your Active Directory case sensitive
+  name: user-userid-email-com-clusterrole-edit
+  # Ex: if the user email is lalith.vaka@kp.org the name should be user-lalith-vaka-kp-org-clusterrole-edit
+  # Note: if the user email is Lalith.Vaka@kp.org from your Active Directory, the name should be user-lalith-vaka-kp-org-clusterrole-edit
+  namespace: profileName # replace with the namespace/profile name that you are adding contribbitors to
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-edit
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: userid@email.com   # replace with the email of the user from your Active Directory case sensitive
+```
+
+Create a servicerolebinding.yaml file with the following content on your local machine:
+
+```
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  annotations:
+    role: edit
+    user: userid@email.com   # replace with the email of the user from your Active Directory case sensitive
+  generation: 1
+  name: user-userid-email-com-clusterrole-edit 
+  # Ex: if the user email is lalith.vaka@kp.org the name should be user-lalith-vaka-kp-org-clusterrole-edit
+  # Note: if the user email is Lalith.Vaka@kp.org from your Active Directory, the name should be user-lalith-vaka-kp-org-clusterrole-edit
+  namespace: profileName # replace with the namespace/profile name that you are adding contribbitors to
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: ns-access-istio
+  subjects:
+  - properties:
+      request.headers[kubeflow-userid]: userid@email.com   # replace with the email of the user from your Active Directory case sensitive
+status: {}
+```
+
+Run the following command to create the corresponding contributor resources:
+
+```
+kubectl create -f rolebinding.yaml
+
+kubectl create -f servicerolebinding.yaml 
+```
+
+The above command adds a contributor *userid@email.com* to the profile named *profileName*. The contributor
+*userid@email.com* has view and modify access to that profile.


### PR DESCRIPTION
Updated the documentation for the following
1. How to disable self registration
2. Resource quota spec example as part of the create profile sample
3. Add contributors manually