### PR TITLE
Remove the outdated banner for cloud storage

### DIFF
--- a/content/en/docs/started/cloud/getting-started-azure.md
+++ b/content/en/docs/started/cloud/getting-started-azure.md
@@ -3,10 +3,6 @@ description = "Get Kubeflow running on Microsoft Azure"
 weight = 2
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 Please refer to the [deployment section](/docs/azure/deploy) in the 
 [Azure docs](/docs/azure/) for information on setting up your Azure environment and deploying Kubeflow on an existing Azure Resource Group or Cluster for AKS (Azure Kubernetes Service).


### PR DESCRIPTION
Remove the banner indicating outdated and directly land user to the installation page. This will align with pages for GKE and IBM.