### PR TITLE
Add filter to gcloud accelerator list command to show zones that support the accelerator in the default configuration

### DIFF
--- a/content/en/docs/gke/deploy/deploy-cli.md
+++ b/content/en/docs/gke/deploy/deploy-cli.md
@@ -179,7 +179,7 @@ gcloud.compute.zone | The zone to use for zonal resources; must be in gcloud.com
   * For the default configuration, you need to choose a location that supports NVIDIA Tesla K80 Accelerators (`nvidia-tesla-k80`). 
     To see which accelerators are available in each zone, run the following command:
     ```
-    gcloud compute accelerator-types list
+    gcloud compute accelerator-types list --filter=name:nvidia-tesla-k80
     ```
 
 * The **Makefile** at `${KF_DIR}/Makefile` contains a rule `set-values` with appropriate `kpt cfg` commands to set the values


### PR DESCRIPTION
Added a filter to the gcloud command so that zones that support the default accelerator are listed since quite a few zones don't have it