### PR TITLE
Remove deprecated link for upgrading/upgrade/

### DIFF
--- a/content/en/docs/openshift/install-kubeflow.md
+++ b/content/en/docs/openshift/install-kubeflow.md
@@ -104,7 +104,6 @@ Use the following steps to install Kubeflow 1.0 on OpenShift 4.x.
 ## Next steps
 
 * Learn about the [changes made](https://developers.redhat.com/blog/2020/08/13/open-data-hub-0-7-adds-support-for-kubeflow-1-0//) to Kubeflow manifests to enable deployment on OpenShift
-* See how to [upgrade Kubeflow](/docs/upgrading/upgrade/) and how to 
-  [upgrade or reinstall a Kubeflow Pipelines deployment](/docs/pipelines/upgrade/).
+* See how to [upgrade or reinstall a Kubeflow Pipelines deployment](/docs/pipelines/upgrade/).
 * See how to [uninstall](/docs/openshift/uninstall-kubeflow) your Kubeflow deployment 
   using the CLI.


### PR DESCRIPTION
The link for "See how to upgrade Kubeflow" in 
https://www.kubeflow.org/docs/openshift/install-kubeflow/ is invalid.

As the link was removed by 93dd06a4985828f669c322f807a59bf6f295db57
this patch removes the link as well.