### PR TITLE
doc(gcp): fix deploy doc e2e

### DIFF
--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -68,12 +68,6 @@ one if you haven't already.
     gcloud auth login
     ```
 
-1. Create user credentials. You only need to run this command once:
-   
-    ```
-    gcloud auth application-default login
-    ```
-
 ## Fetch packages using kpt
 
 1. Fetch the blueprint

--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -131,6 +131,23 @@ gcloud.compute.zone | The zone to use for zonal resources; must be in gcloud.com
    * Note there are multiple invocations of `kpt cfg set` on different directories to
      work around [GoogleContainerTools/kpt#541](https://github.com/GoogleContainerTools/kpt/issues/541)      
 
+* You need to configure the kubectl context provided in `mgmt-ctxt`.
+
+  * Choose the management cluster context
+    ```bash
+    kubectl config use-context ${mgmt-ctxt}
+    ```
+
+  * Create a namespace in your management cluster for the managed project if you haven't done so.
+    ```bash
+    kubectl create namespace ${PROJECT}
+    ```
+
+  * Make the managed project's namespace default of the context:
+    ```bash
+    kubectl config set-context --current --namespace ${PROJECT}
+    ```
+
 * If you haven't previously created an OAuth client for IAP then follow
   the [directions](https://www.kubeflow.org/docs/gke/deploy/oauth-setup/) to setup
   your consent screen and oauth client. 

--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -55,7 +55,7 @@ one if you haven't already.
    * If you don't have go installed you can download
      a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
 
-1. Follow these [instructions](https://cloud.google.com/service-mesh/docs/gke-install-new-cluster#download_the_installation_file) to
+1. Follow these [instructions](https://cloud.google.com/service-mesh/docs/archive/1.4/docs/gke-install-new-cluster#preparing_to_install_anthos_service_mesh) to
    install istioctl
 
 

--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -45,6 +45,10 @@ one if you haven't already.
    ```
 
 1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+
+1. Install [Kustomize v3.2.1](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.2.1).
+
+    Note, Kubeflow is not compatible with later versions of Kustomize. Read [this GitHub issue](https://github.com/kubeflow/manifests/issues/538) for the latest status.
    
 1. Install [yq](https://github.com/mikefarah/yq)
 
@@ -55,9 +59,9 @@ one if you haven't already.
    * If you don't have go installed you can download
      a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
 
-1. Follow these [instructions](https://cloud.google.com/service-mesh/docs/archive/1.4/docs/gke-install-new-cluster#preparing_to_install_anthos_service_mesh) to
-   install istioctl
+1.  Follow the instructions from [Preparing to install Anthos Service Mesh](https://cloud.google.com/service-mesh/docs/archive/1.4/docs/gke-install-new-cluster#preparing_to_install_anthos_service_mesh) to install `istioctl`.
 
+    Note, the `istioctl` downloaded from above instructions is specific to Anthos Service Mesh. It is different from the `istioctl` you can download on https://istio.io/.
 
 <a id="prepare-environment"></a>
 ## Prepare your environment

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -65,6 +65,12 @@ to manage GCP infrastructure using GitOps.
 
    * Where **NAME**, **LOCATION**, **PROJECT** should be the actual values for your deployment
 
+1. Set the values
+
+   ```
+   make set-values
+   ```
+
 1. Hydrate and apply the manifests to create the cluster
 
    ```

--- a/content/en/docs/gke/deploy/oauth-setup.md
+++ b/content/en/docs/gke/deploy/oauth-setup.md
@@ -4,10 +4,6 @@ description = "Creating an OAuth client for Cloud IAP on Google Cloud Platform (
 weight = 2
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 If you want to use 
 [Cloud Identity-Aware Proxy (Cloud IAP)](https://cloud.google.com/iap/docs/) 
@@ -15,8 +11,6 @@ when deploying Kubeflow on GCP,
 then you must follow these instructions to create an OAuth client for use
 with Kubeflow.
 
-You can skip the instructions on this page if you want to use basic 
-authentication (username and password) with Kubeflow instead of Cloud IAP.
 Cloud IAP is recommended for production deployments or deployments with access 
 to sensitive data.
 

--- a/content/en/docs/gke/deploy/project-setup.md
+++ b/content/en/docs/gke/deploy/project-setup.md
@@ -60,7 +60,6 @@ Follow these steps to set up your GCP project:
     --data '' \
     https://meshconfig.googleapis.com/v1alpha1/projects/${PROJECT_ID}:initialize
   ```
-  
   Refer to [Anthos Service Mesh documentation](https://cloud.google.com/service-mesh/docs/archive/1.4/docs/gke-install-new-cluster#setting_credentials_and_permissions) for details.
 
 You do not need a running GKE cluster. The deployment process creates a


### PR DESCRIPTION
/assign @jlewi @joeliedtke 

Fixes https://github.com/kubeflow/website/issues/2123

changes:
* remove mentions of basic authentication
* add missing set-values
* istioctl download doc link update
* add instructions for configuring management cluster context
* `gcloud auth application-default login` is no longer required
* Clarified istioctl should be downloaded from anthos service mesh site
* We should use `kustomize v3.2.1`, later versions have a breaking change