### PR TITLE
Modify links for the Katib manifests

### DIFF
--- a/content/en/docs/components/katib/env-variables.md
+++ b/content/en/docs/components/katib/env-variables.md
@@ -17,7 +17,7 @@ environment variable in an appropriate Katib component's manifest.
 ## Katib Controller
 
 Bellow are the environment variables for the
-[Katib Controller](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/katib-controller/katib-controller.yaml)
+[Katib Controller](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/controller/controller.yaml)
 deployment:
 
 <div class="table-responsive">
@@ -79,7 +79,7 @@ If you want to use your own DB Manager to report Katib metrics, you can change `
 ## Katib UI
 
 Below are the environment variables for the
-[Katib UI](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/ui/deployment.yaml)
+[Katib UI](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/ui/ui.yaml)
 deployment:
 
 <div class="table-responsive">
@@ -126,7 +126,7 @@ Katib UI calls Katib DB Manager with the same address expression as Katib Contro
 ## Katib DB Manager
 
 Bellow are the environment variables for the
-[Katib DB Manager](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/db-manager/deployment.yaml)
+[Katib DB Manager](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/db-manager/db-manager.yaml)
 deployment:
 
 <div class="table-responsive">
@@ -182,7 +182,7 @@ deployment:
 
 Currently, Katib DB Manager supports only **MySQL** database. You can use your own DB Manager and Database to report metrics.
 
-For the [Katib DB Manager](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/db-manager/deployment.yaml#L29)
+For the [Katib DB Manager](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/db-manager/db-manager.yaml#L25)
 you can change `DB_PASSWORD` to your own MySQL DB password.
 
 Katib DB Manager creates connection to the DB, using `mysql` driver and this data source name:
@@ -191,10 +191,10 @@ Katib DB Manager creates connection to the DB, using `mysql` driver and this dat
 
 ## Katib MySQL DB
 
-For the [Katib MySQL](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/mysql-db/deployment.yaml)
+For the [Katib MySQL](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/mysql/mysql.yaml)
 you need to set these environment variables:
 
-- `MYSQL_ROOT_PASSWORD` to a value from [katib-mysql-secrets](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/mysql-db/secret.yaml),
+- `MYSQL_ROOT_PASSWORD` to a value from [katib-mysql-secrets](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/mysql/secret.yaml),
   which is equal to "test".
 - `MYSQL_ALLOW_EMPTY_PASSWORD` as `true`
 - `MYSQL_DATABASE` as `katib`.

--- a/content/en/docs/components/katib/hyperparameter.md
+++ b/content/en/docs/components/katib/hyperparameter.md
@@ -34,6 +34,9 @@ git clone https://github.com/kubeflow/katib
 make deploy
 ```
 
+**Note:** You should have [kustomize](https://kustomize.io/) version >= 3.2 to
+install Katib.
+
 ### Setting up persistent volumes
 
 If you used the [above-mentioned script](#katib-install) to deploy Katib,
@@ -57,11 +60,11 @@ After deploying Katib to your cluster, run the following command to create the
 PV:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubeflow/katib/master/manifests/v1beta1/pv/pv.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubeflow/katib/master/manifests/v1beta1/components/mysql/pv.yaml
 ```
 
 The above `kubectl apply` command uses a YAML file -
-[`pv.yaml`](https://raw.githubusercontent.com/kubeflow/katib/master/manifests/v1beta1/pv/pv.yaml) -
+[`pv.yaml`](https://raw.githubusercontent.com/kubeflow/katib/master/manifests/v1beta1/components/mysql/pv.yaml) -
 that defines the properties of the PV.
 
 <a id="katib-ui"></a>

--- a/content/en/docs/components/katib/katib-config.md
+++ b/content/en/docs/components/katib/katib-config.md
@@ -6,7 +6,7 @@ weight = 70
 +++
 
 This guide describes
-[Katib config](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/katib-controller/katib-config.yaml) —
+[Katib config](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/controller/katib-config.yaml) —
 the Kubernetes
 [Config Map](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) that contains information about:
 

--- a/content/en/docs/components/katib/trial-template.md
+++ b/content/en/docs/components/katib/trial-template.md
@@ -89,7 +89,7 @@ To define experiment's trial, you should specify these parameters in `.spec.tria
     trial template is located. This ConfigMap must have the label
     `app: katib-trial-templates` and contains key-value pairs, where
     `key: <template-name>, value: <template-yaml>`. Check the example of the
-    [ConfigMap with trial templates](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/katib-controller/trial-template-configmap.yaml).
+    [ConfigMap with trial templates](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/controller/trial-templates.yaml).
 
     The `configMap` specification should have:
 
@@ -249,7 +249,7 @@ to know more about CRDs.
 Follow these two simple steps to integrate your custom CRD in Katib:
 
 1. Modify Katib controller
-   [ClusterRole's rules](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/katib-controller/rbac.yaml#L5)
+   [ClusterRole's rules](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/controller/rbac.yaml#L5)
    with the new rule to give Katib access to all resources that are created
    by the trial. To know more about ClusterRole, check
    [Kubernetes guide](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).
@@ -269,9 +269,9 @@ Follow these two simple steps to integrate your custom CRD in Katib:
    ```
 
 1. Modify Katib controller
-   [Deployment's `args`](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/katib-controller/katib-controller.yaml#L26)
-   with the new
-   `--trial-resources=<object-kind>.<object-API-version>.<object-API-group>` flag.
+   [Deployment's `args`](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/controller/controller.yaml#L26)
+   with the new flag:
+   `--trial-resources=<object-kind>.<object-API-version>.<object-API-group>`.
 
    For example, to support Tekton `Pipeline`:
 


### PR DESCRIPTION
Blocked by: https://github.com/kubeflow/katib/pull/1464.
We changed our Katib manifest structure, I made appropriate changes in the links.
