### PR TITLE
UPDATE fix broken links to tensoflorw serving

### DIFF
--- a/content/en/docs/gke/gcp-e2e.md
+++ b/content/en/docs/gke/gcp-e2e.md
@@ -124,7 +124,7 @@ It's time to get started!
 
 [tensorflow]: https://www.tensorflow.org/
 [tf-train]: https://www.tensorflow.org/api_guides/python/train
-[tf-serving]: https://www.tensorflow.org/serving/
+[tf-serving]: https://www.tensorflow.org/tfx/guide/serving
 
 [kubernetes]: https://kubernetes.io/
 [kubernetes-engine]: https://cloud.google.com/kubernetes-engine/

--- a/content/en/docs/ibm/iks-e2e.md
+++ b/content/en/docs/ibm/iks-e2e.md
@@ -83,4 +83,4 @@ It's time to get started!
 [mnist-data]: http://yann.lecun.com/exdb/mnist/index.html
 [tensorflow]: https://www.tensorflow.org/
 [tf-train]: https://www.tensorflow.org/api_guides/python/train
-[tf-serving]: https://www.tensorflow.org/serving/
+[tf-serving]: https://www.tensorflow.org/tfx/guide/serving

--- a/content/en/serving.svg
+++ b/content/en/serving.svg
@@ -62,7 +62,7 @@
      transform="translate(194.55005,-307.89663)">
     <a
        id="a3826"
-       xlink:href="https://www.tensorflow.org/serving/"
+       xlink:href="https://www.tensorflow.org/tfx/guide/serving"
        target="_blank"
        xlink:title="Tensorflow Serving"
        transform="matrix(1.1600221,0,0,1.1479458,66.012361,-64.226551)">


### PR DESCRIPTION
The links to https://www.tensorflow.org/serving/ gives me a 404 believe it should be https://www.tensorflow.org/tfx/guide/serving. 