### PR TITLE
Remove OUTDATED from quickstart page

### DIFF
--- a/content/en/docs/pipelines/pipelines-quickstart.md
+++ b/content/en/docs/pipelines/pipelines-quickstart.md
@@ -3,12 +3,6 @@ title = "Pipelines Quickstart"
 description = "Getting started with Kubeflow Pipelines"
 weight = 10
                     
-+++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
-
 {{% beta-status 
   feedbacklink="https://github.com/kubeflow/pipelines/issues" %}}
 

--- a/content/en/docs/pipelines/pipelines-quickstart.md
+++ b/content/en/docs/pipelines/pipelines-quickstart.md
@@ -2,7 +2,8 @@
 title = "Pipelines Quickstart"
 description = "Getting started with Kubeflow Pipelines"
 weight = 10
-                    
++++
+
 {{% beta-status 
   feedbacklink="https://github.com/kubeflow/pipelines/issues" %}}
 


### PR DESCRIPTION
Looking at the page seems it points to [deploying Kubeflow on GCP](/docs/gke/deploy/) that already have not anymore the outdated banner so seems inconsistent to me still have it here.. maybe someone from @kubeflow/google may just confirm 1.1 is okay?