### PR TITLE
Update the Creating a private EKS clusters guide (AWS) for inclusive language

### DIFF
--- a/content/en/docs/aws/private-access.md
+++ b/content/en/docs/aws/private-access.md
@@ -17,7 +17,7 @@ aws eks update-cluster-config \
     --resources-vpc-config endpointPublicAccess=true,endpointPrivateAccess=true
 ```
 
-By default, this API server endpoint is public to the internet (`endpointPublicAccess=true`) , and access to the API server is secured using a combination of [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) and native Kubernetes [Role Based Access Control](https://kubernetes.io/docs/admin/authorization/rbac/) (`endpointPrivateAccess=false`).
+By default, this API server endpoint is public to the internet (`endpointPublicAccess=true`) , and access to the API server is secured using a combination of [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) and built-in Kubernetes [Role Based Access Control](https://kubernetes.io/docs/admin/authorization/rbac/) (`endpointPrivateAccess=false`).
 
 You can enable private access to the Kubernetes API server so that all communication between your worker nodes and the API server stays within your VPC (`endpointPrivateAccess=true`). You can also completely disable public access to your API server so that it's not accessible from the internet (`endpointPublicAccess=false`). In this case, you need to have an instance inside your VPC to talk with your Kubernetes API server.
 


### PR DESCRIPTION
Updated the Creating a private EKS clusters guide (AWS) for inclusive language:

* ~~Native~~ → Built-in

(Source: a presentation by @heyawhite—a Tech Writer at Google)