### PR TITLE
Fix Minikube start commands

### DIFF
--- a/content/en/docs/started/workstation/minikube-linux.md
+++ b/content/en/docs/started/workstation/minikube-linux.md
@@ -81,7 +81,7 @@ rm minikube
 
 The following command starts Minikube with 6 CPUs, 12288 memory, 120G disk size: 
 ```
-minikube start --vm-driver=none --cpus 6 --memory 12288 --disk-size=120g --extra-config=apiserver.authorization-mode=RBAC --extra-config=kubelet.resolv-conf=/run/systemd/resolve/resolv.conf --extra-config kubeadm.ignore-preflight-errors=SystemVerification
+minikube start --vm-driver=none --cpus 6 --memory 12288 --disk-size=120g --extra-config=apiserver.authorization-mode=RBAC,Node --extra-config=kubelet.resolv-conf=/run/systemd/resolve/resolv.conf --extra-config kubeadm.ignore-preflight-errors=SystemVerification
 ```
 
 ## Installation of Kubeflow


### PR DESCRIPTION
As per Kubernetes v1.17.x and newer, should use "--extra-config=apiserver.authorization-mode=Node,RBAC" otherwise results in error: "writing Crisocket information: timed out waiting for the condition"