### PR TITLE
Update install-kubeflow.md

### DIFF
--- a/content/en/docs/aws/deploy/install-kubeflow.md
+++ b/content/en/docs/aws/deploy/install-kubeflow.md
@@ -193,7 +193,7 @@ Traditional way to attach IAM policies to node group role is still working, feel
 
 ## Access Kubeflow central dashboard
 
-If you are using {{% config-uri-aws-cognito %}}, run following command to get Kubeflow service endpoint host name and copy link in browser.
+If you are using {{% config-uri-aws-cognito %}} , run following command to get Kubeflow service endpoint host name and copy link in browser.
 
 ```
 kubectl get ingress -n istio-system


### PR DESCRIPTION
The lack of space there includes "," to the URL, the result is this:
```
<a href="https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_aws_cognito.v1.0.2.yaml,">https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_aws_cognito.v1.0.2.yaml,</a>
```
closes #2038