### PR TITLE
docs: delete upgrading/_index.md

### DIFF
--- a/content/en/docs/upgrading/_index.md
+++ b/content/en/docs/upgrading/_index.md
@@ -1,5 +1,0 @@
-+++
-title = "Upgrading Kubeflow"
-description = "Guides to upgrading your Kubeflow deployment"
-weight = 100
-+++


### PR DESCRIPTION
Follow up of https://github.com/kubeflow/website/pull/2275

Delete top level upgrade guide

/assign @8bitmp3 
Fixes https://github.com/kubeflow/website/issues/2429