### PR TITLE
[IBM] update ibm docs for openshift

### DIFF
--- a/content/en/docs/ibm/create-cluster.md
+++ b/content/en/docs/ibm/create-cluster.md
@@ -40,9 +40,9 @@ If you have an existing cluster, use it to install Kubeflow as far as it meets t
 
 Get the Kubeconfig file:
 
-	```shell
-	ibmcloud ks cluster config --cluster $CLUSTER_NAME
-	```
+```shell
+ibmcloud ks cluster config --cluster $CLUSTER_NAME
+```
 
 From here on, please see [Install Kubeflow](/docs/ibm/deploy/install-kubeflow).
 

--- a/content/en/docs/ibm/deploy/authentication.md
+++ b/content/en/docs/ibm/deploy/authentication.md
@@ -97,7 +97,7 @@ column):
 `istio-ingressgateway` pods in namespace `istio-system`:
 
     ```shell
-    kubectl get secret $INGRESS_GATEWAY_SECRET -o yaml > istio-ingressgateway-certs.yaml
+    kubectl get secret $INGRESS_GATEWAY_SECRET -n istio-system -o yaml > istio-ingressgateway-certs.yaml
     ```
 
 6. Update the `istio-ingressgateway-certs.yaml` file by changing the value of

--- a/content/en/docs/ibm/deploy/deployment-process.md
+++ b/content/en/docs/ibm/deploy/deployment-process.md
@@ -55,3 +55,7 @@ Run the following commands to set up and deploy Kubeflow:
       export PATH=$PATH:<path to where kfctl was unpacked>
       ```
  
+ ## Next Steps
+
+ 1. Go here for installing [Kubeflow on IKS](/docs/ibm/deploy/install-kubeflow-on-iks)
+ 2. Go here for installing [Kubeflow on IBM OpenShift](/docs/ibm/deploy/install-kubeflow-on-ibm-openshift)

--- a/content/en/docs/ibm/deploy/deployment-process.md
+++ b/content/en/docs/ibm/deploy/deployment-process.md
@@ -1,0 +1,57 @@
++++
+title = "Kubeflow Deployment Process"
+description = "How kubeflow installation works"
+weight = 5
++++
+
+## Understanding the Kubeflow deployment process
+
+The deployment process is controlled by the following commands:
+
+* **build** - (Optional) Creates configuration files defining the various
+  resources in your deployment. You only need to run `kfctl build` if you want
+  to edit the resources before running `kfctl apply`.
+* **apply** - Creates or updates the resources.
+* **delete** - Deletes the resources.
+
+### App layout
+
+Your Kubeflow application directory **${KF_DIR}** contains the following files and 
+directories:
+
+* **${CONFIG_FILE}** is a YAML file that defines configurations related to your 
+  Kubeflow deployment.
+
+  * This file is a copy of the GitHub-based configuration YAML file that
+    you used when deploying Kubeflow. For example, {{% config-uri-ibm %}}.
+  * When you run `kfctl apply` or `kfctl build`, kfctl creates
+    a local version of the configuration file, `${CONFIG_FILE}`,
+    which you can further customize if necessary.
+
+* **kustomize** is a directory that contains the kustomize packages for Kubeflow applications.
+    * The directory is created when you run `kfctl build` or `kfctl apply`.
+    * You can customize the Kubernetes resources (modify the manifests and run `kfctl apply` again).
+
+## Kubeflow installation
+
+**Note**: kfctl is currently available for Linux and macOS users only. If you use Windows, you can install kfctl on Windows Subsystem for Linux (WSL). Refer to the official [instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10) for setting up WSL.
+
+Run the following commands to set up and deploy Kubeflow:
+
+1. Download the latest kfctl {{% kf-latest-version %}} release from the
+  [Kubeflow releases 
+  page](https://github.com/kubeflow/kfctl/releases/tag/{{% kf-latest-version %}}).
+  
+  **Note**: You're strongly recommended to install **kfctl v1.2** or above because kfctl v1.2 addresses several critical bugs that can break the Kubeflow deployment.
+
+2. Extract the archived TAR file:
+
+      ```shell
+      tar -xvf kfctl_{{% kf-latest-version %}}_<platform>.tar.gz
+      ```
+3. Make kfctl binary easier to use (optional). If you don’t add the binary to your path, you must use the full path to the kfctl binary each time you run it.
+
+      ```shell
+      export PATH=$PATH:<path to where kfctl was unpacked>
+      ```
+ 

--- a/content/en/docs/ibm/deploy/install-kubeflow-on-IBM-openshift.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow-on-IBM-openshift.md
@@ -1,6 +1,6 @@
 +++
-title = "Install Kubeflow on Openshift"
-description = "Instructions for deploying Kubeflow on IBM Cloud Openshift"
+title = "Install Kubeflow on OpenShift"
+description = "Instructions for deploying Kubeflow on IBM Cloud OpenShift"
 weight = 7
 +++
 
@@ -78,10 +78,13 @@ kfctl apply -V -f ${CONFIG_FILE}
 The Kubeflow deployment is exposed with a Route. To find the Route you can use 
 
 ```
