### PR TITLE
Corrected broken link to pytorch documentation

### DIFF
--- a/content/en/docs/components/serving/overview.md
+++ b/content/en/docs/components/serving/overview.md
@@ -62,7 +62,7 @@ KFServing and Seldon Core. A check mark (**&check;**) indicates that the system
       <tr>
         <td></td>
         <td>PyTorch</td>
-        <td><b>&check;</b> <a href="https://github.com/kubeflow/kfserving/tree/master/docs/samples/pytorch">sample</a></td>
+        <td><b>&check;</b> <a href="https://github.com/kubeflow/kfserving/tree/master/python/pytorchserver">sample</a></td>
         <td><b>&check;</b></td>
       </tr>
       <tr>


### PR DESCRIPTION
I suspect the correct link is https://github.com/kubeflow/kfserving/tree/master/python/pytorchserver