### PR TITLE
Add v1.0 to Kubeflow docs config.toml (v1.1 is the latest)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -171,6 +171,11 @@ githubbranch = "v1.1-branch"
   githubbranch = "v0.7-branch"
   url = "https://v0-7.kubeflow.org"
 
+[[params.versions]]
+  version = "v1.0"
+  githubbranch = "v1.0-branch"
+  url = "https://v1-0-branch.kubeflow.org"
+
 # Docsy: User interface configuration
 [params.ui]
 # Docsy: Enable to show the side bar menu in its compact state.


### PR DESCRIPTION
This PR updates Kubeflow docs' `config.toml` so the versions drop down shows the link to the 1.0 docs (v1.1 is the latest) @jlewi . Note that the link points to `https://v1-0-branch.kubeflow.org` (as per https://github.com/kubeflow/website/issues/1984#issuecomment-671375882).