### PR TITLE
[AWS] Update AWS Notebook Image to v1.2.0

### DIFF
--- a/content/en/docs/aws/notebook-server.md
+++ b/content/en/docs/aws/notebook-server.md
@@ -9,10 +9,10 @@ weight = 90
 Currently, we add AWS optimized Kubeflow Notebook Images and make them default options in notebook server.
 
 ```
-527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.1.0
-527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.1.0
-527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.1.0
-527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.1.0
+527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.2.0
+527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.2.0
+527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.2.0
+527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.2.0
 ```
 
 The ECR image provides:


### PR DESCRIPTION
Update AWS Notebook Image from tag from `1.1.0` to `1.2.0`