### PR TITLE
Update istio documentation to branch 1.2 for Kubeflow v1.2

### DIFF
--- a/layouts/shortcodes/config-file-istio-dex.html
+++ b/layouts/shortcodes/config-file-istio-dex.html
@@ -1,1 +1,1 @@
-kfctl_istio_dex.v1.1.0.yaml
+kfctl_istio_dex.v1.2.0.yaml

--- a/layouts/shortcodes/config-file-k8s-istio.html
+++ b/layouts/shortcodes/config-file-k8s-istio.html
@@ -1,1 +1,1 @@
-kfctl_k8s_istio.v1.1.0.yaml
+kfctl_k8s_istio.v1.2.0.yaml

--- a/layouts/shortcodes/config-uri-istio-dex.html
+++ b/layouts/shortcodes/config-uri-istio-dex.html
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_istio_dex.v1.1.0.yaml
+https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_istio_dex.v1.2.0.yaml

--- a/layouts/shortcodes/config-uri-k8s-istio.html
+++ b/layouts/shortcodes/config-uri-k8s-istio.html
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.v1.1.0.yaml
+https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_k8s_istio.v1.2.0.yaml


### PR DESCRIPTION
Documentation for installation via K8s needs update to v1.2 as all URLs point to 1.1