### PR TITLE
Remove issue GoogleContainerTools/kpt#539 from the docs (solved)

### DIFF
--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -94,16 +94,6 @@ one if you haven't already.
    make get-pkg
    ```
 
-  * This generates an error like the one below but you can ignore it;
-
-    ```
-    kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
-    fetching package / from https://github.com/jlewi/manifests to upstream/manifests
-    Error: resources must be annotated with config.kubernetes.io/index to be written to files
-    ```
-
-    * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539)
-
 ## Configure Kubeflow
 
 There are certain parameters that you must define in order to configure how and where

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -55,16 +55,6 @@ For a more detailed explanation of the changes affecting Kubeflow 1.1 on Google 
    make get-pkg
    ```
 
-  * This generates an error like the one below but you can ignore it;
-
-    ```  
-    kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
-    fetching package / from https://github.com/jlewi/manifests to upstream/manifests
-    Error: resources must be annotated with config.kubernetes.io/index to be written to files    
-    ```
-  
-    * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) 
-
 1. Open up the **Makefile** at `./management/Makefile` and edit the `set-values` rule to set values for the name, project, and location of your management; when you are done the section should look like
 
    ```  


### PR DESCRIPTION
Seems fixed:
https://github.com/GoogleContainerTools/kpt/issues/510 / https://github.com/kubernetes-sigs/kustomize/pull/2636

The issue described in the guide is not appearing anymore:

```
> cd ./management && make get-pkg
mkdir -p  ./upstream
kpt pkg get https://github.com/kubeflow/manifests.git/gcp/v2/management@1f948ed ./upstream/management
fetching package /gcp/v2/management from https://github.com/kubeflow/manifests to upstream/management
> echo $?
0
```