### PR TITLE
Removed "outdated" from version agnostic "Getting started" docs

### DIFF
--- a/content/en/docs/started/getting-started.md
+++ b/content/en/docs/started/getting-started.md
@@ -156,25 +156,6 @@ The matrix is therefore an alternative way of accessing the information in the
   </table>
 </div>
 
-## Installing command line tools
-
-The following information is useful if you need or prefer to use command line
-tools for deploying and managing Kubeflow:
-
-* Download the kfctl binary from the
-  [Kubeflow releases page](https://github.com/kubeflow/kfctl/releases/).
-
-* Follow the kubectl installation and setup instructions from the [Kubernetes
-  documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-  As described in the Kubernetes documentation, your kubectl
-  version must be within one minor version of the Kubernetes version that you
-  use in your Kubeflow cluster.
-
-* Follow the kustomize installation and setup instructions from the guide to
-  [kustomize in Kubeflow](/docs/other-guides/kustomize/).
-  Make sure that you have the minimum required version of kustomize:
-  <b>{{% kustomize-min-version %}}</b> or later.
-
 ## Understanding the Kubeflow versioning policies
 
 With the launch of Kubeflow {{% kf-latest-version %}}, the Kubeflow community attributes 

--- a/content/en/docs/started/getting-started.md
+++ b/content/en/docs/started/getting-started.md
@@ -2,7 +2,7 @@
 title = "Installing Kubeflow"
 description = "Overview of installation choices for various environments"
 weight = 20
-                    
+
 +++
 
 This document provides information about setting up Kubeflow in various
@@ -28,8 +28,8 @@ in the "Doc diagrams" folder in the Kubeflow team drive.
 The following diagram gives an overview of the options for deploying Kubeflow:
 
 <div>
-  <object type="image/svg+xml" 
-    data="/docs/images/kubeflow-getting-started-diagram.svg" 
+  <object type="image/svg+xml"
+    data="/docs/images/kubeflow-getting-started-diagram.svg"
     alt="A diagrammatic overview of Kubeflow deployment options"
     class="mt-3 mb-3 border border-info rounded">
   </object>
@@ -84,9 +84,9 @@ Choose the guide for your operating system or environment:
   * To use MiniKF (mini Kubeflow) on Google Cloud Platform, follow the guide to
     [MiniKF on GCP](/docs/started/workstation/minikf-gcp/).
 
-## Configuration quick reference
+## Deployment quick reference
 
-Below is a matrix of the platforms where you can deploy Kubeflow and the 
+Below is a matrix of the platforms where you can deploy Kubeflow and the
 corresponding manifest files that specify the default configuration for each
 platform. The matrix shows the same manifests as the installation guides.
 The matrix is therefore an alternative way of accessing the information in the
@@ -97,59 +97,42 @@ The matrix is therefore an alternative way of accessing the information in the
     <thead class="thead-light">
       <tr>
         <th>Deployment platform</th>
-        <th>Manifest</th>
         <th>Deployment guide</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td><b>Existing Kubernetes cluster</b> using a standard Kubeflow 
+        <td><b>Existing Kubernetes cluster</b> using a standard Kubeflow
           installation</td>
-        <td><a href="{{% config-uri-k8s-istio %}}">{{% config-file-k8s-istio %}}</a> 
-        </td>
         <td><a href="/docs/started/k8s/kfctl-k8s-istio/">Docs</a></td>
       </tr>
       <tr>
         <td><b>Existing Kubernetes cluster</b> using Dex for authentication</td>
-        <td><a href="{{% config-uri-istio-dex %}}">{{% config-file-istio-dex %}}</a>
-        </td>
         <td><a href="/docs/started/k8s/kfctl-istio-dex/">Docs</a></td>
       </tr>
       <tr>
         <td><b>Amazon Web Services (AWS)</b> using the standard setup</td>
-        <td><a href="{{% config-uri-aws-standard %}}">{{% config-file-aws-standard %}}</a> 
-        </td>
         <td><a href="/docs/aws/deploy/install-kubeflow/">Docs</a></td>
       </tr>
       <tr>
         <td><b>Amazon Web Services (AWS)</b> with authentication</td>
-        <td><a href="{{% config-uri-aws-cognito %}}">{{% config-file-aws-cognito %}}</a> 
-        </td>
         <td><a href="/docs/aws/deploy/install-kubeflow/">Docs</a></td>
       </tr>
       <tr>
         <td><b>Microsoft Azure</b></td>
-        <td><a href="{{% config-uri-k8s-istio %}}">{{% config-file-k8s-istio %}}</a>  
-        </td>
         <td><a href="/docs/azure/deploy/install-kubeflow/">Docs</a></td>
       </tr>
       <tr>
-        <td><b>Google Cloud Platform (GCP)</b> with Cloud Identity-Aware Proxy 
+        <td><b>Google Cloud Platform (GCP)</b> with Cloud Identity-Aware Proxy
           (Cloud IAP)</td>
-        <td><a href="{{% config-uri-gcp-iap %}}">{{% config-file-gcp-iap %}}</a>  
-        </td>
         <td><a href="/docs/gke/deploy/">Docs</a></td>
       </tr>
       <tr>
         <td><b>IBM Cloud (IKS)</b></td>
-        <td><a href="{{% config-uri-ibm %}}">{{% config-file-ibm %}}</a>  
-        </td>
         <td><a href="/docs/started/cloud/getting-started-iks/">Docs</a></td>
       </tr>
       <tr>
         <td><b>OpenShift</b></td>
-        <td><a href="{{% config-uri-openshift %}}">{{% config-file-openshift %}}</a>  
-        </td>
         <td><a href="/docs/openshift/">Docs</a></td>
       </tr>
     </tbody>
@@ -158,13 +141,13 @@ The matrix is therefore an alternative way of accessing the information in the
 
 ## Understanding the Kubeflow versioning policies
 
-With the launch of Kubeflow {{% kf-latest-version %}}, the Kubeflow community attributes 
-*stable status* to those applications and other components that 
+With the launch of Kubeflow {{% kf-latest-version %}}, the Kubeflow community attributes
+*stable status* to those applications and other components that
 meet the required level of stability, supportability, and upgradability.
 
-Read about the 
+Read about the
 [Kubeflow versioning policies](/docs/reference/version-policy/),
-including the stable status of Kubeflow applications and deployment 
+including the stable status of Kubeflow applications and deployment
 platforms.
 
 ## Troubleshooting

--- a/content/en/docs/started/getting-started.md
+++ b/content/en/docs/started/getting-started.md
@@ -4,10 +4,6 @@ description = "Overview of installation choices for various environments"
 weight = 20
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 This document provides information about setting up Kubeflow in various
 environments.

--- a/content/en/docs/started/kubeflow-overview.md
+++ b/content/en/docs/started/kubeflow-overview.md
@@ -4,10 +4,6 @@ description = "How Kubeflow helps you organize your ML workflow"
 weight = 10
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 <!--
 Note for authors: The source of the diagrams is held in Google Slides decks,

--- a/content/en/docs/started/kubeflow-overview.md
+++ b/content/en/docs/started/kubeflow-overview.md
@@ -131,17 +131,6 @@ The UI offers a central dashboard that you can use to access the components
 of your Kubeflow deployment. Read 
 [how to access the central dashboard](/docs/components/central-dash/overview/).
 
-### Kubeflow command line interface (CLI)
-
-**Kfctl** is the Kubeflow CLI that you can use to install and configure 
-Kubeflow. Read about kfctl in the guide to 
-[configuring Kubeflow](/docs/other-guides/kustomize/).
-
-The Kubernetes CLI, **kubectl**, is useful for running commands against your
-Kubeflow cluster. You can use kubectl to deploy applications, inspect and manage
-cluster resources, and view logs. Read about kubectl in the [Kubernetes 
-documentation](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-
 ## Kubeflow APIs and SDKs
 
 Various components of Kubeflow offer APIs and Python SDKs. See the following


### PR DESCRIPTION
The entrance for users when they click `Getting started` on Kubeflow.org is the `Installing Kubeflow` page, which appears outdated:

![image](https://user-images.githubusercontent.com/27001378/95198009-61c8ac80-07d2-11eb-9301-b81eb4967a11.png)

At a first glance, this is more of a gateway, which seems version agnostic. And we're telling ALL users that our main docs page is outdated. It surely has space to improve, but at the current pace, I argue that we should remove the outdated banner and later on create a coordinated effort to update it. 

Same for `Getting Started > Kubeflow Overview`.

@8bitmp3 @jlewi @jbottum what are your thoughts on this? 