### PR TITLE
Limit Kustomize version to 3.x.x

### DIFF
--- a/content/en/docs/distributions/gke/deploy/deploy-cli.md
+++ b/content/en/docs/distributions/gke/deploy/deploy-cli.md
@@ -78,13 +78,14 @@ purpose. No tools will assume they actually exists in your terminal environment.
 
 1. Install [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/).
 
-    **Note:** Prior to Kubeflow v1.2, Kubeflow was compatible only with Kustomize `v3.2.1`. Starting from Kubeflow v1.2, you can now use the latest Kustomize versions to install Kubeflow.
+    **Note:** Prior to Kubeflow v1.2, Kubeflow was compatible only with Kustomize `v3.2.1`. Starting from Kubeflow v1.2, you can now use a newer version of `v3.x.x` but not a `v4.x.x` version.
 
-    To deploy the latest version of Kustomize on a Linux or Mac machine, run the following commands:
+    To deploy 3.x.x version of Kustomize on a Linux or Mac machine, run the following commands:
 
     ```bash
     # Detect your OS and download the corresponding latest Kustomize binary
-    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  > install_kustomize.sh
+    bash ./install_kustomize.sh 3.10.0
 
     # Add the kustomize package to your $PATH env variable
     sudo mv ./kustomize /usr/local/bin/kustomize


### PR DESCRIPTION
Kustomize version 4.x is incompatible with the current syntax.
