### PR TITLE
add v1.1 install instructions to vanilla k8s

### DIFF
--- a/content/en/docs/started/k8s/kfctl-istio-dex.md
+++ b/content/en/docs/started/k8s/kfctl-istio-dex.md
@@ -4,10 +4,6 @@ description = "Instructions for installing Kubeflow with kfctl_istio_dex.yaml co
 weight = 4
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 Follow these instructions if you want to install Kubeflow on an existing Kubernetes cluster.
 

--- a/content/en/docs/started/k8s/kfctl-k8s-istio.md
+++ b/content/en/docs/started/k8s/kfctl-k8s-istio.md
@@ -4,10 +4,6 @@ description = "Instructions for installing Kubeflow on your existing Kubernetes 
 weight = 2
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 This configuration creates a vanilla deployment of Kubeflow with all its core components without any external dependencies. The deployment can be customized based on your environment needs.
 

--- a/layouts/shortcodes/config-file-istio-dex.html
+++ b/layouts/shortcodes/config-file-istio-dex.html
@@ -1,1 +1,1 @@
-kfctl_istio_dex.v1.0.2.yaml
+kfctl_istio_dex.yaml

--- a/layouts/shortcodes/config-file-istio-dex.html
+++ b/layouts/shortcodes/config-file-istio-dex.html
@@ -1,1 +1,1 @@
-kfctl_istio_dex.yaml
+kfctl_istio_dex.v1.1.0.yaml

--- a/layouts/shortcodes/config-file-k8s-istio.html
+++ b/layouts/shortcodes/config-file-k8s-istio.html
@@ -1,1 +1,1 @@
-kfctl_k8s_istio.v1.0.2.yaml
+kfctl_k8s_istio.yaml

--- a/layouts/shortcodes/config-file-k8s-istio.html
+++ b/layouts/shortcodes/config-file-k8s-istio.html
@@ -1,1 +1,1 @@
-kfctl_k8s_istio.yaml
+kfctl_k8s_istio.v1.1.0.yaml

--- a/layouts/shortcodes/config-uri-istio-dex.html
+++ b/layouts/shortcodes/config-uri-istio-dex.html
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_istio_dex.v1.0.2.yaml
+https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_istio_dex.yaml

--- a/layouts/shortcodes/config-uri-istio-dex.html
+++ b/layouts/shortcodes/config-uri-istio-dex.html
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_istio_dex.yaml
+https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_istio_dex.v1.1.0.yaml

--- a/layouts/shortcodes/config-uri-k8s-istio.html
+++ b/layouts/shortcodes/config-uri-k8s-istio.html
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.yaml
+https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.v1.1.0.yaml

--- a/layouts/shortcodes/config-uri-k8s-istio.html
+++ b/layouts/shortcodes/config-uri-k8s-istio.html
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/kubeflow/manifests/v1.0-branch/kfdef/kfctl_k8s_istio.v1.0.2.yaml
+https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.yaml


### PR DESCRIPTION
Release docs for Kubeflow v1.1: https://github.com/kubeflow/website/issues/1984