### PR TITLE
[docs:] Fix missing port-foward URL

### DIFF
--- a/content/en/docs/pipelines/installation/localcluster-deployment.md
+++ b/content/en/docs/pipelines/installation/localcluster-deployment.md
@@ -330,6 +330,14 @@ Executors](https://argoproj.github.io/argo/workflow-executors/) and reference
     ```
 
     The Kubeflow Pipelines deployment may take several minutes to complete.
+    2. Verify that the Kubeflow Pipelines UI is accessible by port-forwarding:
+
+   ```SHELL
+   kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8080:80
+   ```
+
+Open the Kubeflow Pipelines UI at http://localhost:8080/ or if you are using Kind or K3s within a VM http://{VM IP ADDRESS}:8080/
+Please note that K3ai will automatically print the right UI URL at the end of the installation process.
 
 
     **Note**: `kubectl apply -k` accepts local paths and paths that are

--- a/content/en/docs/pipelines/installation/localcluster-deployment.md
+++ b/content/en/docs/pipelines/installation/localcluster-deployment.md
@@ -330,14 +330,18 @@ Executors](https://argoproj.github.io/argo/workflow-executors/) and reference
     ```
 
     The Kubeflow Pipelines deployment may take several minutes to complete.
-    2. Verify that the Kubeflow Pipelines UI is accessible by port-forwarding:
 
-   ```SHELL
-   kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8080:80
-   ```
+2. Verify that the Kubeflow Pipelines UI is accessible by port-forwarding:
 
-Open the Kubeflow Pipelines UI at http://localhost:8080/ or if you are using Kind or K3s within a VM http://{VM IP ADDRESS}:8080/
-Please note that K3ai will automatically print the right UI URL at the end of the installation process.
+    ```shell
+    kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8080:80
+    ```
+
+    Then, open the Kubeflow Pipelines UI at `http://localhost:8080/` or - if you are
+    using kind or K3s within a virtual machine - `http://{YOUR_VM_IP_ADDRESS}:8080/`
+    
+    Note that K3ai will automatically print the URL for the web UI at the end of
+    the installation process.
 
 
     **Note**: `kubectl apply -k` accepts local paths and paths that are


### PR DESCRIPTION
Apparently, in the last rework, we deleted the port-forward section that helps folks to be able to use the pipelines UI.
/assign @8bitmp3 /cherry-picking