### PR TITLE
Add Katib config PV reclaim policy

### DIFF
--- a/content/en/docs/components/katib/katib-config.md
+++ b/content/en/docs/components/katib/katib-config.md
@@ -369,7 +369,14 @@ suggestion: |-
   `<suggestion-name>-<suggestion-algorithm>-<suggestion-namespace>`
   to the path. That makes host paths unique across suggestions.
 
-  **Note:** PV `storageClassName` is always equal to **`katib-suggestion`**.
+  **Note:**
+
+  - PV `storageClassName` is always equal to **`katib-suggestion`**.
+
+  - PV `persistentVolumeReclaimPolicy` is always equal to **`Delete`** to properly
+    remove all resources once Katib experiment is deleted. To know more about
+    PV reclaim policies check the
+    [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming).
 
 ## Early stopping settings
 


### PR DESCRIPTION
Related to: https://github.com/kubeflow/katib/blob/master/pkg/util/v1beta1/katibconfig/config.go#L130.
I added info about `persistentVolumeReclaimPolicy` for the Suggestion's PV.

/cc @gaocegege @johnugeorge @RFMVasconcelos 