### PR TITLE
Fix management cluster setup instructions

### DIFF
--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -49,38 +49,21 @@ to manage GCP infrastructure using GitOps.
   
     * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) 
 
-1. Pick a name for the management cluster
+1. Open up the **Makefile** and edit the `set-values` rule to set values for the name, project, and location of your management; when you are done the section should look like
+
+   ```  
+    set-values: 
+    kpt cfg set ./instance name NAME
+    kpt cfg set ./instance location LOCATION
+    kpt cfg set ./instance gcloud.core.project PROJECT
+  
+    kpt cfg set ./upstream/management name NAME
+    kpt cfg set ./upstream/management location LOCATION
+    kpt cfg set ./upstream/management gcloud.core.project PROJECT
 
    ```
-   export MGMT_NAME=<some name>
-   ```
 
-1. Pick a location for the Kubeflow deployment
-
-   ```
-   export LOCATION=<zone or region>
-   export PROJECT=<project>   
-   ```
-
-1. Set the name for the management resources in the upstream kustomize package
-
-   ```
-   kpt cfg set ./upstream name ${MGMT_NAME}
-   ```
-
-1. Set the same names in the instance kustomize package defining patches
-
-   ```   
-   
-   kpt cfg set ./instance name ${MGMT_NAME} 
-   kpt cfg set ./instance location ${LOCATION}
-   kpt cfg set ./instance gcloud.core.project ${PROJECT}
-   ```
-
-   * This directory defines kustomize overlays applied to `upstream/management`
-
-   * The names of the CNRM resources need to be set in both the base 
-     package and the overlays
+   * Where **NAME**, **LOCATION**, **PROJECT** should be the actual values for your deployment
 
 1. Hydrate and apply the manifests to create the cluster
 
@@ -94,69 +77,34 @@ to manage GCP infrastructure using GitOps.
    make create-ctxt
    ```
 
-1. Install the CNRM system components
+1. Install CNRM
 
    ```
    make apply-kcc
    ```
 
-### Setup KCC Namespace For Each Project
+   * This will install CNRM in your cluster
+   * It will create the GCP service account **${NAME}-cnrm-system@${PROJECT}.iam.gserviceaccount.com**
 
-You will configure Config Connector in [Namespaced Mode](https://cloud.google.com/config-connector/docs/concepts/installation-types#namespaced_mode). This means
+### Authorize CNRM for each project
 
-* There will be a separate namespace for each GCP project under management
-* CNRM resources will be created in the namespace matching the GCP project
-  in which the resource lives.
-* There will be multiple instances of the CNRM controller each managing
-  resources in a different namespace
-* Each CNRM controller can use a different K8s account which can be bound
-  through workload identity to a different GCP Service Account with permissions to manage the project
+In the last step we created the GCP service account **${NAME}-cnrm-system@${PROJECT}.iam.gserviceaccount.com**
+this is the service account that CNRM will use to create any GCP resources. Consequently
+you need to grant this GCP service account sufficient privileges to create the desired
+resources in one or more projects. 
 
-For each project you want to setup follow the instructions below.
+The easiest way to do this is to grant the GCP service account owner permissions on one or more projects
 
-1. Create a copy of the per namespace/project resources
+1. Set the managed project
 
    ```
-   cp -r ./instance/cnrm-install-per-namespace ./instance/cnrm-install-${MANAGED_PROJECT}
-   ```
-1. Set the project to be mananged
-
-   ```
-   kpt cfg set ./instance/cnrm-install-${MANAGED_PROJECT} managed_project ${MANAGED_PROJECT}
+   kpt cfg set ./instance managed-project ${MANAGED-PROJECT}
    ```
 
-1. Set the host project where kcc is running
+1. Update the policy
 
    ```
-   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} managed_gsa_name ${MANAGED_GSA_NAME}
-   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} host_project ${HOST_PROJECT}
-   kpt cfg set instance/cnrm-install-${MANAGED_PROJECT} host_id_pool ${HOST_PROJECT}.svc.id.goog
-   ```
-
-   * **MANAGED_SA_NAME** Name for the Google Service Account (GSA) to create to be used
-     with Cloud Config Connector to create resources in the managed project
-   * host_id_pool should be the workload identity pool used for the host project
-
-1. Apply this manifest to the mgmt cluster
-
-
-   ```
-   kubectl --context=${MGMTCTXT} apply -f ./instance/cnrm-install-${PROJECT}/per-namespace-components.yaml
-   ```
-
-1. Create the GSA and workload identity binding
-
-   ```
-   anthoscli apply --project=${MANAGED_PROJECT} -f ./instance/cnrm-install-${PROJECT}/service_account.yaml
-   ```
-
-1. anthoscli doesn't support IAMPolicyMember resources yet so we use this as a workaround
-   to make the newly created GSA an owner of the hosted project
-
-   ```
-   gcloud projects add-iam-policy-binding ${MANAGED_PROJECT} \
-    --member=serviceAccount:${MANAGED_GSA_NAME}@${MANAGED_PROJECT}.iam.gserviceaccount.com  \
-    --role roles/owner
+   anthoscli apply -f ./instance/managed-project/iam.yaml 
    ```
 
 ## References


### PR DESCRIPTION
* Instructions should reference the Makefile
* We will now install CNRM in workload identity mode not namespace mode
  per kubeflow/gcp-blueprints#13