### PR TITLE
Make kfctl first distribution

### DIFF
--- a/content/en/docs/distributions/kfctl/_index.md
+++ b/content/en/docs/distributions/kfctl/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "kfctl"
 description = "How to use the kfctl method for Kubeflow"
-weight = 60
+weight = 10
 +++


### PR DESCRIPTION
Looking at the current distributions list, I believe that kfctl should always be the first on the list, as it is the community endorsed method. 
