### PR TITLE
Parameterize default storageclass for ibm cloud

### DIFF
--- a/content/en/docs/ibm/deploy/install-kubeflow.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow.md
@@ -48,18 +48,18 @@ get the best experience from Kubeflow.
 
 3. Install the IBM Cloud Block Storage plug-in. When you install the plug-in, pre-defined block storage classes are added to your cluster.
     ```shell
-    helm install 1.6.0 iks-charts/ibmcloud-block-storage-plugin -n kube-system
+    helm install 1.7.0 iks-charts/ibmcloud-block-storage-plugin -n kube-system
     ```
     
     Example output:
     ```
-    NAME: 1.6.0
-    LAST DEPLOYED: Thu Feb 27 11:41:35 2020
+    NAME: 1.7.0
+    LAST DEPLOYED: Fri Aug 28 11:23:56 2020
     NAMESPACE: kube-system
     STATUS: deployed
     REVISION: 1
     NOTES:
-    Thank you for installing: ibmcloud-block-storage-plugin.   Your release is named: 1.6.0
+    Thank you for installing: ibmcloud-block-storage-plugin.   Your release is named: 1.7.0
     ...
     ```
 
@@ -75,10 +75,12 @@ get the best experience from Kubeflow.
 
 6. Set the Block Storage as the default storageclass.
     ```shell
-    kubectl patch storageclass ibmc-block-gold -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+    NEW_STORAGE_CLASS=ibmc-block-gold
+    OLD_STORAGE_CLASS=$(kubectl get sc | grep "(default)" | grep -v ${NEW_STORAGE_CLASS} | awk '{ print $1;exit }')
+    kubectl patch storageclass ${NEW_STORAGE_CLASS} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 
     # Check the default storageclass is block storage
-    kubectl get storageclass | grep \(default\)
+    kubectl get storageclass | grep "(default)"
     ```
 
     Example output:
@@ -86,10 +88,10 @@ get the best experience from Kubeflow.
     ibmc-block-gold (default)   ibm.io/ibmc-block   65s
     ```
 
-    Make sure `ibmc-block-gold` is the only `default` storageclass. If there are two or more rows in the above output, there is other `default` storageclass. Unset it with the below command, for example, will make the `ibmc-file-bronze` storage no longer the `default` storageclass for the cluster.
+    Make sure `ibmc-block-gold` is the only `default` storageclass. If there are two or more rows in the above output, there is other `default` storageclass. Unset it with the below command, for example, to remove the previous `default` storageclass for the cluster.
 
     ```shell
-    kubectl patch storageclass ibmc-file-bronze -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+    kubectl patch storageclass ${OLD_STORAGE_CLASS} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
     ```
 
 ## Understanding the Kubeflow deployment process

--- a/content/en/docs/ibm/deploy/install-kubeflow.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow.md
@@ -76,7 +76,7 @@ get the best experience from Kubeflow.
 6. Set the Block Storage as the default storageclass.
     ```shell
     NEW_STORAGE_CLASS=ibmc-block-gold
-    OLD_STORAGE_CLASS=$(kubectl get sc | grep "(default)" | grep -v ${NEW_STORAGE_CLASS} | awk '{ print $1;exit }')
+    OLD_STORAGE_CLASS=$(kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}')
     kubectl patch storageclass ${NEW_STORAGE_CLASS} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 
     # Check the default storageclass is block storage

--- a/content/en/docs/ibm/deploy/install-kubeflow.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow.md
@@ -16,7 +16,7 @@ This guide describes how to use the kfctl binary to deploy Kubeflow on IBM Cloud
   ibmcloud login
   ```
 
-* Create and access to a Kubernetes cluster on IKS
+* Create and access a Kubernetes cluster on IKS
 
   To deploy Kubeflow on IBM Cloud, you need a cluster running on IKS. If you don't have a cluster running, follow the [Create an IBM Cloud cluster](/docs/ibm/create-cluster) guide.
 
@@ -43,12 +43,14 @@ get the best experience from Kubeflow.
 1. [Follow the instructions](https://helm.sh/docs/intro/install/) to install the Helm version 3 client on your local machine.
 
 2. Add the IBM Cloud Helm chart repository to the cluster where you want to use the IBM Cloud Block Storage plug-in.
+
     ```shell
     helm repo add iks-charts https://icr.io/helm/iks-charts
     helm repo update
     ```
 
 3. Install the IBM Cloud Block Storage plug-in. When you install the plug-in, pre-defined block storage classes are added to your cluster.
+
     ```shell
     helm install 1.7.0 iks-charts/ibmcloud-block-storage-plugin -n kube-system
     ```
@@ -66,16 +68,19 @@ get the best experience from Kubeflow.
     ```
 
 4. Verify that the installation was successful.
+
     ```shell
     kubectl get pod -n kube-system | grep block
     ```
     
 5. Verify that the storage classes for Block Storage were added to your cluster.
+
     ```
     kubectl get storageclasses | grep block
     ```
 
 6. Set the Block Storage as the default storage class.
