### PR TITLE
Kubeflow docs: create an OWNERS file for other guides

### DIFF
--- a/content/en/docs/other-guides/OWNERS
+++ b/content/en/docs/other-guides/OWNERS
@@ -2,6 +2,6 @@ approvers:
   - 8bitmp3
   - RFMVasconcelos
 
-reviews:
+reviewers:
   - alfsuse
   - PatrickXYS

--- a/content/en/docs/other-guides/OWNERS
+++ b/content/en/docs/other-guides/OWNERS
@@ -1,3 +1,6 @@
 approvers:
   - 8bitmp3
   - RFMVasconcelos
+
+reviews:
+  - PatrickXYS

--- a/content/en/docs/other-guides/OWNERS
+++ b/content/en/docs/other-guides/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - 8bitmp3
+  - RFMVasconcelos

--- a/content/en/docs/other-guides/OWNERS
+++ b/content/en/docs/other-guides/OWNERS
@@ -3,4 +3,5 @@ approvers:
   - RFMVasconcelos
 
 reviews:
+  - alfsuse
   - PatrickXYS


### PR DESCRIPTION
Adding an OWNERS file to Other Guides with @RFMVasconcelos and 8bitmp3 as approvers (the docs people :)), since we don't have an OWNERS file.

Currently, we have the following guides that were mostly created by @jlewi and @sarahmaddox :

- Data management: integrating KF with Rok for data versioning, packaging, and secure sharing: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/integrations/data-management.md
- FAQ: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/freq-ask-questions.md
- Istio on Kubeflow: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/istio-in-kubeflow.md
- Job scheduling: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/job-scheduling.md
- Kubeflow on-prem in a multi-node k8s cluster: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/kubeflow-on-multinode-cluster.md
- Configuring KF with kfctl and kustomize: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/kustomize.md
- Support: where to with questions and suggestions: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/support.md
- Troubleshooting Kubeflow deployments: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/troubleshooting.md
- Usage reporting: https://github.com/kubeflow/website/blob/master/content/en/docs/other-guides/usage-reporting.md

@Tomcli @animeshsingh @Jeffwan @PatrickXYS @Bobgy @numerology @janeman98 do you want to be added as approvers/reviewers or do you know anyone who should be? 

Thank you!

/assign @Bobgy 