### PR TITLE
Create OWNERS for GKE docs

### DIFF
--- a/content/en/docs/gke/OWNERS
+++ b/content/en/docs/gke/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - Bobgy
+  - joeliedtke
+  - rmgogogo
+reviewers:
+  - 8bitmp3
+  - joeliedtke


### PR DESCRIPTION
I think this better route github reviewers and assignments to related people.