### PR TITLE
Add link to AutoML WG Slack channel

### DIFF
--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -69,6 +69,7 @@ The Kubeflow Slack workspace offers several channels. Here are a few examples:
 | :---------------------------------------------------------------------------------------- | :------------------------------------------------------------------- |
 | General discussion                                                                        | [#general](https://kubeflow.slack.com/messages/C7REE0EHK)            |
 | Community meeting chat                                                                    | [#community](https://kubeflow.slack.com/messages/C8Q0QJYNB)          |
+| WG AutoML ([GitHub](https://github.com/kubeflow/community/tree/master/wgs/wg-automl))     | [#wg-automl](https://kubeflow.slack.com/archives/C018PMV53NW)        |
 | WG Training ([GitHub](https://github.com/kubeflow/community/tree/master/wgs/wg-training)) | [#wg-training](https://app.slack.com/client/T7QLHSH6U/C018N3M6QKB)   |
 | KFServing ([GitHub](https://github.com/kubeflow/kfserving))                               | [#kfserving](https://kubeflow.slack.com/messages/CH6E58LNP)          |
 | Pipelines ([GitHub](https://github.com/kubeflow/pipelines))                               | [#kubeflow-pipelines](https://kubeflow.slack.com/messages/CE10KS9M4) |


### PR DESCRIPTION
I added link to AutoML WG Slack channel in community page. 
I think it can be useful.

/assign @joeliedtke @8bitmp3

/cc @jlewi @gaocegege @johnugeorge 