### PR TITLE
Fix KF_DIR env. var. description

### DIFF
--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -57,7 +57,7 @@ Set these environment variables in your shell:
 ```bash
 KF_NAME=<name of your Kubeflow cluster>
 KF_PROJECT=<the project where you deploy your Kubeflow cluster>
-KF_DIR=<path to your management cluster configuration directory>
+KF_DIR=<path to your Kubeflow configuration directory>
 MGMT_NAME=<name of your management cluster>
 MGMTCTXT="${MGMT_NAME}"
 ```


### PR DESCRIPTION
Replace 'management' with 'kubeflow' to describe KF_DIR env. variable, as correctly described just above there.