### PR TITLE
Update setting the values step

### DIFF
--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -49,13 +49,14 @@ to manage GCP infrastructure using GitOps.
   
     * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) 
 
-1. Set the cluster **NAME**, **ZONE_OR_REGION**, **PROJECT_TO_DEPLOY_IN**
+1. Set the cluster **NAME**, **LOCATION**, **PROJECT**
 
    ```  
    kpt cfg set ./instance name <NAME>
    kpt cfg set ./instance location <ZONE_OR_REGION>
    kpt cfg set ./instance gcloud.core.project <PROJECT_TO_DEPLOY_IN>
    ```
+   * Where **NAME**, **LOCATION**, **PROJECT** should be the actual values for your deployment
 
 1. Hydrate and apply the manifests to create the cluster
 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -49,7 +49,7 @@ to manage GCP infrastructure using GitOps.
   
     * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) 
 
-1. Set the values **NAME**, **LOCATION**, **PROJECT** for the cluster
+1. Set the cluster **NAME**, **ZONE_OR_REGION**, **PROJECT_TO_DEPLOY_IN**
 
    ```  
     kpt cfg set ./instance name <NAME>

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -39,7 +39,7 @@ to manage GCP infrastructure using GitOps.
    make get-pkg
    ```
 
-  * This generates an error like the one below but you can ignore it;
+   * This generates an error like the one below but you can ignore it;
 
     ```  
     kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
@@ -49,21 +49,11 @@ to manage GCP infrastructure using GitOps.
   
     * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) 
 
-1. Open up the **Makefile** and edit the `set-values` rule to set values for the name, project, and location of your management; when you are done the section should look like
+1. Set the values **NAME**, **LOCATION**, **PROJECT** for the cluster
 
    ```  
-    set-values: 
-    kpt cfg set ./instance name NAME
-    kpt cfg set ./instance location LOCATION
-    kpt cfg set ./instance gcloud.core.project PROJECT
-  
-    kpt cfg set ./upstream/management name NAME
-    kpt cfg set ./upstream/management location LOCATION
-    kpt cfg set ./upstream/management gcloud.core.project PROJECT
-
+    NAME=<NAME> LOCATION=<ZONE_OR_REGION> PROJECT=<PROJECT> make set-values
    ```
-
-   * Where **NAME**, **LOCATION**, **PROJECT** should be the actual values for your deployment
 
 1. Hydrate and apply the manifests to create the cluster
 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -52,7 +52,9 @@ to manage GCP infrastructure using GitOps.
 1. Set the values **NAME**, **LOCATION**, **PROJECT** for the cluster
 
    ```  
-    NAME=<NAME> LOCATION=<ZONE_OR_REGION> PROJECT=<PROJECT> make set-values
+    kpt cfg set ./instance name <NAME>
+    kpt cfg set ./instance location <ZONE_OR_REGION>
+    kpt cfg set ./instance gcloud.core.project <PROJECT_TO_DEPLOY_IN>
    ```
 
 1. Hydrate and apply the manifests to create the cluster


### PR DESCRIPTION
What?
- Remove the make `set-values` rule step as it creates confusion of writing the same source of truth at multiple places.

Why?
- more user friendly

Additionally, fix the list step numbers.