### PR TITLE
Make component development doc more language agnostic

### DIFF
--- a/content/en/docs/pipelines/sdk/component-development.md
+++ b/content/en/docs/pipelines/sdk/component-development.md
@@ -76,8 +76,8 @@ There are two main ways a command-line program usually consumes data:
 ## Writing the program code
 
 This section describes an example program that has two inputs (for small and 
-large pieces of data) and one output. The programming language in this example
-is Python 3.
+large pieces of data) and one output. Although the programming language in this example
+is Python 3, you can build your component in any language.
 
 ### program.py
 
@@ -128,7 +128,7 @@ of your choice to create the Docker containers.
 
 Your [Dockerfile](https://docs.docker.com/engine/reference/builder/) must
 contain all program code, including the wrapper, and the dependencies (operating
-system packages, Python packages etc).  
+system packages, external packages, etc).
 
 Ensure you have write access to a container registry where you can push
 the container image. Examples include 

--- a/content/en/docs/pipelines/sdk/component-development.md
+++ b/content/en/docs/pipelines/sdk/component-development.md
@@ -128,7 +128,7 @@ of your choice to create the Docker containers.
 
 Your [Dockerfile](https://docs.docker.com/engine/reference/builder/) must
 contain all program code, including the wrapper, and the dependencies (operating
-system packages, external packages, etc).
+system packages, external libraries, etc).
 
 Ensure you have write access to a container registry where you can push
 the container image. Examples include 


### PR DESCRIPTION
Updated some phrases in *component-development.md* document to make it more clear pipeline components are language agnostic. 

Based on kubeflow/pipelines#4599 discussion

[Preview Link](https://deploy-preview-2294--competent-brattain-de2d6d.netlify.app/docs/pipelines/sdk/component-development/)