### PR TITLE
Cleanup the root owners file.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -12,7 +12,6 @@ reviewers:
   - Jeffwan
   - jinchihe  
   - nickchase
-  - RFMVasconcelos
   - pdmack
   - terrytangyuan  
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,27 +1,18 @@
 approvers:
-  - jlewi
-  - joeliedtke
   - animeshsingh
+  - Bobgy
+  - joeliedtke
   - rmgogogo
 reviewers:
+  - 8bitmp3
   - aronchick
-  - carmine
-  - dansanche
-  - Jeffwan
-  - jinchihe
-  - lluunn
-  - nickchase
-  - pdmack
-  - terrytangyuan
-  - willingc
-  - dsdinter
-  - Ark-kun
-  - gaoning777
-  - hongye-sun
-  - IronPan
-  - neuromage 
-  - paveldournov
-  - qimingj
-  - rileyjbauer
   - berndverst
+  - dansanche
+  - dsdinter
+  - Jeffwan
+  - jinchihe  
+  - nickchase
+  - RFMVasconcelos
+  - pdmack
+  - terrytangyuan  
 


### PR DESCRIPTION
* Remove jlewi@ as an approver; I will no longer be actively reviewing
  miscellaneous doc changes
* Add @Bobgy  as another co-approver
* Add 8bitmp3 and RFMVasconcelos they are reviewing a lot of docs and
  working up to becoming approvers

* Prune the reviewers list so that PRs can be better autoassigned. We should
  arguably have OWNERs files in all subdirectories and rarely hit root owners
  file.
* Alphabetize the reviewers list