### PR TITLE
Fix typo in overview

### DIFF
--- a/content/en/docs/components/hyperparameter-tuning/overview.md
+++ b/content/en/docs/components/hyperparameter-tuning/overview.md
@@ -29,7 +29,7 @@ not adjust the hyperparameter values.
 
 *Hyperparameter tuning* is the process of optimizing the hyperparameter values
 to maximize the predictive accuracy of the model. If you don't use Katib or a 
-similar system for hyperparameter tuning, you need run many training jobs 
+similar system for hyperparameter tuning, you need to run many training jobs 
 yourself, manually adjusting the hyperparameters to find the optimal values.
 
 Automated hyperparameter tuning works by optimizing a target variable, 


### PR DESCRIPTION
Added particle to change `you need run many training jobs` to `you need **to** run many training jobs`