### PR TITLE
Add RFMVasconcelos to OWNERS/approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ approvers:
   - animeshsingh
   - Bobgy
   - joeliedtke
+  - RFMVasconcelos
 reviewers:
   - 8bitmp3
   - aronchick
@@ -9,9 +10,7 @@ reviewers:
   - dansanche
   - dsdinter
   - Jeffwan
-  - jinchihe  
+  - jinchihe
   - nickchase
   - pdmack
-  - RFMVasconcelos
-  - terrytangyuan  
-
+  - terrytangyuan


### PR DESCRIPTION
I would like to nominate @RFMVasconcelos as an approver for `kubeflow/website` in recognition of his significant contributions, and with him being the most active committer to the docs.

NOTE: the other diffs are removing some random spaces at the end of the lines