### PR TITLE
Remove outdated banner for Katib docs

### DIFF
--- a/content/en/docs/components/hyperparameter-tuning/env-variables.md
+++ b/content/en/docs/components/hyperparameter-tuning/env-variables.md
@@ -4,10 +4,6 @@ description = "How to set up environment variables for each Katib component"
 weight = 50
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 This page describes information about environment variables for each Katib component. If you want to change Katib installation, you can modify some of these variables.
 

--- a/content/en/docs/components/hyperparameter-tuning/experiment.md
+++ b/content/en/docs/components/hyperparameter-tuning/experiment.md
@@ -4,10 +4,6 @@ description = "How to configure and run a hyperparameter tuning or neural archit
 weight = 30
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 This page describes in detail how to configure and run a Katib experiment.
 The experiment can perform hyperparameter tuning or a neural architecture search 

--- a/content/en/docs/components/hyperparameter-tuning/hyperparameter.md
+++ b/content/en/docs/components/hyperparameter-tuning/hyperparameter.md
@@ -4,10 +4,6 @@ description = "How to set up Katib and run some hyperparameter tuning examples"
 weight = 20
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 This page gets you started with Katib. Follow this guide to perform any
 additional setup you may need, depending on your environment, and to run a few

--- a/content/en/docs/components/hyperparameter-tuning/katib-config.md
+++ b/content/en/docs/components/hyperparameter-tuning/katib-config.md
@@ -4,10 +4,6 @@ description = "How to make changes in Katib configuration"
 weight = 40
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 This page describes information about [Katib config](https://github.com/kubeflow/katib/blob/master/manifests/v1alpha3/katib-controller/katib-config.yaml).
 

--- a/content/en/docs/components/hyperparameter-tuning/overview.md
+++ b/content/en/docs/components/hyperparameter-tuning/overview.md
@@ -4,10 +4,6 @@ description = "Overview of Katib for hyperparameter tuning and neural architectu
 weight = 10
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 {{% beta-status 
   feedbacklink="https://github.com/kubeflow/katib/issues" %}}

--- a/content/en/docs/reference/katib/v1alpha3/katib.md
+++ b/content/en/docs/reference/katib/v1alpha3/katib.md
@@ -4,14 +4,9 @@ description = "Reference documentation for Katib"
 weight = 100
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [api.proto](#apiproto)
   - [AlgorithmSetting](#algorithmsetting)
   - [AlgorithmSpec](#algorithmspec)


### PR DESCRIPTION
All Katib docs should be up to date for 1.1 release from 11th of June, see this: https://github.com/kubeflow/katib/issues/1211.


/cc @gaocegege @johnugeorge @jlewi 