### PR TITLE
Add OWNERs for about section

### DIFF
--- a/content/en/docs/about/OWNERS
+++ b/content/en/docs/about/OWNERS
@@ -1,6 +1,8 @@
 approvers:
+  - 8bitmp3
   - andreyvelich
   - gaocegege
   - Jeffwan
   - johnugeorge
+  - RFMVasconcelos
   - terrytangyuan

--- a/content/en/docs/about/OWNERS
+++ b/content/en/docs/about/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - andreyvelich
+  - gaocegege
+  - Jeffwan
+  - johnugeorge
+  - terrytangyuan

--- a/content/en/docs/about/OWNERS
+++ b/content/en/docs/about/OWNERS
@@ -4,5 +4,4 @@ approvers:
   - gaocegege
   - Jeffwan
   - johnugeorge
-  - RFMVasconcelos
   - terrytangyuan


### PR DESCRIPTION
See comment: https://github.com/kubeflow/website/pull/2120#issuecomment-672888785.

@gaocegege @terrytangyuan @johnugeorge @Jeffwan You wouldn't mind to be in the OWNERs file for about section?

/cc @jlewi 