### PR TITLE
Updated management cluster instructions

### DIFF
--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -39,20 +39,7 @@ For a more detailed explanation of the changes affecting Kubeflow 1.1 on Google 
 
     **Note:** Kubeflow is not compatible with Kustomize versions above 3.2.1. Read [this GitHub issue](https://github.com/kubeflow/manifests/issues/538) for the latest status.
 
-1. Next, you'll be installing `yq`. Here are some options:
-
-    * Follow the [official instructions](https://github.com/mikefarah/yq#install).
-    
-    * Use Go:
-
-       1. Check that you have [Go](https://golang.org) installed by running the `go version`
-          command. If you don't, you can download a binary from
-          [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
-       2. Install yq by running the following command line:
-
-          ```
-          GO111MODULE=on go get github.com/mikefarah/yq/v3
-          ```
+1. Install [yq](https://github.com/mikefarah/yq#install).
  
 ## Setting up the management cluster
 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -39,16 +39,20 @@ For a more detailed explanation of the changes affecting Kubeflow 1.1 on Google 
 
     **Note:** Kubeflow is not compatible with Kustomize versions above 3.2.1. Read [this GitHub issue](https://github.com/kubeflow/manifests/issues/538) for the latest status.
 
-1. Next, you'll be installing [yq](https://github.com/mikefarah/yq):
+1. Next, you'll be installing `yq`. Here are some options:
 
-    1. Check that you have [Go](https://golang.org) installed by running the `go version`
-       command. If you don't, you can download a binary from
-       [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
-    2. Install yq by running the following command line:
+    * Follow the [official instructions](https://github.com/mikefarah/yq#install).
+    
+    * Use Go:
 
-       ```
-       GO111MODULE=on go get github.com/mikefarah/yq/v3
-       ```
+       1. Check that you have [Go](https://golang.org) installed by running the `go version`
+          command. If you don't, you can download a binary from
+          [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
+       2. Install yq by running the following command line:
+
+          ```
+          GO111MODULE=on go get github.com/mikefarah/yq/v3
+          ```
  
 ## Setting up the management cluster
 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -39,14 +39,16 @@ For a more detailed explanation of the changes affecting Kubeflow 1.1 on Google 
 
     Note, Kubeflow is not compatible with later versions of Kustomize. Read [this GitHub issue](https://github.com/kubeflow/manifests/issues/538) for the latest status.
 
-1. Install [yq](https://github.com/mikefarah/yq)
+1. Next, you'll be installing [yq](https://github.com/mikefarah/yq):
 
-   ```
-   GO111MODULE=on go get github.com/mikefarah/yq/v3
-   ```
+    1. Check that you have [Go](https://golang.org) installed by running the `go version`
+       command. If you don't, you can download a binary from
+       [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
+    2. Install yq by running the following command line:
 
-   * If you don't have [Go](https://golang.org) installed you can download
-     a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
+       ```
+       GO111MODULE=on go get github.com/mikefarah/yq/v3
+       ```
  
 ## Setting up the management cluster
 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -64,16 +64,6 @@ For a more detailed explanation of the changes affecting Kubeflow 1.1 on Google 
    make get-pkg
    ```
 
-  * This generates an error like the one below but you can ignore it;
-
-    ```  
-    kpt pkg get https://github.com/jlewi/manifests.git@blueprints ./upstream
-    fetching package / from https://github.com/jlewi/manifests to upstream/manifests
-    Error: resources must be annotated with config.kubernetes.io/index to be written to files    
-    ```
-  
-    * This is being tracked in [GoogleContainerTools/kpt#539](https://github.com/GoogleContainerTools/kpt/issues/539) 
-
 1. Open up the **Makefile** at `./management/Makefile` and edit the `set-values` rule to set values for the name, project, and location of your management; when you are done the section should look like
 
    ```  

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -39,6 +39,15 @@ For a more detailed explanation of the changes affecting Kubeflow 1.1 on Google 
 
     Note, Kubeflow is not compatible with later versions of Kustomize. Read [this GitHub issue](https://github.com/kubeflow/manifests/issues/538) for the latest status.
 
+1. Install [yq](https://github.com/mikefarah/yq)
+
+   ```
+   GO111MODULE=on go get github.com/mikefarah/yq/v3
+   ```
+
+   * If you don't have [Go](https://golang.org) installed you can download
+     a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases).
+ 
 ## Setting up the management cluster
 
 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -1,6 +1,6 @@
 +++
 title = "Management cluster setup"
-description = "Instructions for setting up a management cluster on Google Cloud"
+description = "Setting up a management cluster on Google Cloud"
 weight = 3
 +++
 
@@ -109,7 +109,7 @@ For a more detailed explanation of the changes affecting Kubeflow 1.1 on Google 
 
 ### Authorize CNRM for each project
 
-In the last step we created the Google Cloud service account **${NAME}-cnrm-system@${PROJECT}.iam.gserviceaccount.com**
+In the last step you created the Google Cloud service account **${NAME}-cnrm-system@${PROJECT}.iam.gserviceaccount.com**
 this is the service account that CNRM will use to create any Google Cloud resources. Consequently
 you need to grant this Google Cloud service account sufficient privileges to create the desired
 resources in one or more projects. 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -37,7 +37,7 @@ For a more detailed explanation of the changes affecting Kubeflow 1.1 on Google 
 
 1. Install [Kustomize v3.2.1](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.2.1).
 
-    Note, Kubeflow is not compatible with later versions of Kustomize. Read [this GitHub issue](https://github.com/kubeflow/manifests/issues/538) for the latest status.
+    **Note:** Kubeflow is not compatible with Kustomize versions above 3.2.1. Read [this GitHub issue](https://github.com/kubeflow/manifests/issues/538) for the latest status.
 
 1. Next, you'll be installing [yq](https://github.com/mikefarah/yq):
 


### PR DESCRIPTION
Just walked through this - the error has been resolved and doesn't show up anymore and `yq` dependency was missing, copied that from `deploy-cli` page.