### PR TITLE
Update oidc auth secret to match the 1.1 release in the IBM multi user doc

### DIFF
--- a/content/en/docs/ibm/deploy/install-kubeflow.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow.md
@@ -260,7 +260,8 @@ The scenario is a GitHub organization owner can authorize its organization membe
         - id: kubeflow-oidc-authservice
           redirectURIs: ["/login/oidc"]
           name: 'Dex Login Application'
-          secret: pUCnCOY80SnXgjibTYM0ZWNzY3xreNGQok
+          # Update the secret below to match with the oidc authservice.
+          secret: pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
     ```
     - Replace `clientID` and `clientSecret` in the `config.yaml` field with the `Client ID` and `Client Secret` created above for the GitHub OAuth application. Add your organization name to the `orgs` field, e.g.
     ```YAML


### PR DESCRIPTION
The oidc secret in the IBM multi user doc is not matching with the default oidc secret for the Kubeflow 1.1 release. Thus, updating the doc to have to correct default secret.

Secret reference: https://github.com/kubeflow/manifests/blob/master/stacks/ibm/application/oidc-authservice/kustomization.yaml#L20