### PR TITLE
Update Azure OIDC guidance to verify statefulset and also lint the yaml to be the same as the autherservice

### DIFF
--- a/content/en/docs/azure/authentication-oidc.md
+++ b/content/en/docs/azure/authentication-oidc.md
@@ -89,13 +89,13 @@ This section shows the how to set up Kubeflow with authentication and authorizat
 
 3. Deploy Kubeflow:
 
-    ```
+    ```shell
     kfctl apply -V -f ${CONFIG_URI}
     ```
 
 4. Check that the resources were deployed correctly in namespace `kubeflow`:
 
-    ```
+    ```shell
     kubectl get all -n kubeflow
     ```
 
@@ -103,7 +103,7 @@ This section shows the how to set up Kubeflow with authentication and authorizat
 
 1. Update Istio Gateway to expose port 443 with HTTPS and make port 80 redirect to 443:
 
-    ```
+    ```shell
     kubectl edit -n kubeflow gateways.networking.istio.io kubeflow-gateway
     ```
 
@@ -144,25 +144,29 @@ This section shows the how to set up Kubeflow with authentication and authorizat
 
     To expose Kubeflow with a load balancer service, change the type of the `istio-ingressgateway` service to `LoadBalancer`.
 
-    ```
+    ```shell
     kubectl patch service -n istio-system istio-ingressgateway -p '{"spec": {"type": "LoadBalancer"}}'
     ```
 
-    After that, obtain the `LoadBalancer` IP or Hostname from its status and create the necessary certificate.
+    After that, obtain the `LoadBalancer` IP address or Hostname from its status and create the necessary certificate.
 
-    ```
+    ```shell
     kubectl get svc -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0]}'
     ```
 
     {{% alert title="Warning" color="warning" %}}
-    If you are exposing Ingress gateway through public IP please ensure its matches IP address of OIDC ```REDIRECT_URL```, by running:
-    ```
+    If you are exposing [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) gateway through public IP, make sure it matches the IP address of OIDC `REDIRECT_URL`, by running:
+    
+    ```shell
     kubectl get statefulset authservice -n istio-system -o yaml
     ```
-    If it doesn't match, update ```REDIRECT_URL``` in the statefulset to be the public IP address you got in the last step, by running:
-        ```
+
+    If it doesn't match, update `REDIRECT_URL` in the StatefulSet to be the public IP address from the last step, by running:
+    
+    ```shell
     kubectl edit statefulset authservice -n istio-system
     ```
+
     {{% /alert %}}
 
 
@@ -178,7 +182,7 @@ This section shows the how to set up Kubeflow with authentication and authorizat
     namespace: istio-system
     spec:
     commonName: istio-ingressgateway.istio-system.svc
-    # Use ipAddresses if your LoadBalancer issues an IP
+    # Use ipAddresses if your LoadBalancer issues an IP address
     ipAddresses:
     - <LoadBalancer IP>
     # Use dnsNames if your LoadBalancer issues a hostname
@@ -193,7 +197,7 @@ This section shows the how to set up Kubeflow with authentication and authorizat
 
     Apply `certificate.yaml` in `istio-system` namespace
 
-    ```
+    ```shell
     kubectl apply -f certificate.yaml -n istio-system
     ```
 

--- a/content/en/docs/azure/authentication-oidc.md
+++ b/content/en/docs/azure/authentication-oidc.md
@@ -122,22 +122,22 @@ This section shows the how to set up Kubeflow with authentication and authorizat
     - hosts:
         - '*'
         port:
-        name: http
-        number: 80
-        protocol: HTTP
-              # Upgrade HTTP to HTTPS
+            name: http
+            number: 80
+            protocol: HTTP
+        # Upgrade HTTP to HTTPS
         tls:
-        httpsRedirect: true
+            httpsRedirect: true
     - hosts:
         - '*'
         port:
-        name: https
-        number: 443
-        protocol: HTTPS
+            name: https
+            number: 443
+            protocol: HTTPS
         tls:
-        mode: SIMPLE
-        privateKey: /etc/istio/ingressgateway-certs/tls.key
-        serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+            mode: SIMPLE
+            privateKey: /etc/istio/ingressgateway-certs/tls.key
+            serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
     {{< /highlight >}}
 
 1. Expose Kubeflow with a load balancer service:
