### PR TITLE
Fix link for v1alpha3 Katib SDK

### DIFF
--- a/content/en/docs/components/hyperparameter-tuning/OWNERS
+++ b/content/en/docs/components/hyperparameter-tuning/OWNERS
@@ -2,3 +2,4 @@ approvers:
   - andreyvelich
   - gaocegege
   - johnugeorge
+  - sperlingxx

--- a/content/en/docs/components/hyperparameter-tuning/overview.md
+++ b/content/en/docs/components/hyperparameter-tuning/overview.md
@@ -122,7 +122,7 @@ You can use the following interfaces to interact with Katib:
     Kubeflow cluster. Read about kubectl in the [Kubernetes 
     documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
-* Katib SDK. See the [Katib SDK documentation on GitHub](https://github.com/kubeflow/katib/tree/master/sdk/python).
+* Katib SDK. See the [Katib SDK documentation on GitHub](https://github.com/kubeflow/katib/tree/master/sdk/python/v1alpha3).
 
 ## Katib concepts
 


### PR DESCRIPTION
After this PR: https://github.com/kubeflow/katib/pull/1252 we moved SDK for v1alpha3 under `sdk/python/v1alpha3` folder.
I fixed the link on the website to point for correct version.

Also, I added @sperlingxx to the OWNERS for Katib docs since he is helping us with developing.

/assign @sperlingxx @gaocegege @johnugeorge 

/cc @jlewi 