### PR TITLE
Fix resourceQuotaSpec with GPU

### DIFF
--- a/content/en/docs/components/multi-tenancy/getting-started.md
+++ b/content/en/docs/components/multi-tenancy/getting-started.md
@@ -155,7 +155,7 @@ spec:
    hard:
      cpu: "2"
      memory: 2Gi
-     nvidia.com/gpu: "1"
+     requests.nvidia.com/gpu: "1"
      persistentvolumeclaims: "1"
      requests.storage: "5Gi"
 ```


### PR DESCRIPTION
`nvidia.com/gpu: "1"` actually doesn't work.

`requests.nvidia.com/gpu: "1"` works well.

https://kubernetes.io/docs/concepts/policy/resource-quotas/#resource-quota-for-extended-resources