@@ -148,11 +148,23 @@ This section shows the how to set up Kubeflow with authentication and authorizat
     kubectl patch service -n istio-system istio-ingressgateway -p '{"spec": {"type": "LoadBalancer"}}'
     ```
 
-   After that, obtain the `LoadBalancer` IP or Hostname from its status and create the necessary certificate.
+    After that, obtain the `LoadBalancer` IP or Hostname from its status and create the necessary certificate.
 
     ```
     kubectl get svc -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0]}'
     ```
+
+    {{% alert title="Warning" color="warning" %}}
+    If you are exposing Ingress gateway through public IP please ensure its matches IP address of OIDC ```REDIRECT_URL```, by running:
+    ```
+    kubectl get statefulset authservice -n istio-system -o yaml
+    ```
+    If it doesn't match, update ```REDIRECT_URL``` in the statefulset to be the public IP address you got in the last step, by running:
+        ```
+    kubectl edit statefulset authservice -n istio-system
+    ```
+    {{% /alert %}}
+
 
 1. Create a self-signed Certificate with cert-manager:
 
@@ -166,10 +178,10 @@ This section shows the how to set up Kubeflow with authentication and authorizat
     namespace: istio-system
     spec:
     commonName: istio-ingressgateway.istio-system.svc
-        # Use ipAddresses if your LoadBalancer issues an IP
+    # Use ipAddresses if your LoadBalancer issues an IP
     ipAddresses:
     - <LoadBalancer IP>
-        # Use dnsNames if your LoadBalancer issues a hostname
+    # Use dnsNames if your LoadBalancer issues a hostname
     dnsNames:
     - <LoadBalancer HostName>
     isCA: true

--- a/content/en/docs/azure/authentication-oidc.md
+++ b/content/en/docs/azure/authentication-oidc.md
@@ -155,7 +155,7 @@ This section shows the how to set up Kubeflow with authentication and authorizat
     ```
 
     {{% alert title="Warning" color="warning" %}}
-    If you are exposing [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) gateway through public IP, make sure it matches the IP address of OIDC `REDIRECT_URL`, by running:
+    If you are exposing [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) gateway through public IP, make sure it matches the IP address of the OIDC `REDIRECT_URL` by running:
     
     ```shell
     kubectl get statefulset authservice -n istio-system -o yaml

--- a/content/en/docs/azure/authentication-oidc.md
+++ b/content/en/docs/azure/authentication-oidc.md
@@ -154,8 +154,7 @@ This section shows the how to set up Kubeflow with authentication and authorizat
     kubectl get svc -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0]}'
     ```
 
-    **Note:**
-    If you are exposing [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) gateway through public IP, make sure it matches the IP address of the OIDC `REDIRECT_URL` by running:
+    **Note**: If you are exposing [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) gateway through public IP, make sure it matches the IP address of the OIDC `REDIRECT_URL` by running:
     
     ```shell
     kubectl get statefulset authservice -n istio-system -o yaml

--- a/content/en/docs/azure/authentication-oidc.md
+++ b/content/en/docs/azure/authentication-oidc.md
@@ -154,7 +154,7 @@ This section shows the how to set up Kubeflow with authentication and authorizat
     kubectl get svc -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0]}'
     ```
 
-    {{% alert title="Warning" color="warning" %}}
+    **Note:**
     If you are exposing [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) gateway through public IP, make sure it matches the IP address of the OIDC `REDIRECT_URL` by running:
     
     ```shell
@@ -165,9 +165,8 @@ This section shows the how to set up Kubeflow with authentication and authorizat
     
     ```shell
     kubectl edit statefulset authservice -n istio-system
+    kubectl rollout restart statefulset authservice -n istio-system
     ```
-
-    {{% /alert %}}
 
 
 1. Create a self-signed Certificate with cert-manager:


### PR DESCRIPTION
- Adding steps to verify the redirect url to be the same as specified in the AAD app, otherwise the authentication would complain. 
- Lint the yaml file to be the same as in the autherservice, i.e. edit the json file to better reflect the structure.