### PR TITLE
doc: reduce confusion on reinstall instructions

### DIFF
--- a/content/en/docs/pipelines/installation/overview.md
+++ b/content/en/docs/pipelines/installation/overview.md
@@ -181,7 +181,7 @@ For instances **without** managed storage:
 For instances with managed storage:
 
 1. [Delete your AI Platform Pipelines instance](https://cloud.google.com/ai-platform/pipelines/docs/getting-started#clean_up).
-1. Reinstall Kubeflow Pipelines from the Google Cloud Marketplace using the same application name and managed storage options as before. You can freely install it in a different cluster or namespace, because persisted artifacts and database data are stored in managed storages (Google Cloud Storage and Cloud SQL), and will be automatically picked up during reinstallation.
+1. Reinstall Kubeflow Pipelines from the Google Cloud Marketplace using the same application name and managed storage options as before. You can freely install it in any cluster and namespace (not necessarily the same as before), because persisted artifacts and database data are stored in managed storages (Google Cloud Storage and Cloud SQL), and will be automatically picked up during reinstallation.
 
 Notes on specific features
 :


### PR DESCRIPTION
Reduce confusion in this question on slack: https://kubeflow.slack.com/archives/CE10KS9M4/p1596480791242800

> For instances with managed storage, is it required (or strongly recommended) that we delete the cluster ? Or is it fine to just delete the instance and reinstall into the existing cluster ?