### PR TITLE
Update aws-e2e.md to resolve 404s on model yaml files and update kfserving version to resolve x509 error

### DIFF
--- a/content/en/docs/aws/aws-e2e.md
+++ b/content/en/docs/aws/aws-e2e.md
@@ -309,7 +309,7 @@ webhook-5846486ff4-4ltjq            1/1     Running   0          18d
 #### Deploy kfserving
 Install KFserving using the manifest file:
 ```shell script
-kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfserving/master/install/0.2.2/kfserving.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfserving/master/install/v0.4.1/kfserving.yaml
 ```
 That will create a `kfserving-system` namespace with one pod running.
 
@@ -318,9 +318,9 @@ That will create a `kfserving-system` namespace with one pod running.
 Deploy a Tensorflow, a PyTorch and a Scikit-learn model using KFserving:
 
 ```shell script
-kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfserving/master/docs/samples/tensorflow/tensorflow.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfserving/master/docs/samples/pytorch/pytorch.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfserving/master/docs/samples/sklearn/sklearn.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfserving/master/docs/samples/v1alpha2/tensorflow/tensorflow.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfserving/master/docs/samples/v1alpha2/pytorch/pytorch.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubeflow/kfserving/master/docs/samples/v1alpha2/sklearn/sklearn.yaml
 ```
 
 Validate that all three inference services are available:


### PR DESCRIPTION
Updated kfserving to the latest stable version to avoid the following error: failed calling webhook "inferenceservice.kfserving-webhook-server.defaulter": x509: certificate signed by unknown authority.

Updated paths to model yaml files to avoid 404s