### PR TITLE
update broken link

### DIFF
--- a/content/en/docs/components/pipelines/sdk/pipelines-with-tekton.md
+++ b/content/en/docs/components/pipelines/sdk/pipelines-with-tekton.md
@@ -5,7 +5,7 @@ weight = 140
                     
 +++
 
-You can use the [KFP-Tekton SDK](https://github.com/kubeflow/kfp-tekton/sdk)
+You can use the [KFP-Tekton SDK](https://github.com/kubeflow/kfp-tekton/tree/master/sdk)
 to compile, upload and run your Kubeflow Pipeline DSL Python scripts on a
 [Kubeflow Pipelines with Tekton backend](https://github.com/kubeflow/kfp-tekton/tree/master/tekton_kfp_guide.md).
 


### PR DESCRIPTION
The link https://github.com/kubeflow/kfp-tekton/sdk is 404 for me believe it should be  https://github.com/kubeflow/kfp-tekton/tree/master/sdk