### PR TITLE
Redirect blog to the new location instead of Medium

### DIFF
--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -4,7 +4,7 @@
 /version/stable/gke/scripts/deploy.sh  https://raw.githubusercontent.com/kubeflow/kubeflow/v0.2.2/scripts/gke/deploy.sh
 /version/stable/scripts/deploy.sh      https://raw.githubusercontent.com/kubeflow/kubeflow/v0.2.2/scripts/deploy.sh
 /version/stable/source.tar.gz          https://github.com/kubeflow/kubeflow/archive/v0.2.2.tar.gz
-/blog/                                 https://medium.com/kubeflow
+/blog/                                 https://blog.kubeflow.org
 /blog/why_kubeflow/                    https://medium.com/kubeflow/why-kubeflow-in-your-infrastructure-56b8fabf1f3e
 /blog/announcing_kubeflow_0.3/         https://medium.com/kubeflow/kubeflow-0-3-simplifies-setup-improves-ml-development-98b8ca10bd69
 /blog/blog_posts/                      https://medium.com/kubeflow/blog-posts-about-kubeflow-7068688359f3


### PR DESCRIPTION
Blogs have been migrated to https://blog.kubeflow.org/.