### PR TITLE
Rename "Jupyter Notebooks" to "Notebook Servers"

### DIFF
--- a/content/en/docs/notebooks/_index.md
+++ b/content/en/docs/notebooks/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Jupyter Notebooks"
+title = "Notebook Servers"
 description = "Using Jupyter notebooks in Kubeflow"
 weight = 35
 +++


### PR DESCRIPTION
See #2465 