### PR TITLE
WIP: Update "Kubeflow on Linux" getting started page

### DIFF
--- a/content/en/docs/started/workstation/getting-started-linux.md
+++ b/content/en/docs/started/workstation/getting-started-linux.md
@@ -42,14 +42,6 @@ The only following applications are required to use MiniKF:
 The full set of instructions are available on the
 [MiniKF getting started](/docs/started/workstation/getting-started-minikf/) page.
 
-#### Kind
-
-[kind](https://kind.sigs.k8s.io/) is a tool for running local Kubernetes clusters using Docker container "nodes".
-kind was primarily designed for testing Kubernetes itself, but may be used for local development or CI.
-
-The full set of instructions are available on the
-[kind getting started](/docs/other-guides/virtual-dev/getting-started-kind/) page.
-
 ### Linux appliance
 
 A Linux appliance is a virtual machine that holds the linux operating system. From there


### PR DESCRIPTION
### TODOs:

1. Removing / Updating `Kind ` installation as there are no docs - #2141
2. Restructuring content: the page looks quite confusing, even though there are only 3 ways to deploy:
> - Microk8s (download or with multipass)
> - MiniKF
> - MiniKube

### Page now:
![image](https://user-images.githubusercontent.com/27001378/90672713-72d35380-e24e-11ea-8802-1b209bea343b.png)
