### PR TITLE
Kubeflow deployment gcp managment cluster bug fix

### DIFF
--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -16,11 +16,11 @@ to manage Google Cloud infrastructure using GitOps.
 
 ## FAQs
 
-* Where is `kfctl`?
+- Where is `kfctl`?
 
   `kfctl` is no longer being used to apply resources for Google Cloud, because required functionalities are now supported by generic tools including [Make](https://www.gnu.org/software/make/), [Kustomize](https://kustomize.io), [kpt](https://googlecontainertools.github.io/kpt/), and [Cloud Config Connector](https://cloud.google.com/config-connector/docs/overview).
 
-* Why do we use an extra management cluster to manage Google Cloud resources?
+- Why do we use an extra management cluster to manage Google Cloud resources?
 
   The management cluster is very lightweight cluster that runs [Cloud Config Connector](https://cloud.google.com/config-connector/docs/overview). Cloud Config Connector makes it easier to configure Google Cloud resources using YAML and Kustomize.
 
@@ -30,26 +30,26 @@ For a more detailed explanation of the drastic changes happened in Kubeflow v1.1
 
 1. Install gcloud components
 
-    ```bash
-    gcloud components install kubectl kpt anthoscli beta
-    gcloud components update
-    ```
+   ```bash
+   gcloud components install kubectl kpt anthoscli beta
+   gcloud components update
+   ```
 
 1. Install [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/).
 
-    **Note:** Starting from Kubeflow v1.2, we fixed the compatibility problem with Kustomize `v3.2.1+`, so you can now install any Kustomize `v3+`, including the latest Kustomize versions.
+   **Note:** Starting from Kubeflow v1.2, we fixed the compatibility problem with Kustomize `v3.2.1+`, so you can now install any Kustomize `v3+`, including the latest Kustomize versions.
 
-    To deploy the latest version of Kustomize on a Linux or Mac machine, run the following commands:
+   To deploy the latest version of Kustomize on a Linux or Mac machine, run the following commands:
 
-    ```bash
-    # Detect your OS and download corresponding latest Kustomize binary
-    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+   ```bash
+   # Detect your OS and download corresponding latest Kustomize binary
+   curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 
-    # Add the kustomize package to your $PATH env variable
-    sudo mv ./kustomize /usr/local/bin/kustomize
-    ```
+   # Add the kustomize package to your $PATH env variable
+   sudo mv ./kustomize /usr/local/bin/kustomize
+   ```
 
-    Then, to verify the installation, run `kustomize version`. You should see `Version:kustomize/vX.Y.Z` in the output if you've successfully deployed Kustomize.
+   Then, to verify the installation, run `kustomize version`. You should see `Version:kustomize/vX.Y.Z` in the output if you've successfully deployed Kustomize.
 
 1. Install [yq](https://github.com/mikefarah/yq#install).
 
@@ -57,16 +57,17 @@ For a more detailed explanation of the drastic changes happened in Kubeflow v1.1
 
 This guide assumes the following convention:
 
-* The `${MGMT_PROJECT}` environment variable contains the Google Cloud project
+- The `${MGMT_PROJECT}` environment variable contains the Google Cloud project
   ID where management cluster is deployed to.
-* The `${MGMT_DIR}` environment variable contains the path to
+- The `${MGMT_DIR}` environment variable contains the path to
   your management directory, which holds your management cluster configuration
   files. For example, `~/kf-deployments/management/`. You can choose any path
   you would like for the directory `${MGMT_DIR}`.
 
   To continously manage the management cluster, you are recommended to check
   the management configuration directory into source control.
-* The `${MGMT_NAME}` environment variable contains the name of your management cluster.
+
+- The `${MGMT_NAME}` environment variable contains the name of your management cluster.
 
 Set these environment variables in your shell:
 
@@ -74,6 +75,8 @@ Set these environment variables in your shell:
 MGMT_PROJECT=<the project where you deploy your management cluster>
 MGMT_DIR=<path to your management cluster configuration directory>
 MGMT_NAME=<name of your management cluster>
+MGMT_LOCATION=<location of your management cluster>
+
 ```
 
 However, the environment variables are used purely for command illustration
@@ -85,102 +88,102 @@ To deploy a management cluster:
 
 1. Fetch the management blueprint to current directory
 
-    ```bash
-    kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/management@v1.2.0 "${MGMT_DIR}"
-    ```
+   ```bash
+   kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/management@v1.2.0 "${MGMT_DIR}"
+   ```
 
 1. Change to the Kubeflow directory
 
-    ```bash
-    cd "${MGMT_DIR}"
-    ```
+   ```bash
+   cd "${MGMT_DIR}"
+   ```
 
-    Note, all the instructions below assume your current working directory is `${MGMT_DIR}`.
+   Note, all the instructions below assume your current working directory is `${MGMT_DIR}`.
 
 1. Fetch the upstream management package
 
-    ```bash
-    make get-pkg
-    ```
+   ```bash
+   make get-pkg
+   ```
 
 1. Use kpt to set values for the name, project, and location of your management cluster:
 
-    ```bash
-    kpt cfg set -R . name "${MGMT_NAME}"
-    kpt cfg set -R . gcloud.core.project "${PROJECT}"
-    kpt cfg set -R . location "${LOCATION}"
-    ```
+   ```bash
+   kpt cfg set -R . name "${MGMT_NAME}"
+   kpt cfg set -R . gcloud.core.project "${MGMT_PROJECT}"
+   kpt cfg set -R . location "${MGMT_LOCATION}"
+   ```
 
-    For the values you need to set for management cluster:
+   For the values you need to set for management cluster:
 
-    * MGMT_NAME is the cluster name of your management cluster and prefix for other Google Cloud resources created in the deployment process. Management cluster
-      should be a different cluster from your Kubeflow cluster.
+   - MGMT_NAME is the cluster name of your management cluster and prefix for other Google Cloud resources created in the deployment process. Management cluster
+     should be a different cluster from your Kubeflow cluster.
 
-      Note, MGMT_NAME should
+     Note, MGMT_NAME should
 
-      * start with a lowercase letter
-      * only contain lowercase letters, numbers and `-`
-      * end with a number or a letter
-      * contain no more than 18 characters
+     - start with a lowercase letter
+     - only contain lowercase letters, numbers and `-`
+     - end with a number or a letter
+     - contain no more than 18 characters
 
-    * LOCATION is the management cluster's location, you can choose between regional or zonal.
-    * PROJECT is the Google Cloud project where you will create this management cluster.
+   - MGMT_LOCATION is the management cluster's location, you can choose between regional or zonal.
+   - MGMT_PROJECT is the Google Cloud project where you will create this management cluster.
 
-    Running `kpt cfg set` stores values you set in `./instance/Kptfile` and
-    `./upstream/management/Kptfile`. Commit the changes to source control to
-    preserve your configuration.
+   Running `kpt cfg set` stores values you set in `./instance/Kptfile` and
+   `./upstream/management/Kptfile`. Commit the changes to source control to
+   preserve your configuration.
 
-    We have two packages with setters: `./instance` and `./upstream/management`.
-    The `-R` flag means `--recurse-subpackages`. It sets values recursively in all the
-    nested subpackages in current directory `.` in one command.
+   We have two packages with setters: `./instance` and `./upstream/management`.
+   The `-R` flag means `--recurse-subpackages`. It sets values recursively in all the
+   nested subpackages in current directory `.` in one command.
 
-    You can learn more about `kpt cfg set` in [kpt documentation](https://googlecontainertools.github.io/kpt/reference/cfg/set/), or by running `kpt cfg set --help`.
+   You can learn more about `kpt cfg set` in [kpt documentation](https://googlecontainertools.github.io/kpt/reference/cfg/set/), or by running `kpt cfg set --help`.
 
-    Note, you can find out which setters exist in a package and what their
-    current values are by running the following command:
+   Note, you can find out which setters exist in a package and what their
+   current values are by running the following command:
 
-    ```bash
-    kpt cfg list-setters .
-    ```
+   ```bash
+   kpt cfg list-setters .
+   ```
 
 1. Create or apply the management cluster:
 
-    ```bash
-    make apply-cluster
-    ```
+   ```bash
+   make apply-cluster
+   ```
 
-    Optionally, you can verify the management cluster spec before applying it by:
+   Optionally, you can verify the management cluster spec before applying it by:
 
-    ```bash
-    make hydrate-cluster
-    ```
+   ```bash
+   make hydrate-cluster
+   ```
 
-    and look into `./build/cluster` folder.
+   and look into `./build/cluster` folder.
 
 1. Create a kubectl context for the management cluster, it will be named `${MGMT_NAME}`:
 
-    ```bash
-    make create-context
-    ```
+   ```bash
+   make create-context
+   ```
 
 1. Install the Cloud Config Connector:
 
-    ```bash
-    make apply-kcc
-    ```
+   ```bash
+   make apply-kcc
+   ```
 
-    This step:
+   This step:
 
-    * Installs Config Connector in your cluster, and
-    * Creates the Google Cloud service account **${MGMT_NAME}-cnrm-system@${PROJECT}.iam.gserviceaccount.com**.
+   - Installs Config Connector in your cluster, and
+   - Creates the Google Cloud service account **${MGMT_NAME}-cnrm-system@${PROJECT}.iam.gserviceaccount.com**.
 
-    Optionally, you can verify the Config Connector installation before applying it by:
+   Optionally, you can verify the Config Connector installation before applying it by:
 
-    ```bash
-    make hydrate-kcc
-    ```
+   ```bash
+   make hydrate-kcc
+   ```
 
-    and check `./build/cnrm-install-*` folders.
+   and check `./build/cnrm-install-*` folders.
 
 ### Authorize Cloud Config Connector for each managed project
 
@@ -214,19 +217,19 @@ deployment process, so that you can customize your management cluster if necessa
 
 Your management cluster directory contains the following files and directories:
 
-* **Makefile** is a file that defines rules to automate deployment process. You can refer to [GNU make documentation](https://www.gnu.org/software/make/manual/make.html#Introduction) for more introduction. The Makefile we provide is designed to be user maintainable. You are encouraged to read, edit and maintain it to suit your own deployment customization needs.
+- **Makefile** is a file that defines rules to automate deployment process. You can refer to [GNU make documentation](https://www.gnu.org/software/make/manual/make.html#Introduction) for more introduction. The Makefile we provide is designed to be user maintainable. You are encouraged to read, edit and maintain it to suit your own deployment customization needs.
 
-* **upstream** is a directory containing kustomize packages for deploying your management cluster.
+- **upstream** is a directory containing kustomize packages for deploying your management cluster.
   This directory contains the upstream configurations on which your deployment is based on.
 
-* **instance** is a directory that defines user overlays that are applied to the upstream
+- **instance** is a directory that defines user overlays that are applied to the upstream
   configurations in order to customize management cluster for your use case.
 
-  * **cluster** is a kustomize package defining all the Google Cloud resources needed using [gcloud beta anthos apply](https://cloud.google.com/sdk/gcloud/reference/beta/anthos/apply). It can apply some Google Cloud resource types using the same resource definition for Config Connector. You can edit this kustomize package in order to customize the Google Cloud resources for your purposes.
+  - **cluster** is a kustomize package defining all the Google Cloud resources needed using [gcloud beta anthos apply](https://cloud.google.com/sdk/gcloud/reference/beta/anthos/apply). It can apply some Google Cloud resource types using the same resource definition for Config Connector. You can edit this kustomize package in order to customize the Google Cloud resources for your purposes.
 
-  * **cnrm-install-\*** folders contain kustomize packages for Google Cloud services, iam policies and Kubernetes resources to install Config Connector following [Advanced installation options for Config Connector](https://cloud.google.com/config-connector/docs/how-to/advanced-install).
+  - **cnrm-install-\*** folders contain kustomize packages for Google Cloud services, iam policies and Kubernetes resources to install Config Connector following [Advanced installation options for Config Connector](https://cloud.google.com/config-connector/docs/how-to/advanced-install).
 
-* **build** is a directory that will contain the hydrated manifests outputted by
+- **build** is a directory that will contain the hydrated manifests outputted by
   the `make` rules
 
 ## Layout rationale
@@ -242,8 +245,8 @@ The following tips help you customize, verify and re-apply them to your cluster.
 
 Some useful links for Kustomize:
 
-* [patchesStrategicMerge](https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/) let you patch any fields of an existing resource using a partial resource definition.
-* Reference for all Kustomize features: https://kubectl.docs.kubernetes.io/references/kustomize/.
+- [patchesStrategicMerge](https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/) let you patch any fields of an existing resource using a partial resource definition.
+- Reference for all Kustomize features: https://kubectl.docs.kubernetes.io/references/kustomize/.
 
 To get detailed reference for Google Cloud resources, refer to
 [Config Connector resources reference](https://cloud.google.com/config-connector/docs/reference/overview).

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -16,11 +16,11 @@ to manage Google Cloud infrastructure using GitOps.
 
 ## FAQs
 
-- Where is `kfctl`?
+* Where is `kfctl`?
 
   `kfctl` is no longer being used to apply resources for Google Cloud, because required functionalities are now supported by generic tools including [Make](https://www.gnu.org/software/make/), [Kustomize](https://kustomize.io), [kpt](https://googlecontainertools.github.io/kpt/), and [Cloud Config Connector](https://cloud.google.com/config-connector/docs/overview).
 
-- Why do we use an extra management cluster to manage Google Cloud resources?
+* Why do we use an extra management cluster to manage Google Cloud resources?
 
   The management cluster is very lightweight cluster that runs [Cloud Config Connector](https://cloud.google.com/config-connector/docs/overview). Cloud Config Connector makes it easier to configure Google Cloud resources using YAML and Kustomize.
 
@@ -30,26 +30,26 @@ For a more detailed explanation of the drastic changes happened in Kubeflow v1.1
 
 1. Install gcloud components
 
-   ```bash
-   gcloud components install kubectl kpt anthoscli beta
-   gcloud components update
-   ```
+    ```bash
+    gcloud components install kubectl kpt anthoscli beta
+    gcloud components update
+    ```
 
 1. Install [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/).
 
-   **Note:** Starting from Kubeflow v1.2, we fixed the compatibility problem with Kustomize `v3.2.1+`, so you can now install any Kustomize `v3+`, including the latest Kustomize versions.
+    **Note:** Starting from Kubeflow v1.2, we fixed the compatibility problem with Kustomize `v3.2.1+`, so you can now install any Kustomize `v3+`, including the latest Kustomize versions.
 
-   To deploy the latest version of Kustomize on a Linux or Mac machine, run the following commands:
+    To deploy the latest version of Kustomize on a Linux or Mac machine, run the following commands:
 
-   ```bash
-   # Detect your OS and download corresponding latest Kustomize binary
-   curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+    ```bash
+    # Detect your OS and download corresponding latest Kustomize binary
+    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 
-   # Add the kustomize package to your $PATH env variable
-   sudo mv ./kustomize /usr/local/bin/kustomize
-   ```
+    # Add the kustomize package to your $PATH env variable
+    sudo mv ./kustomize /usr/local/bin/kustomize
+    ```
 
-   Then, to verify the installation, run `kustomize version`. You should see `Version:kustomize/vX.Y.Z` in the output if you've successfully deployed Kustomize.
+    Then, to verify the installation, run `kustomize version`. You should see `Version:kustomize/vX.Y.Z` in the output if you've successfully deployed Kustomize.
 
 1. Install [yq](https://github.com/mikefarah/yq#install).
 
@@ -57,17 +57,16 @@ For a more detailed explanation of the drastic changes happened in Kubeflow v1.1
 
 This guide assumes the following convention:
 
-- The `${MGMT_PROJECT}` environment variable contains the Google Cloud project
+* The `${MGMT_PROJECT}` environment variable contains the Google Cloud project
   ID where management cluster is deployed to.
-- The `${MGMT_DIR}` environment variable contains the path to
+* The `${MGMT_DIR}` environment variable contains the path to
   your management directory, which holds your management cluster configuration
   files. For example, `~/kf-deployments/management/`. You can choose any path
   you would like for the directory `${MGMT_DIR}`.
 
   To continously manage the management cluster, you are recommended to check
   the management configuration directory into source control.
-
-- The `${MGMT_NAME}` environment variable contains the name of your management cluster.
+* The `${MGMT_NAME}` environment variable contains the name of your management cluster.
 
 Set these environment variables in your shell:
 
@@ -88,102 +87,102 @@ To deploy a management cluster:
 
 1. Fetch the management blueprint to current directory
 
-   ```bash
-   kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/management@v1.2.0 "${MGMT_DIR}"
-   ```
+    ```bash
+    kpt pkg get https://github.com/kubeflow/gcp-blueprints.git/management@v1.2.0 "${MGMT_DIR}"
+    ```
 
 1. Change to the Kubeflow directory
 
-   ```bash
-   cd "${MGMT_DIR}"
-   ```
+    ```bash
+    cd "${MGMT_DIR}"
+    ```
 
-   Note, all the instructions below assume your current working directory is `${MGMT_DIR}`.
+    Note, all the instructions below assume your current working directory is `${MGMT_DIR}`.
 
 1. Fetch the upstream management package
 
-   ```bash
-   make get-pkg
-   ```
+    ```bash
+    make get-pkg
+    ```
 
 1. Use kpt to set values for the name, project, and location of your management cluster:
 
-   ```bash
-   kpt cfg set -R . name "${MGMT_NAME}"
-   kpt cfg set -R . gcloud.core.project "${MGMT_PROJECT}"
-   kpt cfg set -R . location "${MGMT_LOCATION}"
-   ```
+    ```bash
+    kpt cfg set -R . name "${MGMT_NAME}"
+    kpt cfg set -R . gcloud.core.project "${MGMT_PROJECT}"
+    kpt cfg set -R . location "${MGMT_LOCATION}"
+    ```
 
-   For the values you need to set for management cluster:
+    For the values you need to set for management cluster:
 
-   - MGMT_NAME is the cluster name of your management cluster and prefix for other Google Cloud resources created in the deployment process. Management cluster
-     should be a different cluster from your Kubeflow cluster.
+    * MGMT_NAME is the cluster name of your management cluster and prefix for other Google Cloud resources created in the deployment process. Management cluster
+      should be a different cluster from your Kubeflow cluster.
 
-     Note, MGMT_NAME should
+      Note, MGMT_NAME should
 
-     - start with a lowercase letter
-     - only contain lowercase letters, numbers and `-`
-     - end with a number or a letter
-     - contain no more than 18 characters
+      * start with a lowercase letter
+      * only contain lowercase letters, numbers and `-`
+      * end with a number or a letter
+      * contain no more than 18 characters
 
-   - MGMT_LOCATION is the management cluster's location, you can choose between regional or zonal.
-   - MGMT_PROJECT is the Google Cloud project where you will create this management cluster.
+    * MGMT_LOCATION is the management cluster's location, you can choose between regional or zonal.
+    * MGMT_PROJECT is the Google Cloud project where you will create this management cluster.
 
-   Running `kpt cfg set` stores values you set in `./instance/Kptfile` and
-   `./upstream/management/Kptfile`. Commit the changes to source control to
-   preserve your configuration.
+    Running `kpt cfg set` stores values you set in `./instance/Kptfile` and
+    `./upstream/management/Kptfile`. Commit the changes to source control to
+    preserve your configuration.
 
-   We have two packages with setters: `./instance` and `./upstream/management`.
-   The `-R` flag means `--recurse-subpackages`. It sets values recursively in all the
-   nested subpackages in current directory `.` in one command.
+    We have two packages with setters: `./instance` and `./upstream/management`.
+    The `-R` flag means `--recurse-subpackages`. It sets values recursively in all the
+    nested subpackages in current directory `.` in one command.
 
-   You can learn more about `kpt cfg set` in [kpt documentation](https://googlecontainertools.github.io/kpt/reference/cfg/set/), or by running `kpt cfg set --help`.
+    You can learn more about `kpt cfg set` in [kpt documentation](https://googlecontainertools.github.io/kpt/reference/cfg/set/), or by running `kpt cfg set --help`.
 
-   Note, you can find out which setters exist in a package and what their
-   current values are by running the following command:
+    Note, you can find out which setters exist in a package and what their
+    current values are by running the following command:
 
-   ```bash
-   kpt cfg list-setters .
-   ```
+    ```bash
+    kpt cfg list-setters .
+    ```
 
 1. Create or apply the management cluster:
 
-   ```bash
-   make apply-cluster
-   ```
+    ```bash
+    make apply-cluster
+    ```
 
-   Optionally, you can verify the management cluster spec before applying it by:
+    Optionally, you can verify the management cluster spec before applying it by:
 
-   ```bash
-   make hydrate-cluster
-   ```
+    ```bash
+    make hydrate-cluster
+    ```
 
-   and look into `./build/cluster` folder.
+    and look into `./build/cluster` folder.
 
 1. Create a kubectl context for the management cluster, it will be named `${MGMT_NAME}`:
 
-   ```bash
-   make create-context
-   ```
+    ```bash
+    make create-context
+    ```
 
 1. Install the Cloud Config Connector:
 
-   ```bash
-   make apply-kcc
-   ```
+    ```bash
+    make apply-kcc
+    ```
 
-   This step:
+    This step:
 
-   - Installs Config Connector in your cluster, and
-   - Creates the Google Cloud service account **${MGMT_NAME}-cnrm-system@${PROJECT}.iam.gserviceaccount.com**.
+    * Installs Config Connector in your cluster, and
+    * Creates the Google Cloud service account **${MGMT_NAME}-cnrm-system@${PROJECT}.iam.gserviceaccount.com**.
 
-   Optionally, you can verify the Config Connector installation before applying it by:
+    Optionally, you can verify the Config Connector installation before applying it by:
 
-   ```bash
-   make hydrate-kcc
-   ```
+    ```bash
+    make hydrate-kcc
+    ```
 
-   and check `./build/cnrm-install-*` folders.
+    and check `./build/cnrm-install-*` folders.
 
 ### Authorize Cloud Config Connector for each managed project
 
@@ -217,19 +216,19 @@ deployment process, so that you can customize your management cluster if necessa
 
 Your management cluster directory contains the following files and directories:
 
-- **Makefile** is a file that defines rules to automate deployment process. You can refer to [GNU make documentation](https://www.gnu.org/software/make/manual/make.html#Introduction) for more introduction. The Makefile we provide is designed to be user maintainable. You are encouraged to read, edit and maintain it to suit your own deployment customization needs.
+* **Makefile** is a file that defines rules to automate deployment process. You can refer to [GNU make documentation](https://www.gnu.org/software/make/manual/make.html#Introduction) for more introduction. The Makefile we provide is designed to be user maintainable. You are encouraged to read, edit and maintain it to suit your own deployment customization needs.
 
-- **upstream** is a directory containing kustomize packages for deploying your management cluster.
+* **upstream** is a directory containing kustomize packages for deploying your management cluster.
   This directory contains the upstream configurations on which your deployment is based on.
 
-- **instance** is a directory that defines user overlays that are applied to the upstream
+* **instance** is a directory that defines user overlays that are applied to the upstream
   configurations in order to customize management cluster for your use case.
 
-  - **cluster** is a kustomize package defining all the Google Cloud resources needed using [gcloud beta anthos apply](https://cloud.google.com/sdk/gcloud/reference/beta/anthos/apply). It can apply some Google Cloud resource types using the same resource definition for Config Connector. You can edit this kustomize package in order to customize the Google Cloud resources for your purposes.
+  * **cluster** is a kustomize package defining all the Google Cloud resources needed using [gcloud beta anthos apply](https://cloud.google.com/sdk/gcloud/reference/beta/anthos/apply). It can apply some Google Cloud resource types using the same resource definition for Config Connector. You can edit this kustomize package in order to customize the Google Cloud resources for your purposes.
 
-  - **cnrm-install-\*** folders contain kustomize packages for Google Cloud services, iam policies and Kubernetes resources to install Config Connector following [Advanced installation options for Config Connector](https://cloud.google.com/config-connector/docs/how-to/advanced-install).
+  * **cnrm-install-\*** folders contain kustomize packages for Google Cloud services, iam policies and Kubernetes resources to install Config Connector following [Advanced installation options for Config Connector](https://cloud.google.com/config-connector/docs/how-to/advanced-install).
 
-- **build** is a directory that will contain the hydrated manifests outputted by
+* **build** is a directory that will contain the hydrated manifests outputted by
   the `make` rules
 
 ## Layout rationale
@@ -245,8 +244,8 @@ The following tips help you customize, verify and re-apply them to your cluster.
 
 Some useful links for Kustomize:
 
-- [patchesStrategicMerge](https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/) let you patch any fields of an existing resource using a partial resource definition.
-- Reference for all Kustomize features: https://kubectl.docs.kubernetes.io/references/kustomize/.
+* [patchesStrategicMerge](https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/) let you patch any fields of an existing resource using a partial resource definition.
+* Reference for all Kustomize features: https://kubectl.docs.kubernetes.io/references/kustomize/.
 
 To get detailed reference for Google Cloud resources, refer to
 [Config Connector resources reference](https://cloud.google.com/config-connector/docs/reference/overview).


### PR DESCRIPTION
Bugfix for the management cluster deployment found [here](https://www.kubeflow.org/docs/gke/deploy/management-setup/). 

Adding env variables for location and update so the naming is correct. 