### PR TITLE
Add OWNERS for reference docs

### DIFF
--- a/content/en/docs/reference/OWNERS
+++ b/content/en/docs/reference/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - andreyvelich
+  - gaocegege
+  - Jeffwan
+  - johnugeorge
+  - terrytangyuan

--- a/content/en/docs/reference/images.md
+++ b/content/en/docs/reference/images.md
@@ -22,7 +22,9 @@ needs to be updated for Kubeflow 1.1.
 | katib/suggestion-chocolate |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/chocolate/v1alpha3/Dockerfile> |
 | katib/suggestion-hyperopt |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/hyperopt/v1alpha3/Dockerfile> |
 | katib/suggestion-hyperband |     <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/hyperband/v1alpha3/Dockerfile> |
-| katib/suggestion-nasrl |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/nas/enas/v1alpha3/Dockerfile> |
+| katib/suggestion-enas |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/nas/enas/v1alpha3/Dockerfile> |
+| katib/suggestion-darts |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/nas/darts/v1alpha3/Dockerfile> |
+| katib/suggestion-goptuna |    <https://github.com/kubeflow/katib/blob/master/cmd/suggestion/goptuna/v1alpha3/Dockerfile> |
 | katib/file-metricscollector |    <https://github.com/kubeflow/katib/blob/master/cmd/metricscollector/v1alpha3/file-metricscollector/Dockerfile> |
 | katib/tfevent-metricscollector |    <https://github.com/kubeflow/katib/blob/master/cmd/metricscollector/v1alpha3/tfevent-metricscollector/Dockerfile> |
 | datawire/ambassador    | <https://github.com/datawire/ambassador/blob/master/builder/Dockerfile> |


### PR DESCRIPTION
I added OWNERS file for reference documentation since it contains some info about Training/Katib.

Also I updated Katib images.

/assign @joeliedtke @jlewi

/cc @gaocegege @terrytangyuan @Jeffwan @johnugeorge 