### PR TITLE
[IBM] Fix formatting in HTTPS doc

### DIFF
--- a/content/en/docs/ibm/deploy/authentication.md
+++ b/content/en/docs/ibm/deploy/authentication.md
@@ -5,48 +5,48 @@ weight = 10
 +++
 
 This guide describes how to secure the Kubeflow authentication with HTTPS.
-You can enable HTTPS for Kubeflow dashboard (and other web UIs) using the 
-network load balancer (NLB) feature of the IBM Cloud Kubernetes service—choose 
-the `classic` worker nodes provider in the 
-[Setting environment variables](../../create-cluster#setting-environment-variables) 
+You can enable HTTPS for Kubeflow dashboard (and other web UIs) using the
+network load balancer (NLB) feature of the IBM Cloud Kubernetes service—choose
+the `classic` worker nodes provider in the
+[Setting environment variables](../../create-cluster#setting-environment-variables)
 section of the Create an IBM Cloud cluster guide.
 
 **Note**: For details on NLB, go to the official
-[Classic: About network load balancers](https://cloud.ibm.com/docs/containers?topic=containers-loadbalancer-about) 
+[Classic: About network load balancers](https://cloud.ibm.com/docs/containers?topic=containers-loadbalancer-about)
 guide.
 
 ## Prerequisites
 
-* Install and configure the 
+* Install and configure the
 [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cli-getting-started).
-* Install 
+* Install
 [multi-user, auth-enabled Kubeflow](../install-kubeflow/#multi-user-auth-enabled).
 
 ## Setting up an NLB
 
-To set up an NLB for your Kubernetes cluster, follow the official 
-[Classic: Setting up basic load balancing with an NLB 1.0](https://cloud.ibm.com/docs/containers?topic=containers-loadbalancer) 
-guide. Notice that the setup process for a multi-zone cluster differs from that 
-of a single-zone cluster. For details, go to 
+To set up an NLB for your Kubernetes cluster, follow the official
+[Classic: Setting up basic load balancing with an NLB 1.0](https://cloud.ibm.com/docs/containers?topic=containers-loadbalancer)
+guide. Notice that the setup process for a multi-zone cluster differs from that
+of a single-zone cluster. For details, go to
 [Setting up an NLB 1.0 in a multi-zone cluster](https://cloud.ibm.com/docs/containers?topic=containers-loadbalancer#multi_zone_config).
 
-1. To use the existing Istio ingress gateway (instead of creating a new 
-service), you need to update the service type of `istio-ingressgateway` to 
+1. To use the existing Istio ingress gateway (instead of creating a new
+service), you need to update the service type of `istio-ingressgateway` to
 `LoadBalancer` from `NodePort`. Run the following command:
 
     ```shell
     kubectl patch svc istio-ingressgateway -n istio-system -p '{"spec":{"type":"LoadBalancer"}}'
     ```
 
-2. Verify that the NLB was created successfully. It might take a few minutes for 
-the service to be created and an IP address to be made available. Run the 
+2. Verify that the NLB was created successfully. It might take a few minutes for
+the service to be created and an IP address to be made available. Run the
 command below and check if you can see the `LoadBalancer Ingress` IP address:
 
     ```shell
     kubectl describe service istio-ingressgateway -n istio-system | grep "LoadBalancer Ingress"
     ```
 
-3. Store the external IP of the `istio-ingressgateway` service in an environment 
+3. Store the external IP of the `istio-ingressgateway` service in an environment
 variable:
 
     ```shell
@@ -55,18 +55,18 @@ variable:
 
 ## Exposing the Kubeflow dashboard with DNS and TLS termination
 
-The following instructions use the Kubeflow dashboard as an example. However, 
-they apply to other web UI applications, since they all go through the Istio 
+The following instructions use the Kubeflow dashboard as an example. However,
+they apply to other web UI applications, since they all go through the Istio
 ingress gateway.
 
-1. Store the Kubernetes cluster name in an environment variable by running the 
+1. Store the Kubernetes cluster name in an environment variable by running the
 following command:
 
    ```shell
    export CLUSTER_NAME=<cluster_name>
    ```
 
-2. Create a DNS domain and certificates for the IP of the service 
+2. Create a DNS domain and certificates for the IP of the service
 `istio-ingressgateway` in namespace `istio-system`:
 
     ```shell
@@ -79,28 +79,28 @@ following command:
     ibmcloud ks nlb-dns ls --cluster $CLUSTER_NAME
     ```
 
-4. Wait until the status of the certificate—the fourth field—of the new domain 
-name becomes `created`. Then, save the value of the column `SSL Cert Secret 
-Name` in environment variables by running these commands (replace 
-`{SECRET_NAME}` with the secret's name as shown in the `SSL Cert Secret Name` 
+4. Wait until the status of the certificate—the fourth field—of the new domain
+name becomes `created`. Then, save the value of the column `SSL Cert Secret
+Name` in environment variables by running these commands (replace
+`{SECRET_NAME}` with the secret's name as shown in the `SSL Cert Secret Name`
 column):
 
     ```shell
     export INGRESS_GATEWAY_SECRET={SECRET_NAME}
     ```
 
-    **Note**: If there is more than one entry in the output, choose the one 
-    that matches the IP address from `LoadBalancer Ingress` (step 2) of service 
+    **Note**: If there is more than one entry in the output, choose the one
+    that matches the IP address from `LoadBalancer Ingress` (step 2) of service
     `istio-ingressgateway`.
 
-5. Create a secret named `istio-ingressgateway-certs` for the 
+5. Create a secret named `istio-ingressgateway-certs` for the
 `istio-ingressgateway` pods in namespace `istio-system`:
 
     ```shell
     kubectl get secret $INGRESS_GATEWAY_SECRET -o yaml > istio-ingressgateway-certs.yaml
     ```
 
-6. Update the `istio-ingressgateway-certs.yaml` file by changing the value of 
+6. Update the `istio-ingressgateway-certs.yaml` file by changing the value of
 `metadata.name` to `istio-ingressgateway-certs` and the value of
 `metadata.namespace` to `istio-system`. Then, run the following commands:
 
@@ -110,38 +110,38 @@ column):
     rm istio-ingressgateway-certs.yaml
     ```
 
-7. Update the gateway `kubeflow-gateway` to expose port `443`. Create a resource 
-file `kubeflow-gateway.yaml` as follows by replacing `<hostname>` with the value 
+7. Update the gateway `kubeflow-gateway` to expose port `443`. Create a resource
+file `kubeflow-gateway.yaml` as follows by replacing `<hostname>` with the value
 of the column `Hostname` in step 4:
 
     ```YAML
     apiVersion: networking.istio.io/v1alpha3
     kind: Gateway
     metadata:
-    name: kubeflow-gateway
-    namespace: kubeflow
+      name: kubeflow-gateway
+      namespace: kubeflow
     spec:
       selector:
         istio: ingressgateway
-    servers:
-    - hosts:
-      - '<hostname>'
-      port:
-        name: https
-        number: 443
-        protocol: HTTPS
-      tls:
-        mode: SIMPLE
-        privateKey: /etc/istio/ingressgateway-certs/tls.key
-        serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+      servers:
+      - hosts:
+        - '<hostname>'
+        port:
+          name: https
+          number: 443
+          protocol: HTTPS
+        tls:
+          mode: SIMPLE
+          privateKey: /etc/istio/ingressgateway-certs/tls.key
+          serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
     ```
 
-8. Verify that the traffic is routed via HTTPS by using the value of 
-above-mentioned `Hostname` in your browser. It should redirect traffic from an 
+8. Verify that the traffic is routed via HTTPS by using the value of
+above-mentioned `Hostname` in your browser. It should redirect traffic from an
 HTTP address to HTTPS address automatically.
 
-**Note**: The certificates for the NLB DNS host secret expire every **90** days. 
+**Note**: The certificates for the NLB DNS host secret expire every **90** days.
 The secret in the `default` namespace is automatically renewed by IBM Cloud
-Kubernetes Service 37 days before it expires. After this secret is updated, you 
-must manually copy it to the `istio-ingressgateway-certs` secret by repeating 
+Kubernetes Service 37 days before it expires. After this secret is updated, you
+must manually copy it to the `istio-ingressgateway-certs` secret by repeating
 commands in step 5 and 6.


### PR DESCRIPTION
This PR fixes the `kubeflow-gateway` YAML in the IBM authentication doc and removes any trailing whitespace from lines.

Closes: #2393