### PR TITLE
typo - using your own domain section

### DIFF
--- a/content/en/docs/gke/custom-domain.md
+++ b/content/en/docs/gke/custom-domain.md
@@ -13,7 +13,7 @@ so, follow the guide to
 
 ## Using your own domain
 
-If you want to use your own domain instead of **${KF_NAME}.endpoints.${PROJECT}.cloud.goog**, follow these instructions after running `kfctl build`:
+If you want to use your own domain instead of **${KF_NAME}.endpoints.${PROJECT}.cloud.goog**, follow these instructions after building your cluster:
 
 1. Remove the substitution `hostname` in the Kptfile.
 


### PR DESCRIPTION
Recently, I made a PR to change the section about using your own domain. But I realized that I missed a phrase that mentions kfctl, I understood that as a kind of typo. In this PR I'm changing this phrase to remove the old kfctl reference.