### PR TITLE
fix(doc): update docs that still refer to KFP latest SDK reference. Fixes kubelow/pipelines#4685

### DIFF
--- a/content/en/docs/gke/pipelines/authentication-pipelines.md
+++ b/content/en/docs/gke/pipelines/authentication-pipelines.md
@@ -52,7 +52,7 @@ Please refer to [gcloud container clusters create command documentation](https:/
 
 Pipelines don't need any specific changes to authenticate to GCP, it will use the default service account transparently.
 
-However, you must update existing pipelines that use the [use_gcp_secret kfp sdk operator](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret). Remove the `use_gcp_secret` usage to let your pipeline authenticate to Google Cloud using the default service account.
+However, you must update existing pipelines that use the [use_gcp_secret kfp sdk operator](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.extensions.html#kfp.gcp.use_gcp_secret). Remove the `use_gcp_secret` usage to let your pipeline authenticate to Google Cloud using the default service account.
 
 ## Securing the cluster with fine-grained GCP permission control
 
@@ -74,7 +74,7 @@ This document distinguishes between [Kubernetes service accounts](https://kubern
 
 Pipelines don't need any specific changes to authenticate to Google Cloud. With Workload Identity, pipelines run as the Google service account that is bound to the KSA.
 
-However, existing pipelines that use [use_gcp_secret kfp sdk operator](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret) need to remove the `use_gcp_secret` usage to use the bound GSA.
+However, existing pipelines that use [use_gcp_secret kfp sdk operator](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.extensions.html#kfp.gcp.use_gcp_secret) need to remove the `use_gcp_secret` usage to use the bound GSA.
 You can also continue to use `use_gcp_secret` in a cluster with Workload Identity enabled and `use_gcp_secret` will take precedence for those workloads.
 
 #### Cluster setup to use Workload Identity for Full Kubeflow
@@ -145,7 +145,7 @@ It is recommended to use Workload Identity for easier and secure management, but
 Each pipeline step describes a 
 container that is run independently. If you want to grant access for a single step to use
  one of your service accounts, you can use 
-[`kfp.gcp.use_gcp_secret()`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html#kfp.gcp.use_gcp_secret).
+[`kfp.gcp.use_gcp_secret()`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.extensions.html#kfp.gcp.use_gcp_secret).
 Examples for how to use this function can be found in the 
 [Kubeflow examples repo](https://github.com/kubeflow/examples/blob/871895c54402f68685c8e227c954d86a81c0575f/pipelines/mnist-pipelines/mnist_pipeline.py#L97).
 

--- a/content/en/docs/ibm/using-icr.md
+++ b/content/en/docs/ibm/using-icr.md
@@ -60,7 +60,7 @@ kubectl -n <my_namespace> create secret docker-registry <secret_name> \
 
 ### Using container images from ICR in Kubeflow Pipelines
 
-The pull image secret may be set in Kubeflow Pipelines SDK's [`PipelineConf`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.PipelineConf). Refer to this [`imagepullsecrets.py`](https://github.com/kubeflow/pipelines/blob/ef381aafccf916482d16774cac3b8568d06dff9e/samples/core/imagepullsecrets/imagepullsecrets.py#L55) sample in Kubeflow Pipelines project for usage.
+The pull image secret may be set in Kubeflow Pipelines SDK's [`PipelineConf`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.PipelineConf). Refer to this [`imagepullsecrets.py`](https://github.com/kubeflow/pipelines/blob/ef381aafccf916482d16774cac3b8568d06dff9e/samples/core/imagepullsecrets/imagepullsecrets.py#L55) sample in Kubeflow Pipelines project for usage.
 
 ### Using notebook images from ICR in a Jupyter Notebook
 

--- a/content/en/docs/pipelines/multi-user.md
+++ b/content/en/docs/pipelines/multi-user.md
@@ -75,7 +75,7 @@ print(client.list_runs(namespace='<Your namespace>'))
 ```
 
 To store your user namespace as the default context, use the
-[`set_user_namespace`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.client.html#kfp.Client.set_user_namespace)
+[`set_user_namespace`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.client.html#kfp.Client.set_user_namespace)
 method. This method stores your user namespace in a configuration file at
 `$HOME/.config/kfp/context.json`. After setting a default namespace, the SDK
 methods default to use this namespace if no namespace argument is provided.
@@ -104,17 +104,17 @@ in-cluster workload directly, read [Current Limitations section](#current-limita
 for more details.
 
 Detailed documentation for the Kubeflow Pipelines SDK can be found in the
-[Kubeflow Pipelines SDK Reference](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.client.html).
+[Kubeflow Pipelines SDK Reference](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.client.html).
 
 ### When using REST API or generated python API client
 
 Similarly, when calling [REST API endpoints](/docs/pipelines/reference/api/kubeflow-pipeline-api-spec/)
-or using [the generated python API client](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.server_api.html),
+or using [the generated python API client](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.server_api.html),
 namespace argument is required for experiment APIs. Note that namespace is
 referred to using a resource reference. The resource reference **type** is
 `NAMESPACE` and resource reference **key id** is the namespace name.
 
-The following example demonstrates how to use [the generated Python API client (kf-server-api)](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.server_api.html) in a multi-user environment.
+The following example demonstrates how to use [the generated Python API client (kf-server-api)](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.server_api.html) in a multi-user environment.
 
 ```python
 from kfp_server_api import ApiRun, ApiPipelineSpec, \

--- a/content/en/docs/pipelines/reference/sdk.md
+++ b/content/en/docs/pipelines/reference/sdk.md
@@ -10,5 +10,5 @@ needs to be updated for Kubeflow 1.1.
 {{% /alert %}}
 
 See the [generated reference docs for the Python 
-SDK](https://kubeflow-pipelines.readthedocs.io/en/latest/) (hosted on 
+SDK](https://kubeflow-pipelines.readthedocs.io/en/stable/) (hosted on 
 *Read the Docs*).

--- a/content/en/docs/pipelines/sdk/enviroment_variables.md
+++ b/content/en/docs/pipelines/sdk/enviroment_variables.md
@@ -29,7 +29,7 @@ component, which writes the variable's value to the log.
 [Learn more about lightweight Python components](/docs/pipelines/sdk/lightweight-python-components/)
 
 To build a component, define a stand-alone Python function and then call 
-[kfp.components.func_to_container_op(func)](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.func_to_container_op) to convert the 
+[kfp.components.func_to_container_op(func)](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.func_to_container_op) to convert the 
 function to a component that can be used in a pipeline. The following function gets an 
 environment variable and writes it to the log.
 
@@ -43,16 +43,16 @@ def logg_env_function():
 ```
 
 Transform the function into a component using 
-[kfp.components.func_to_container_op(func)](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.func_to_container_op).  
+[kfp.components.func_to_container_op(func)](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.func_to_container_op).  
 ```python
 image_name = 'tensorflow/tensorflow:1.11.0-py3'
 logg_env_function_op = comp.func_to_container_op(logg_env_function,
                                                  base_image=image_name)
 ```
 
-Add this component to a pipeline. Use [add_env_variable](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp.container) to pass an 
+Add this component to a pipeline. Use [add_env_variable](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp.container) to pass an 
 environment variable into the component. This code is the same no matter if your
-using python lightweight components or a [container operation](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp). 
+using python lightweight components or a [container operation](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp). 
 
 
 ```python
@@ -70,7 +70,7 @@ def environment_pipeline():
 ```
 
 To pass more environment variables into a component, add more instances of 
-[add_env_variable()](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp.container). Use the following command to run this pipeline using the 
+[add_env_variable()](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp.container). Use the following command to run this pipeline using the 
 Kubeflow Pipelines SDK.
 
 ```python

--- a/content/en/docs/pipelines/sdk/install-sdk.md
+++ b/content/en/docs/pipelines/sdk/install-sdk.md
@@ -11,7 +11,7 @@ which you can use to build machine learning pipelines. You can use the SDK
 to execute your pipeline, or alternatively you can upload the pipeline to
 the Kubeflow Pipelines UI for execution.
 
-All of the SDK's classes and methods are described in the auto-generated [SDK reference docs](https://kubeflow-pipelines.readthedocs.io/en/latest/).
+All of the SDK's classes and methods are described in the auto-generated [SDK reference docs](https://kubeflow-pipelines.readthedocs.io/en/stable/).
 
 **Note:** If you are running [Kubeflow Pipelines with Tekton](https://github.com/kubeflow/kfp-tekton),
 instead of the default [Kubeflow Pipelines with Argo](https://github.com/kubeflow/pipelines), you should use the

--- a/content/en/docs/pipelines/sdk/manipulate-resources.md
+++ b/content/en/docs/pipelines/sdk/manipulate-resources.md
@@ -30,7 +30,7 @@ This feature allows users to perform some action (`get`, `create`, `apply`,
 Users are able to set conditions that denote the success or failure of the
 step undertaking that action.
 
-[Link](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ResourceOp)
+[Link](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ResourceOp)
 to the corresponding Python library.
 
 #### Arguments
@@ -48,7 +48,7 @@ For more information, please refer to the aforementioned link to the library.
 * `failure_condition`: Condition to denote failure of the step once it is true.
   (_optional_)
 * `attribute_outputs`: Similar to `file_outputs` of
-  [`kfp.dsl.ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp).
+  [`kfp.dsl.ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp).
   Maps output parameter names to JSON paths in the Kubernetes object.
   More on that in the following section.
   (_optional_)
@@ -88,7 +88,7 @@ Request the creation of PVC instances simple and fast.
 
 A ResourceOp specialized in PVC creation.
 
-[Link](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.VolumeOp)
+[Link](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.VolumeOp)
 to the corresponding Python library.
 
 #### Arguments
@@ -176,7 +176,7 @@ Those dependencies can then be parsed properly by a `ContainerOp`, when consumed
 in `pvolumes` argument or `add_pvolumes()` method, to extend the dependencies
 of that step.
 
-[Link](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.PipelineVolume)
+[Link](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.PipelineVolume)
 to the corresponding Python library.
 
 _(*) Inherits from V1Volume class of Kubernetes Python client._
@@ -212,7 +212,7 @@ Request the creation of Volume Snapshot instances simple and fast.
 
 A ResourceOp specialized in Volume Snapshot creation.
 
-[Link](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.VolumeSnapshotOp)
+[Link](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.VolumeSnapshotOp)
 to the corresponding Python library.
 
 **NOTE:** You should check if your Kubernetes cluster admin has Volume Snapshots

--- a/content/en/docs/pipelines/sdk/parameters.md
+++ b/content/en/docs/pipelines/sdk/parameters.md
@@ -6,7 +6,7 @@ weight = 70
 +++
 
 The [`kfp.dsl.PipelineParam` 
-class](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.PipelineParam)
+class](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.PipelineParam)
 represents a reference to future data that will be passed to the pipeline or produced by a task.
 
 Your pipeline function should have parameters, so that they can later be configured in the Kubeflow Pipelines UI.

--- a/content/en/docs/pipelines/sdk/python-function-components.ipynb
+++ b/content/en/docs/pipelines/sdk/python-function-components.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "3. Create an instance of the [`kfp.Client` class][kfp-client].\n",
     "\n",
-    "[kfp-client]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.client.html#kfp.Client"
+    "[kfp-client]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.client.html#kfp.Client"
    ]
   },
   {
@@ -83,7 +83,7 @@
    "source": [
     "For more information about the Kubeflow Pipelines SDK, see the [SDK reference guide][sdk-ref].\n",
     "\n",
-    "[sdk-ref]: https://kubeflow-pipelines.readthedocs.io/en/latest/index.html\n",
+    "[sdk-ref]: https://kubeflow-pipelines.readthedocs.io/en/stable/index.html\n",
     "\n",
     "## Getting started with Python function-based components\n",
     "\n",
@@ -113,7 +113,7 @@
     "    factory function that you can use to create [`kfp.dsl.ContainerOp`][container-op] class instances for your pipeline.\n",
     "    The component specification YAML is a reusable and shareable definition of your component.\n",
     "\n",
-    "[container-op]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp"
+    "[container-op]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp"
    ]
   },
   {
@@ -300,7 +300,7 @@
     "image must use Python 3.5 or later.\n",
     "\n",
     "[python37]: https://hub.docker.com/layers/python/library/python/3.7/images/sha256-7eef781ed825f3b95c99f03f4189a8e30e718726e8490651fa1b941c6c815ad1?context=explore\n",
-    "[create-component-from-func]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.create_component_from_func\n",
+    "[create-component-from-func]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.create_component_from_func\n",
     "[subprocess]: https://docs.python.org/3/library/subprocess.html\n",
     "[tf-docker]: https://www.tensorflow.org/install/docker\n",
     "[pytorch-docker]: https://hub.docker.com/r/pytorch/pytorch/tags\n",
@@ -401,7 +401,7 @@
     "    [`kfp.dsl.ContainerOp`][container-op] class instances for your pipeline. This example also specifies the base container\n",
     "    image to run this function in.\n",
     "\n",
-    "[container-op]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp"
+    "[container-op]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp"
    ]
   },
   {

--- a/content/en/docs/pipelines/sdk/python-function-components.md
+++ b/content/en/docs/pipelines/sdk/python-function-components.md
@@ -68,7 +68,7 @@ import kfp.components as comp
 
 3. Create an instance of the [`kfp.Client` class][kfp-client].
 
-[kfp-client]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.client.html#kfp.Client
+[kfp-client]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.client.html#kfp.Client
 
 
 ```python
@@ -80,7 +80,7 @@ client = kfp.Client(host='<your-kubeflow-pipelines-host-name>')
 
 For more information about the Kubeflow Pipelines SDK, see the [SDK reference guide][sdk-ref].
 
-[sdk-ref]: https://kubeflow-pipelines.readthedocs.io/en/latest/index.html
+[sdk-ref]: https://kubeflow-pipelines.readthedocs.io/en/stable/index.html
 
 ## Getting started with Python function-based components
 
@@ -101,7 +101,7 @@ def add(a: float, b: float) -> float:
     factory function that you can use to create [`kfp.dsl.ContainerOp`][container-op] class instances for your pipeline.
     The component specification YAML is a reusable and shareable definition of your component.
 
-[container-op]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp
+[container-op]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp
 
 
 ```python
@@ -261,7 +261,7 @@ If you build or select a container image, instead of using the default container
 image must use Python 3.5 or later.
 
 [python37]: https://hub.docker.com/layers/python/library/python/3.7/images/sha256-7eef781ed825f3b95c99f03f4189a8e30e718726e8490651fa1b941c6c815ad1?context=explore
-[create-component-from-func]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.create_component_from_func
+[create-component-from-func]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.create_component_from_func
 [subprocess]: https://docs.python.org/3/library/subprocess.html
 [tf-docker]: https://www.tensorflow.org/install/docker
 [pytorch-docker]: https://hub.docker.com/r/pytorch/pytorch/tags
@@ -344,7 +344,7 @@ my_divmod(100, 7)
     [`kfp.dsl.ContainerOp`][container-op] class instances for your pipeline. This example also specifies the base container
     image to run this function in.
 
-[container-op]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp
+[container-op]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp
 
 
 ```python

--- a/content/en/docs/pipelines/sdk/sdk-overview.md
+++ b/content/en/docs/pipelines/sdk/sdk-overview.md
@@ -8,7 +8,7 @@ weight = 10
 {{% stable-status %}}
 
 The [Kubeflow Pipelines 
-SDK](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.html)
+SDK](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.html)
 provides a set of Python packages that you can use to specify and run your 
 machine learning (ML) workflows. A *pipeline* is a description of an ML 
 workflow, including all of the *components* that make up the steps in the 
@@ -22,7 +22,7 @@ please follow the [Kubeflow Pipelines SDK for Tekton](/docs/pipelines/sdk/pipeli
 
 The Kubeflow Pipelines SDK includes the following packages:
 
-* [`kfp.compiler`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.compiler.html)
+* [`kfp.compiler`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.compiler.html)
   includes classes and methods for compiling pipeline Python DSL into a workflow yaml spec
     Methods in this package include, but are not limited
   to, the following:
@@ -32,7 +32,7 @@ The Kubeflow Pipelines SDK includes the following packages:
     can process. The Kubeflow Pipelines service converts the static 
     configuration into a set of Kubernetes resources for execution.
 
-* [`kfp.components`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html)
+* [`kfp.components`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html)
   includes classes and methods for interacting with pipeline components. 
   Methods in this package include, but are not limited to, the following:
 
@@ -40,24 +40,24 @@ The Kubeflow Pipelines SDK includes the following packages:
     pipeline component and returns a factory function.
     You can then call the factory function to construct an instance of a 
     pipeline task
-    ([`ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp)) 
+    ([`ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp)) 
     that runs the original function in a container.
 
   * `kfp.components.load_component_from_file` loads a pipeline component from
     a file and returns a factory function.
     You can then call the factory function to construct an instance of a 
     pipeline task 
-    ([`ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp)) 
+    ([`ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp)) 
     that runs the component container image.
 
   * `kfp.components.load_component_from_url` loads a pipeline component from
     a URL and returns a factory function.
     You can then call the factory function to construct an instance of a 
     pipeline task 
-    ([`ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp)) 
+    ([`ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp)) 
     that runs the component container image.
 
-* [`kfp.dsl`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html)
+* [`kfp.dsl`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html)
   contains the domain-specific language (DSL) that you can use to define and
   interact with pipelines and components. 
   Methods, classes, and modules in this package include, but are not limited to, 
@@ -68,45 +68,45 @@ The Kubeflow Pipelines SDK includes the following packages:
     [pipeline parameters](/docs/pipelines/sdk/parameters/).
   * `kfp.dsl.component` is a decorator for DSL functions that returns a
     pipeline component.
-    ([`ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp)).
+    ([`ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp)).
   * `kfp.dsl.pipeline` is a decorator for Python functions that returns a
     pipeline.
   * `kfp.dsl.python_component` is a decorator for Python functions that adds
     pipeline component metadata to the function object.
-  * [`kfp.dsl.types`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.types.html) 
+  * [`kfp.dsl.types`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.types.html) 
     contains a list of types defined by the Kubeflow Pipelines SDK. Types
     include basic types like `String`, `Integer`, `Float`, and `Bool`, as well
     as domain-specific types like `GCPProjectID` and `GCRPath`.
     See the guide to 
     [DSL static type checking](/docs/pipelines/sdk/static-type-checking).
-  * [`kfp.dsl.ResourceOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ResourceOp)
+  * [`kfp.dsl.ResourceOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ResourceOp)
     represents a pipeline task (op) which lets you directly manipulate 
     Kubernetes resources (`create`, `get`, `apply`, ...).
-  * [`kfp.dsl.VolumeOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.VolumeOp)
+  * [`kfp.dsl.VolumeOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.VolumeOp)
     represents a pipeline task (op) which creates a new `PersistentVolumeClaim` 
     (PVC). It aims to make the common case of creating a `PersistentVolumeClaim` 
     fast.
-  * [`kfp.dsl.VolumeSnapshotOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.VolumeSnapshotOp)
+  * [`kfp.dsl.VolumeSnapshotOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.VolumeSnapshotOp)
     represents a pipeline task (op) which creates a new `VolumeSnapshot`. It 
     aims to make the common case of creating a `VolumeSnapshot` fast.
-  * [`kfp.dsl.PipelineVolume`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.PipelineVolume)
+  * [`kfp.dsl.PipelineVolume`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.PipelineVolume)
     represents a volume used to pass data between pipeline steps. `ContainerOp`s 
     can mount a `PipelineVolume` either via the constructor's argument 
     `pvolumes` or `add_pvolumes()` method.
-  * [`kfp.dsl.ParallelFor`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ParallelFor)
+  * [`kfp.dsl.ParallelFor`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ParallelFor)
     represents a parallel for loop over a static or dynamic set of items in a pipeline.
     Each iteration of the for loop is executed in parallel.
   
-  * [`kfp.dsl.ExitHandler`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ExitHandler)
+  * [`kfp.dsl.ExitHandler`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ExitHandler)
     represents an exit handler that is invoked upon exiting a pipeline. A typical
     usage of `ExitHandler` is garbage collection.
   
-  * [`kfp.dsl.Condition`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.Condition)
+  * [`kfp.dsl.Condition`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.Condition)
     represents a group of ops, that will only be executed when a certain condition is met.
     The condition specified need to be determined at runtime, by incorporating at least one task output, 
     or PipelineParam in the boolean expression.
 
-* [`kfp.Client`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.client.html)
+* [`kfp.Client`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.client.html)
   contains the Python client libraries for the [Kubeflow Pipelines 
   API](/docs/pipelines/reference/api/kubeflow-pipeline-api-spec/).
   Methods in this package include, but are not limited to, the following:
@@ -121,7 +121,7 @@ The Kubeflow Pipelines SDK includes the following packages:
   * `kfp.Client.upload_pipeline` uploads a local file to create a new pipeline in Kubeflow Pipelines.
   * `kfp.Client.upload_pipeline_version` uploads a local file to create a pipeline version. [Follow an example to learn more about creating a pipeline version](/docs/pipelines/tutorials/sdk-examples)
 
-* [Kubeflow Pipelines extension modules](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.extensions.html)
+* [Kubeflow Pipelines extension modules](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.extensions.html)
   include classes and functions for specific platforms on which you can use
   Kubeflow Pipelines. Examples include utility functions for on premises,
   Google Cloud Platform (GCP), Amazon Web Services (AWS), and Microsoft Azure.
@@ -200,15 +200,15 @@ Below is a more detailed explanation of the above diagram:
   the [Docker command-line 
   interface](https://docs.docker.com/engine/reference/commandline/cli/)
   or the 
-  [`kfp.compiler.build_docker_image` method](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.compiler.html#kfp.compiler.build_docker_image) from the Kubeflow Pipelines 
+  [`kfp.compiler.build_docker_image` method](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.compiler.html#kfp.compiler.build_docker_image) from the Kubeflow Pipelines 
   SDK.
 
 1. Write a component function using the Kubeflow Pipelines DSL to define your
   pipeline's interactions with the component’s Docker container. Your
   component function must return a
-  [`kfp.dsl.ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.ContainerOp).
+  [`kfp.dsl.ContainerOp`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp).
   Optionally, you can use the [`kfp.dsl.component` 
-  decorator](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.component)
+  decorator](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.component)
   to enable [static type checking](/docs/pipelines/sdk/static-type-checking) in 
   the DSL compiler. To use the decorator, you can add the `@kfp.dsl.component` 
   annotation to your component function:
@@ -225,7 +225,7 @@ Below is a more detailed explanation of the above diagram:
 
 1. Write a pipeline function using the Kubeflow Pipelines DSL to define the 
   pipeline and include all the pipeline components. Use the [`kfp.dsl.pipeline`
-  decorator](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.pipeline)
+  decorator](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.pipeline)
   to build a pipeline from your pipeline function. To use the decorator, you can
   add the `@kfp.dsl.pipeline` annotation to your pipeline function:
 
@@ -246,7 +246,7 @@ Below is a more detailed explanation of the above diagram:
     options:
 
     * Use the 
-      [`kfp.compiler.Compiler.compile`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.compiler.html#kfp.compiler.Compiler) 
+      [`kfp.compiler.Compiler.compile`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.compiler.html#kfp.compiler.Compiler) 
       method:
 
         ```python
@@ -309,7 +309,7 @@ Below is a more detailed explanation of the above diagram:
     ```
 
 1. Use the [`kfp.dsl.python_component`
-  decorator](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.python_component)
+  decorator](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.python_component)
   to convert your Python function into 
   a pipeline component. To use the decorator, you can add the 
   `@kfp.dsl.python_component` annotation to your function:
@@ -324,7 +324,7 @@ Below is a more detailed explanation of the above diagram:
     ```
 
 1. Use 
-  [`kfp.compiler.build_python_component`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.compiler.html#kfp.compiler.build_python_component)
+  [`kfp.compiler.build_python_component`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.compiler.html#kfp.compiler.build_python_component)
   to create a container image for the component.
 
     ```python
@@ -336,7 +336,7 @@ Below is a more detailed explanation of the above diagram:
 
 1. Write a pipeline function using the Kubeflow Pipelines DSL to define the 
   pipeline and include all the pipeline components. Use the [`kfp.dsl.pipeline`
-  decorator](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.pipeline)
+  decorator](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.pipeline)
   to build a pipeline from your pipeline function, by adding 
   the `@kfp.dsl.pipeline` annotation to your pipeline function:
 
@@ -357,7 +357,7 @@ Below is a more detailed explanation of the above diagram:
     options:
 
     * Use the 
-      [`kfp.compiler.Compiler.compile`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.compiler.html#kfp.compiler.Compiler) 
+      [`kfp.compiler.Compiler.compile`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.compiler.html#kfp.compiler.Compiler) 
       method:
 
         ```python
@@ -415,7 +415,7 @@ Below is a more detailed explanation of the above diagram:
     ```
 
 1. Use 
-  [`kfp.components.func_to_container_op`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.func_to_container_op)
+  [`kfp.components.func_to_container_op`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.func_to_container_op)
   to convert your Python function into a pipeline component:
 
     ```python
@@ -432,7 +432,7 @@ Below is a more detailed explanation of the above diagram:
 
 1. If you stored your lightweight component in a file as described in the 
   previous step, use 
-  [`kfp.components.load_component_from_file`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.load_component_from_file)
+  [`kfp.components.load_component_from_file`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_file)
   to load the component:
 
     ```python
@@ -441,7 +441,7 @@ Below is a more detailed explanation of the above diagram:
 
 1. Write a pipeline function using the Kubeflow Pipelines DSL to define the 
   pipeline and include all the pipeline components. Use the [`kfp.dsl.pipeline`
-  decorator](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.pipeline)
+  decorator](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.pipeline)
   to build a pipeline from your pipeline function, by adding 
   the `@kfp.dsl.pipeline` annotation to your pipeline function:
 
@@ -462,7 +462,7 @@ Below is a more detailed explanation of the above diagram:
     options:
 
     * Use the 
-      [`kfp.compiler.Compiler.compile`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.compiler.html#kfp.compiler.Compiler) 
+      [`kfp.compiler.Compiler.compile`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.compiler.html#kfp.compiler.Compiler) 
       method:
 
         ```python
@@ -512,7 +512,7 @@ Below is a more detailed explanation of the above diagram:
   resources](/docs/examples/shared-resources/).
 
 1. Use 
-  [`kfp.components.load_component_from_url`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.components.html#kfp.components.load_component_from_url)
+  [`kfp.components.load_component_from_url`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_url)
   to load the component:
 
     ```python
@@ -521,7 +521,7 @@ Below is a more detailed explanation of the above diagram:
 
 1. Write a pipeline function using the Kubeflow Pipelines DSL to define the 
   pipeline and include all the pipeline components. Use the [`kfp.dsl.pipeline`
-  decorator](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.dsl.html#kfp.dsl.pipeline)
+  decorator](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.pipeline)
   to build a pipeline from your pipeline function, by adding 
   the `@kfp.dsl.pipeline` annotation to your pipeline function:
 
@@ -542,7 +542,7 @@ Below is a more detailed explanation of the above diagram:
     options:
 
     * Use the 
-      [`kfp.compiler.Compiler.compile`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/kfp.compiler.html#kfp.compiler.Compiler) 
+      [`kfp.compiler.Compiler.compile`](https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.compiler.html#kfp.compiler.Compiler) 
       method:
 
         ```python


### PR DESCRIPTION
Update docs that still refer to KFP latest SDK reference.

https://github.com/kubeflow/pipelines/issues/4685