### PR TITLE
Update guides on Integrating Kubeflow with Rock, Microk8s on KF, a private EKS (AWS) for inclusive language

### DIFF
--- a/content/en/docs/aws/private-access.md
+++ b/content/en/docs/aws/private-access.md
@@ -17,7 +17,7 @@ aws eks update-cluster-config \
     --resources-vpc-config endpointPublicAccess=true,endpointPrivateAccess=true
 ```
 
-By default, this API server endpoint is public to the internet (`endpointPublicAccess=true`) , and access to the API server is secured using a combination of [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) and native Kubernetes [Role Based Access Control](https://kubernetes.io/docs/admin/authorization/rbac/) (`endpointPrivateAccess=false`).
+By default, this API server endpoint is public to the internet (`endpointPublicAccess=true`) , and access to the API server is secured using a combination of [AWS Identity and Access Management (IAM)](https://aws.amazon.com/iam/) and built-in Kubernetes [Role Based Access Control](https://kubernetes.io/docs/admin/authorization/rbac/) (`endpointPrivateAccess=false`).
 
 You can enable private access to the Kubernetes API server so that all communication between your worker nodes and the API server stays within your VPC (`endpointPrivateAccess=true`). You can also completely disable public access to your API server so that it's not accessible from the internet (`endpointPublicAccess=false`). In this case, you need to have an instance inside your VPC to talk with your Kubernetes API server.
 

--- a/content/en/docs/other-guides/integrations/data-management.md
+++ b/content/en/docs/other-guides/integrations/data-management.md
@@ -18,8 +18,8 @@ data management systems and processes.
 
 As a leading contributor to Kubeflow, Arrikto incorporates its standards-based,
 scale-out storage and data management solution (Rok) with Kubeflow. Arrikto's
-Rok presents a Kubernetes storage class to Kubeflow and natively integrates with
-the critical Kubeflow components. Rok’s native integration simplifies
+Rok presents a Kubernetes storage class to Kubeflow and integrates with
+the critical Kubeflow components. Rok’s built-in integration simplifies
 operations, boosts performance, and enables best practices for efficient data
 versioning, packaging, and secure sharing across teams and cloud boundaries.
 

--- a/content/en/docs/started/workstation/getting-started-multipass.md
+++ b/content/en/docs/started/workstation/getting-started-multipass.md
@@ -1,6 +1,6 @@
 +++
 title = "Microk8s for Kubeflow"
-description = "Quickly get Kubeflow running locally on native hypervisors"
+description = "Quickly get Kubeflow running locally on built-in hypervisors"
 weight = 60
                     
 +++
@@ -12,7 +12,7 @@ needs to be updated for Kubeflow 1.1.
 {{% alpha-status 
   feedbacklink="https://github.com/kubeflow/kubeflow/issues" %}}
 
-This document outlines the steps that you can take to get your local installation of Kubeflow running on top of Microk8s, a small enterprise Kubernetes cluster. Microk8s requires Linux; if you are not on a Linux system, you can use Multipass to create a Linux VM (virtual machine) on your native hypervisor.
+This document outlines the steps that you can take to get your local installation of Kubeflow running on top of Microk8s, a small enterprise Kubernetes cluster. Microk8s requires Linux; if you are not on a Linux system, you can use Multipass to create a Linux VM (virtual machine) on your built-in hypervisor.
 
 ## Introduction
 


### PR DESCRIPTION
Updated for inclusive language: ~~”Native”~~ → “Built-in”

- Guide: Integrating Kubeflow with Rock guide
- Guide: Microk8s for Kubeflow
- Guide: Creating a private EKS clusters (AWS)

(Source: an a11y presentation by @heyawhite—a Tech Writer at Google)

Thank you