-oc get route -n istio-system
+oc get route -n istio-system istio-ingressgateway -o=jsonpath='{.spec.host}'
 ```
+
+## Next steps
+
+To secure the Kubeflow dashboard with HTTPS, follow the steps in [Exposing the Kubeflow dashboard with DNS and TLS termination](/docs/ibm/deploy/authentication/#setting-up-an-nlb).
 
 ## Additional information
 
 You can find general information about Kubeflow configuration in the guide to [configuring Kubeflow with kfctl and kustomize](/docs/other-guides/kustomize/).
-

--- a/content/en/docs/ibm/deploy/install-kubeflow-on-IBM-openshift.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow-on-IBM-openshift.md
@@ -25,7 +25,7 @@ This guide describes how to use the kfctl binary to deploy Kubeflow on IBM Cloud
 
 ## Installation 
 
-If you're experiencing issues during the installation because of conflicts on your Kubeflow deployment, you can [uninstall Kubeflow](../uninstall-kubeflow) and install it again.
+If you're experiencing issues during the installation because of conflicts on your Kubeflow deployment, you can [uninstall Kubeflow](/docs/ibm/deploy/uninstall-kubeflow) and install it again.
 
 ### Single user
 

--- a/content/en/docs/ibm/deploy/install-kubeflow-on-IBM-openshift.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow-on-IBM-openshift.md
@@ -1,0 +1,87 @@
++++
+title = "Install Kubeflow on Openshift"
+description = "Instructions for deploying Kubeflow on IBM Cloud Openshift"
+weight = 7
++++
+
+This guide describes how to use the kfctl binary to deploy Kubeflow on IBM Cloud Kubernetes Service (IKS).
+
+## Prerequisites
+
+* Authenticate with IBM Cloud
+
+  Log into IBM Cloud at [IBM Cloud](https://cloud.ibm.com)
+
+* Install OpenShift CLI
+
+  OpenShift CLI is the way to manage and access OpenShift cluster. You can [Install OpenShift CLI](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift-cli) from this instructions.
+
+* Create and access a OpenShift cluster on IKS
+
+  To deploy Kubeflow on IBM Cloud, you need a cluster running OpenShift on IKS. If you don't have a cluster running, follow the [Create an IBM Cloud OpenShift cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-clusters) guide.
+
+  To access the cluster follow these directions [Access OpenShift Cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster). We can easily get access from the openshift console on IBM Cloud[Connecting to the cluster from the console](https://cloud.ibm.com/docs/openshift?topic=openshift-access_cluster#access_oc_console).
+
+
+## Installation 
+
+If you're experiencing issues during the installation because of conflicts on your Kubeflow deployment, you can [uninstall Kubeflow](../uninstall-kubeflow) and install it again.
+
+### Single user
+
+Run the following commands to set up and deploy Kubeflow for a single user without any authentication.
+
+**Note**: By default, Kubeflow deployment on IBM Cloud uses the [Kubeflow pipeline with the Tekton backend](https://github.com/kubeflow/kfp-tekton#kubeflow-pipelines-with-tekton).
+If you want to use the Kubeflow pipeline with the Argo backend, you can change `CONFIG_URI` to this kfdef instead
+
+```
+https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_openshift.v1.2.0.yaml
+```
+
+```shell
+# Set KF_NAME to the name of your Kubeflow deployment. This also becomes the
+# name of the directory containing your configuration.
+# For example, your deployment name can be 'my-kubeflow' or 'kf-test'.
+export KF_NAME=<your choice of name for the Kubeflow deployment>
+
+# Set the path to the base directory where you want to store one or more 
+# Kubeflow deployments. For example, /opt/.
+# Then set the Kubeflow application directory for this deployment.
+export BASE_DIR=<path to a base directory>
+export KF_DIR=${BASE_DIR}/${KF_NAME}
+
+# Set the configuration file to use, such as:
+export CONFIG_FILE=kfctl_ibm.yaml
+export CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_openshift.master.kfptekton.yaml"
+
+# Generate Kubeflow:
+mkdir -p ${KF_DIR}
+cd ${KF_DIR}
+curl -L ${CONFIG_URI} > ${CONFIG_FILE}
+
+# Deploy Kubeflow. You can customize the CONFIG_FILE if needed.
+kfctl apply -V -f ${CONFIG_FILE}
+```
+
+* **${KF_NAME}** - The name of your Kubeflow deployment.
+  If you want a custom deployment name, specify that name here.
+  For example,  `my-kubeflow` or `kf-test`.
+  The value of KF_NAME must consist of lower case alphanumeric characters or
+  '-', and must start and end with an alphanumeric character.
+  The value of this variable cannot be greater than 25 characters. It must
+  contain just a name, not a directory path.
+  This value also becomes the name of the directory where your Kubeflow 
+  configurations are stored, that is, the Kubeflow application directory. 
+
+* **${KF_DIR}** - The full path to your Kubeflow application directory.
+
+The Kubeflow deployment is exposed with a Route. To find the Route you can use 
+
+```
+oc get route -n istio-system
+```
+
+## Additional information
+
+You can find general information about Kubeflow configuration in the guide to [configuring Kubeflow with kfctl and kustomize](/docs/other-guides/kustomize/).
+

--- a/content/en/docs/ibm/deploy/install-kubeflow-on-iks.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow-on-iks.md
@@ -104,7 +104,7 @@ get the best experience from Kubeflow.
 
 Choose either **single user** or **multi-tenant** section based on your usage.
 
-If you're experiencing issues during the installation because of conflicts on your Kubeflow deployment, you can [uninstall Kubeflow](../uninstall-kubeflow) and install it again.
+If you're experiencing issues during the installation because of conflicts on your Kubeflow deployment, you can [uninstall Kubeflow](/docs/ibm/deploy/uninstall-kubeflow) and install it again.
 
 ### Single user
 

--- a/content/en/docs/ibm/deploy/install-kubeflow-on-iks.md
+++ b/content/en/docs/ibm/deploy/install-kubeflow-on-iks.md
@@ -1,7 +1,7 @@
 +++
-title = "Install Kubeflow"
-description = "Instructions for deploying Kubeflow on IBM Cloud"
-weight = 5
+title = "Install Kubeflow on IKS"
+description = "Instructions for deploying Kubeflow on IBM Cloud Kubernetes Service"
+weight = 6
 +++
 
 This guide describes how to use the kfctl binary to deploy Kubeflow on IBM Cloud Kubernetes Service (IKS).
@@ -100,61 +100,11 @@ get the best experience from Kubeflow.
     kubectl patch storageclass ${OLD_STORAGE_CLASS} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
     ```
 
