### PR TITLE
Add Katib metric strategies info

### DIFF
--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -86,7 +86,7 @@ These are the fields in the experiment configuration spec:
   Experiment's objective value is calculated in accordance with the
   selected strategy.
 
-  For example, if you set below parameters in Experiment:
+  For example, if you set the below parameters in Experiment:
 
   ```yaml
   . . .

--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -72,6 +72,38 @@ These are the fields in the experiment configuration spec:
   runs the experiment until the corresponding successful trials reach `maxTrialCount`.
   `maxTrialCount` parameter is described below.
 
+  The default way to calculate the experiment's objective is:
+
+  - When the objective `type` is `maximize`, Katib compares all maximum
+    metric values.
+
+  - When the objective `type` is `minimize`, Katib compares all minimum
+    metric values.
+
+  You are able to change this default mechanism. For that, define
+  `metricStrategies` with various rules (`min`, `max` or `latest`) to extract
+  values for each metric from `objectiveMetricName` and `additionalMetricNames`.
+  Experiment's objective value is calculated in accordance with the
+  selected strategy.
+
+  For example, if you set below parameters in Experiment:
+
+  ```yaml
+  . . .
+  objectiveMetricName: accuracy
+  type: maximize
+  metricStrategies:
+    - name: accuracy
+      value: latest
+  . . .
+  ```
+
+  Katib controller is searching for the best maximum from the all latest
+  reported `accuracy` metrics for the each trial.
+  Check the
+  [metrics strategies example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metric-strategy-example.yaml).
+  The default strategy type for each metric are equal to objective `type`.
+
   Refer to the
   [`ObjectiveSpec` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/common/v1beta1/common_types.go#L93).
 

--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -99,7 +99,7 @@ These are the fields in the experiment configuration spec:
   ```
 
   Katib controller is searching for the best maximum from the all latest
-  reported `accuracy` metrics for the each trial. Check the
+  reported `accuracy` metrics for each trial. Check the
   [metrics strategies example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metric-strategy-example.yaml).
   The default strategy type for each metric is equal to the objective `type`.
 

--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -64,7 +64,7 @@ These are the fields in the experiment configuration spec:
   how the hyperparameters work with the model.
   Katib records the value of the best `objectiveMetricName` metric (maximized
   or minimized based on `type`) and the corresponding hyperparameter set
-  in Experiment's `.status.currentOptimalTrial.parameterAssignments`.
+  in experiment's `.status.currentOptimalTrial.parameterAssignments`.
   If the `objectiveMetricName` metric for a set of hyperparameters reaches the `goal`,
   Katib stops trying more hyperparameter combinations.
 
@@ -80,13 +80,13 @@ These are the fields in the experiment configuration spec:
   - When the objective `type` is `minimize`, Katib compares all minimum
     metric values.
 
-  You are able to change this default mechanism. For that, define
+  You are able to change the default mechanism. For that, define
   `metricStrategies` with various rules (`min`, `max` or `latest`) to extract
-  values for each metric from `objectiveMetricName` and `additionalMetricNames`.
-  Experiment's objective value is calculated in accordance with the
-  selected strategy.
+  values for each metric from the experiment's `objectiveMetricName` and
+  `additionalMetricNames`. The experiment's objective value is calculated in
+  accordance with the selected strategy.
 
-  For example, if you set the below parameters in Experiment:
+  For example, if you set the below parameters in your experiment:
 
   ```yaml
   . . .
@@ -99,10 +99,9 @@ These are the fields in the experiment configuration spec:
   ```
 
   Katib controller is searching for the best maximum from the all latest
-  reported `accuracy` metrics for the each trial.
-  Check the
+  reported `accuracy` metrics for the each trial. Check the
   [metrics strategies example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metric-strategy-example.yaml).
-  The default strategy type for each metric are equal to objective `type`.
+  The default strategy type for each metric is equal to the objective `type`.
 
   Refer to the
   [`ObjectiveSpec` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/common/v1beta1/common_types.go#L93).

--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -64,9 +64,9 @@ These are the fields in the experiment configuration spec:
   how the hyperparameters work with the model.
   Katib records the value of the best `objectiveMetricName` metric (maximized
   or minimized based on `type`) and the corresponding hyperparameter set
-  in experiment's `.status.currentOptimalTrial.parameterAssignments`.
-  If the `objectiveMetricName` metric for a set of hyperparameters reaches the `goal`,
-  Katib stops trying more hyperparameter combinations.
+  in the experiment's `.status.currentOptimalTrial.parameterAssignments`.
+  If the `objectiveMetricName` metric for a set of hyperparameters reaches the
+  `goal`, Katib stops trying more hyperparameter combinations.
 
   You can run the experiment without specifying the `goal`. In that case, Katib
   runs the experiment until the corresponding successful trials reach `maxTrialCount`.
@@ -80,13 +80,13 @@ These are the fields in the experiment configuration spec:
   - When the objective `type` is `minimize`, Katib compares all minimum
     metric values.
 
-  You are able to change the default mechanism. For that, define
-  `metricStrategies` with various rules (`min`, `max` or `latest`) to extract
-  values for each metric from the experiment's `objectiveMetricName` and
-  `additionalMetricNames`. The experiment's objective value is calculated in
+  To change the default settings, define `metricStrategies` with various rules
+  (`min`, `max` or `latest`) to extract values for each metric from the
+  experiment's `objectiveMetricName` and `additionalMetricNames`.
+  The experiment's objective value is calculated in
   accordance with the selected strategy.
 
-  For example, if you set the below parameters in your experiment:
+  For example, you can set the parameters in your experiment as follows:
 
   ```yaml
   . . .
@@ -98,8 +98,8 @@ These are the fields in the experiment configuration spec:
   . . .
   ```
 
-  Katib controller is searching for the best maximum from the all latest
-  reported `accuracy` metrics for each trial. Check the
+  where the Katib controller is searching for the best maximum from the all
+  latest reported `accuracy` metrics for each trial. Check the
   [metrics strategies example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metric-strategy-example.yaml).
   The default strategy type for each metric is equal to the objective `type`.
 


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1310.
Blocked by: https://github.com/kubeflow/website/pull/2312.

I added doc about `metricStrategies` in Objective section.

/assign @johnugeorge @gaocegege 

/cc @8bitmp3 