### PR TITLE
Refer to the section where the deployment steps are described

### DIFF
--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -33,6 +33,9 @@ one if you haven't already.
   IAP)](https://cloud.google.com/iap/docs/).
 
 
+Refer to [Understanding the deployment process 
+](#understanding-the-deployment-process) for a description about the deployment steps and artifacts.
+
 ### Install the required tools
 
 1. Install [gcloud](https://cloud.google.com/sdk/).

--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -32,9 +32,8 @@ one if you haven't already.
   to create OAuth credentials for [Cloud Identity-Aware Proxy (Cloud
   IAP)](https://cloud.google.com/iap/docs/).
 
-
-Refer to [Understanding the deployment process 
-](#understanding-the-deployment-process) for a description about the deployment steps and artifacts.
+Refer to 
+[Understanding the deployment process](#understanding-the-deployment-process) for more information on the kfctl configuration and deployment process.
 
 ### Install the required tools
 


### PR DESCRIPTION
Valuable but hidden information. I think the description of the steps should be referred to from the top if not entirely moved there.