### PR TITLE
Changing MANAGED-PROJECT to MANAGED_PROJECT

### DIFF
--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -148,7 +148,7 @@ The easiest way to do this is to grant the Google Cloud service account owner pe
 1. Set the managed project
 
    ```bash
-   kpt cfg set ./instance managed-project ${MANAGED-PROJECT}
+   kpt cfg set ./instance managed-project ${MANAGED_PROJECT}
    ```
 
 1. Update the policy


### PR DESCRIPTION
setting MANAGED-PROJECT using exports fails, e.g., "export: `MANAGED-PROJECT=kubeflow': not a valid identifier"