### PR TITLE
Update Kubernetes v1.16 compatibility status in the Overview of Kubeflow deployment on a k8s cluster guide

### DIFF
--- a/content/en/docs/started/k8s/overview.md
+++ b/content/en/docs/started/k8s/overview.md
@@ -92,7 +92,7 @@ The Kubernetes cluster must meet the following minimum requirements:
         <td>incompatible</td>
         <td>incompatible</td>
         <td>incompatible</td>
-        <td><b>no known issues</b></td>
+        <td><b>compatible</b></td>
       </tr>
       <tr>
         <td>1.17</td>

--- a/content/en/docs/started/k8s/overview.md
+++ b/content/en/docs/started/k8s/overview.md
@@ -28,8 +28,6 @@ The Kubernetes cluster must meet the following minimum requirements:
   {{% kubernetes-tested-version %}}.
   - Your cluster must run at least Kubernetes version
     {{% kubernetes-min-version %}}.
-  - Kubeflow **does not work** on Kubernetes
-    {{% kubernetes-incompatible-versions %}}.
   - Older versions of Kubernetes may not be compatible with the latest Kubeflow versions. The following matrix
     provides information about compatibility between Kubeflow and Kubernetes versions.
 


### PR DESCRIPTION
This PR changes the compatibility status of k8s v1.16 to "compatible". Related issues: https://github.com/kubeflow/website/issues/2178, https://github.com/kubeflow/website/issues/2130, https://github.com/kubeflow/website/issues/2042

@Bobgy We should update the shortcode for incompatible versions (`{{% kubernetes-incompatible-versions %}}`), since it currently says v1.16. 

```
  - Kubeflow **does not work** on Kubernetes
    {{% kubernetes-incompatible-versions %}}.
```

/assign @Bobgy 