### PR TITLE
Update IBM storage config

### DIFF
--- a/content/en/docs/ibm/create-cluster.md
+++ b/content/en/docs/ibm/create-cluster.md
@@ -56,7 +56,7 @@ Follow these steps to create and setup a new [IBM Cloud Kubernetes Service(IKS) 
 Choose the region and the worker node provider for your cluster, and set the environment variables.
 
 ```shell
-export KUBERNERTES_VERSION=1.16
+export KUBERNERTES_VERSION=1.17
 export CLUSTER_ZONE=dal13
 export WORKER_NODE_PROVIDER=classic
 export CLUSTER_NAME=kubeflow


### PR DESCRIPTION
The IKS with classic VM is getting group ID support for the file storage on Kubernetes 1.17+. Since file storage will continue to be the default for classic VM, we will change the recommended classic VM storage to `ibmc-file-gold-gid` to minimize maintenance support.

For OpenShift and other types of VM, block storage is the default and we don't need any extra instructions to configure it.