### PR TITLE
Add yq version in docs

### DIFF
--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -94,13 +94,12 @@ purpose. No tools will assume they actually exists in your terminal environment.
 
 1. Install [yq](https://github.com/mikefarah/yq)
 
-
    ```bash
    GO111MODULE=on go get github.com/mikefarah/yq/v3
    ```
 
    * If you don't have [Go](https://golang.org) installed you can download
-     a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases), following the repository instructions. [Version 3.3.0](https://github.com/mikefarah/yq/releases/tag/3.3.0) is confirmed to work.
+     a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases), and follow the official installation steps. [Version 3.3.0](https://github.com/mikefarah/yq/releases/tag/3.3.0) is confirmed to work.
 
 1. Follow the instructions from [Preparing to install Anthos Service Mesh](https://cloud.google.com/service-mesh/docs/archive/1.4/docs/gke-install-new-cluster#preparing_to_install_anthos_service_mesh) to install `istioctl`.
 

--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -99,7 +99,8 @@ purpose. No tools will assume they actually exists in your terminal environment.
    ```
 
    * If you don't have [Go](https://golang.org) installed you can download
-     a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases), and follow the official installation steps. [Version 3.3.0](https://github.com/mikefarah/yq/releases/tag/3.3.0) is confirmed to work.
+     a binary from [yq's GitHub releases](https://github.com/mikefarah/yq/releases), and follow the official installation steps.
+   * Note: due to changes from [yq v3 to v4](https://mikefarah.gitbook.io/yq/upgrading-from-v3#navigating), Versions 4.x of yq will not work with Kubeflow. [Version 3.3.0](https://github.com/mikefarah/yq/releases/tag/3.3.0) is confirmed to work.
 
 1. Follow the instructions from [Preparing to install Anthos Service Mesh](https://cloud.google.com/service-mesh/docs/archive/1.4/docs/gke-install-new-cluster#preparing_to_install_anthos_service_mesh) to install `istioctl`.
 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -51,7 +51,7 @@ For a more detailed explanation of the drastic changes happened in Kubeflow v1.1
 
     Then, to verify the installation, run `kustomize version`. You should see `Version:kustomize/vX.Y.Z` in the output if you've successfully deployed Kustomize.
 
-1. Install [yq](https://github.com/mikefarah/yq#install), following the repository instructions. [Version 3.3.0](https://github.com/mikefarah/yq/releases/tag/3.3.0) is confirmed to work.
+1. Install [yq](https://github.com/mikefarah/yq#install), and follow the official installation steps. [Version 3.3.0](https://github.com/mikefarah/yq/releases/tag/3.3.0) is confirmed to work.
 
 ## Environment Variables
 

--- a/content/en/docs/gke/deploy/management-setup.md
+++ b/content/en/docs/gke/deploy/management-setup.md
@@ -51,7 +51,7 @@ For a more detailed explanation of the drastic changes happened in Kubeflow v1.1
 
     Then, to verify the installation, run `kustomize version`. You should see `Version:kustomize/vX.Y.Z` in the output if you've successfully deployed Kustomize.
 
-1. Install [yq](https://github.com/mikefarah/yq#install), and follow the official installation steps. [Version 3.3.0](https://github.com/mikefarah/yq/releases/tag/3.3.0) is confirmed to work.
+1. Install [yq](https://github.com/mikefarah/yq#install), and follow the official installation steps. Note: due to changes from [yq v3 to v4](https://mikefarah.gitbook.io/yq/upgrading-from-v3#navigating), Versions 4.x of yq will not work with Kubeflow. [Version 3.3.0](https://github.com/mikefarah/yq/releases/tag/3.3.0) is confirmed to work.
 
 ## Environment Variables
 


### PR DESCRIPTION
Adding yq version `3.3.0` that worked while following the installation steps as opposed to 4.x which had made a lot of changes which were incompatible

Reason: `yq `version 4.2.1 getting an error that is `Error: unknown command "r" for "yq"`

Fixed after switching to 3.x (see discussion of other people repro below)

---
Below is outdated

`KF_DIR` refers to the Kubeflow directory, which is also confirmed in the docs a few paragraphs after this, and is different from the "management cluster directory" which the current wording on the doc says it is.