+
     ```shell
     NEW_STORAGE_CLASS=ibmc-block-gold
     OLD_STORAGE_CLASS=$(kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}')

--- a/content/en/docs/ibm/deploy/install-kubeflow.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow.md
@@ -73,13 +73,13 @@ get the best experience from Kubeflow.
     kubectl get storageclasses | grep block
     ```
 
-6. Set the Block Storage as the default storageclass.
+6. Set the Block Storage as the default storageclass. 
     ```shell
     NEW_STORAGE_CLASS=ibmc-block-gold
     OLD_STORAGE_CLASS=$(kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}')
     kubectl patch storageclass ${NEW_STORAGE_CLASS} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 
-    # Check the default storageclass is block storage
+    # List all the (default) storage classes
     kubectl get storageclass | grep "(default)"
     ```
 
@@ -88,8 +88,7 @@ get the best experience from Kubeflow.
     ibmc-block-gold (default)   ibm.io/ibmc-block   65s
     ```
 
-    Make sure `ibmc-block-gold` is the only `default` storageclass. If there are two or more rows in the above output, there is other `default` storageclass. Unset it with the below command, for example, to remove the previous `default` storageclass for the cluster.
-
+    Make sure `ibmc-block-gold` is the only `(default)` storage class. If there are two or more rows in the above output, unset the previous `(default)` storage classes with the below command:
     ```shell
     kubectl patch storageclass ${OLD_STORAGE_CLASS} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
     ```

--- a/content/en/docs/ibm/deploy/install-kubeflow.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow.md
@@ -1,6 +1,6 @@
 +++
 title = "Install Kubeflow"
-description = "Instructions for deploying Kubeflow with the shell"
+description = "Instructions for deploying Kubeflow on IBM Cloud"
 weight = 5
 +++
 
@@ -8,18 +8,20 @@ This guide describes how to use the kfctl binary to deploy Kubeflow on IBM Cloud
 
 ## Prerequisites
 
-* Authenticating with IBM Cloud
+* Authenticate with IBM Cloud
+
+  Log into IBM Cloud using the [IBM Cloud Command Line Interface (CLI)](https://www.ibm.com/cloud/cli) as follows:
 
   ```shell
   ibmcloud login
   ```
 
-* Accessing the IBM Cloud cluster
+* Create and access to a Kubernetes cluster on IKS
 
-  If you do not have access to a cluster created with IBM Cloud Kubernetes Service, follow the [Create an IBM Cloud cluster](/docs/ibm/create-cluster) guide to create a cluster.
+  To deploy Kubeflow on IBM Cloud, you need a cluster running on IKS. If you don't have a cluster running, follow the [Create an IBM Cloud cluster](/docs/ibm/create-cluster) guide.
 
-  Run following command to switch the Kubernetes context and access the cluster.
-
+  Run the following command to switch the Kubernetes context and access the cluster:
+  
   ```shell
   ibmcloud ks cluster config --cluster <cluster_name>
   ```
@@ -35,7 +37,7 @@ When using the `classic` worker nodes provider of IBM Cloud Kubernetes cluster, 
 [IBM Cloud Block Storage](https://www.ibm.com/cloud/block-storage) provides a fast way to store data and
 satisfy many of the Kubeflow persistent volume requirements such as `fsGroup` out of the box and optimized RWO (read-write single node) which is used on all Kubeflow's persistent volume claim. 
 
-Therefore, we strongly recommend to set up [IBM Cloud Block Storage](https://cloud.ibm.com/docs/containers?topic=containers-block_storage#add_block) as the default storage class so that you can
+Therefore, you're recommended to set up [IBM Cloud Block Storage](https://cloud.ibm.com/docs/containers?topic=containers-block_storage#add_block) as the default storage class so that you can
 get the best experience from Kubeflow.
 
 1. [Follow the instructions](https://helm.sh/docs/intro/install/) to install the Helm version 3 client on your local machine.

--- a/content/en/docs/ibm/deploy/install-kubeflow.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow.md
@@ -73,7 +73,7 @@ get the best experience from Kubeflow.
     kubectl get storageclasses | grep block
     ```
 
-6. Set the Block Storage as the default storageclass. 
+6. Set the Block Storage as the default storage class.
     ```shell
     NEW_STORAGE_CLASS=ibmc-block-gold
     OLD_STORAGE_CLASS=$(kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io\/is-default-class=="true")].metadata.name}')
@@ -88,7 +88,7 @@ get the best experience from Kubeflow.
     ibmc-block-gold (default)   ibm.io/ibmc-block   65s
     ```
 
-    Make sure `ibmc-block-gold` is the only `(default)` storage class. If there are two or more rows in the above output, unset the previous `(default)` storage classes with the below command:
+    Make sure `ibmc-block-gold` is the only `(default)` storage class. If there are two or more rows in the above output, unset the previous `(default)` storage classes with the command below:
     ```shell
     kubectl patch storageclass ${OLD_STORAGE_CLASS} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
     ```


### PR DESCRIPTION
For IBM Cloud IKS service, different machines such as classic and VCP have different default storageclass. Also, different Kubernetes version also have different storageclass due to the [recent IKS changes](https://cloud.ibm.com/docs/containers?topic=containers-kube_concepts#default_storageclass). Therefore, we want to parameterize the bash command to create a better user experience