### PR TITLE
Removing "Out of date" from Central Dashboard docs

### DIFF
--- a/content/en/docs/components/central-dash/overview.md
+++ b/content/en/docs/components/central-dash/overview.md
@@ -4,10 +4,6 @@ description = "Overview of the Kubeflow user interfaces (UIs)"
 weight = 10
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 {{% stable-status %}}
 


### PR DESCRIPTION
From a quick look at this file, and since it has no OWNERS I'd say we should remove "Outdated" banner.