-## Understanding the Kubeflow deployment process
+## Installation 
 
-The deployment process is controlled by the following commands:
-
-* **build** - (Optional) Creates configuration files defining the various
-  resources in your deployment. You only need to run `kfctl build` if you want
-  to edit the resources before running `kfctl apply`.
-* **apply** - Creates or updates the resources.
-* **delete** - Deletes the resources.
-
-### App layout
-
-Your Kubeflow application directory **${KF_DIR}** contains the following files and 
-directories:
-
-* **${CONFIG_FILE}** is a YAML file that defines configurations related to your 
-  Kubeflow deployment.
-
-  * This file is a copy of the GitHub-based configuration YAML file that
-    you used when deploying Kubeflow. For example, {{% config-uri-ibm %}}.
-  * When you run `kfctl apply` or `kfctl build`, kfctl creates
-    a local version of the configuration file, `${CONFIG_FILE}`,
-    which you can further customize if necessary.
-
-* **kustomize** is a directory that contains the kustomize packages for Kubeflow applications.
-    * The directory is created when you run `kfctl build` or `kfctl apply`.
-    * You can customize the Kubernetes resources (modify the manifests and run `kfctl apply` again).
-
-
-## Kubeflow installation
-
-**Note**: kfctl is currently available for Linux and macOS users only. If you use Windows, you can install kfctl on Windows Subsystem for Linux (WSL). Refer to the official [instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10) for setting up WSL.
-
-Run the following commands to set up and deploy Kubeflow:
-
-1. Download the latest kfctl {{% kf-latest-version %}} release from the
-  [Kubeflow releases 
-  page](https://github.com/kubeflow/kfctl/releases/tag/{{% kf-latest-version %}}).
-  
-  **Note**: You're strongly recommended to install **kfctl v1.2** or above because kfctl v1.2 addresses several critical bugs that can break the Kubeflow deployment.
-
-2. Extract the archived TAR file:
-
-      ```shell
-      tar -xvf kfctl_{{% kf-latest-version %}}_<platform>.tar.gz
-      ```
-3. Make kfctl binary easier to use (optional). If you don’t add the binary to your path, you must use the full path to the kfctl binary each time you run it.
-
-      ```shell
-      export PATH=$PATH:<path to where kfctl was unpacked>
-      ```
-    
 Choose either **single user** or **multi-tenant** section based on your usage.
 
-If you're experiencing issues during the installation because of conflicts on your Kubeflow deployment, you can [uninstall Kubeflow](#uninstall-kubeflow) and install it again.
+If you're experiencing issues during the installation because of conflicts on your Kubeflow deployment, you can [uninstall Kubeflow](../uninstall-kubeflow) and install it again.
 
 ### Single user
 
@@ -351,13 +301,3 @@ Then, you can locate the LoadBalancer in the **EXTERNAL_IP** column when you run
 kubectl get svc istio-ingressgateway -n istio-system
 ```
 
-### Uninstall Kubeflow
-
-To uninstall Kubeflow and clean up all the local cache, run the following command:
-
-```shell
-kfctl delete -f ${CONFIG_FILE}
-rm -rf kustomize .cache
-```
-
-where `${CONFIG_FILE}` is the [kfdef](https://www.kubeflow.org/docs/other-guides/kustomize/#specifying-a-configuration-file-when-initializing-your-deployment) for deploying Kubeflow.

--- a/content/en/docs/ibm/deploy/uninstall-kubeflow.md
+++ b/content/en/docs/ibm/deploy/uninstall-kubeflow.md
@@ -13,4 +13,5 @@ cd ${KF_DIR}
 
 # Remove Kubeflow
 kfctl delete -f ${CONFIG_FILE}
+rm -rf kustomize .cache
 ```


### PR DESCRIPTION
- Update kubeflow installtion docs for ibm openshift
- reorganize kfctl installation and deployment process to a separate file to remove duplication
- move `uninstall-kubeflow` instruction from installation steps to remove redundancy
- change link that pointed to uninstalling step on kubeflow install step to point to `uninstall-kubeflow` page
- fix a markdown formatting issue in `ibm/create-cluster.md` file