### PR TITLE
Kubeflow Getting Started: add approvers and reviewers to OWNERS

### DIFF
--- a/content/en/docs/started/OWNERS
+++ b/content/en/docs/started/OWNERS
@@ -4,3 +4,6 @@ approvers:
 
 reviewers:
   - Bobgy
+  - knkski 
+  - RFMVasconcelos
+  - 8bitmp3

--- a/content/en/docs/started/OWNERS
+++ b/content/en/docs/started/OWNERS
@@ -1,3 +1,4 @@
 approvers:
   - RFMVasconcelos
+  - 8bitmp3
   

--- a/content/en/docs/started/OWNERS
+++ b/content/en/docs/started/OWNERS
@@ -4,6 +4,4 @@ approvers:
 
 reviewers:
   - Bobgy
-  - knkski 
-  - RFMVasconcelos
-  - 8bitmp3
+  - knkski

--- a/content/en/docs/started/OWNERS
+++ b/content/en/docs/started/OWNERS
@@ -1,4 +1,6 @@
 approvers:
   - RFMVasconcelos
   - 8bitmp3
-  
+
+reviewers:
+  - Bobgy


### PR DESCRIPTION
This PR adds a second approver in `OWNERS` for the Getting Started section.

Currently, we have 1 approver (@RFMVasconcelos) and no reviewers.

@rmgogogo @joeliedtke @bobgy @animeshsingh - if you would like to volunteer to become, for example, a third approver or a 1st and 2nd reviewer, let us know! Thanks

/assign @rmgogogo @joeliedtke @bobgy @animeshsingh

