### PR TITLE
KFP - Updates guide to building components

### DIFF
--- a/content/en/docs/components/pipelines/sdk/component-development.md
+++ b/content/en/docs/components/pipelines/sdk/component-development.md
@@ -60,12 +60,18 @@ component has finished, the component's outputs are returned as files.
 
 When you design your component's code, consider the following:
 
-*   Which inputs are small enough to pass by value? Examples of inputs that you
-    can pass by value include numbers, booleans, and short strings. All other
-    inputs must be stored as files, with the paths passed into your function.
-*   Your component's outputs must be stored as files. Kubeflow Pipelines passes
-    paths as inputs to your component paths that you can use to store your
-    component's outputs.
+*   Which inputs can be passed to your component by value? Examples of inputs that you
+    can pass by value include numbers, booleans, and short strings. Any value that you
+    could reasonably pass as a command-line argument can be passed to your component by
+    value.  All other inputs must be stored as files, with the paths passed into your function.
+*   To return an output from your component, the output's data must be stored as a file.
+    When you define your component, you let Kubeflow Pipelines know what outputs your
+    component produces. When your pipeline runs, Kubeflow Pipelines passes the
+    paths that you use to store your component's outputs as inputs to your component.
+*   Outputs are typically written to a single file. In some cases, you may need to
+    return a directory of files as an output. In this case, create a directory at the
+    output path and write the output files to that location. In both cases, it may be
+    necessary to create parent directories if they do not exist.
 *   Your component's goal may be to create a dataset in an external service,
     such as a BigQuery table. In this case, it may make sense for the component
     to output an identifier for the produced data, such as a table name,

--- a/content/en/docs/components/pipelines/sdk/component-development.md
+++ b/content/en/docs/components/pipelines/sdk/component-development.md
@@ -63,7 +63,7 @@ When you design your component's code, consider the following:
 *   Which inputs can be passed to your component by value? Examples of inputs that you
     can pass by value include numbers, booleans, and short strings. Any value that you
     could reasonably pass as a command-line argument can be passed to your component by
-    value.  All other inputs must be stored as files, with the paths passed into your function.
+    value.  All other inputs are passed to your component by a reference to the input's path.
 *   To return an output from your component, the output's data must be stored as a file.
     When you define your component, you let Kubeflow Pipelines know what outputs your
     component produces. When your pipeline runs, Kubeflow Pipelines passes the

--- a/content/en/docs/components/pipelines/sdk/component-development.md
+++ b/content/en/docs/components/pipelines/sdk/component-development.md
@@ -64,13 +64,13 @@ When you design your component's code, consider the following:
     can pass by value include numbers, booleans, and short strings. All other
     inputs must be stored as files, with the paths passed into your function.
 *   Your component's outputs must be stored as files. Kubeflow Pipelines passes
-    paths as inputs to your component paths you can use to store your
+    paths as inputs to your component paths that you can use to store your
     component's outputs.
 *   Your component's goal may be to create a dataset in an external service,
     such as a BigQuery table. In this case, it may make sense for the component
     to output an identifier for the produced data, such as a table name,
     instead of the data itself. We recommend that you limit this pattern to
-    cases where the data must be put into external system instead of keeping it
+    cases where the data must be put into an external system instead of keeping it
     inside the Kubeflow Pipelines system.
 *   Since your inputs and output paths are passed in as command-line
     arguments, your component's code must be able to read inputs from the
@@ -209,7 +209,7 @@ section provides some guidelines on standard container creation.
     necessary, revise your application and Dockerfile until your application
     works as expected in the container.
 
-[python37]: https://hub.docker.com/layers/python/library/python/3.7/images/sha256-b007078db11636d951871b9652ae27008cf258d7bee7719b192441c88acf3027?context=explore
+[python37]: https://hub.docker.com/_/python
 [docker]: https://docs.docker.com/get-started/
 [dockerfile]: https://docs.docker.com/engine/reference/builder/
 [google-container-registry]: https://cloud.google.com/container-registry/docs/
@@ -286,7 +286,7 @@ component's implementation.
 
     *   `{inputPath: <input-name>}`:
         This placeholder is replaced with the path to this input as a file.
-        Your component can read the content's of that input at that path during
+        Your component can read the contents of that input at that path during
         the pipeline run.
 
     *   `{outputPath: <output-name>}`:
@@ -328,7 +328,7 @@ The following examples demonstrate how to specify your component's interface.
     ```
 
     Note: `Input 1` and `Parameter 1` do not specify any details about how they
-    are stored or how much data they contain. The Kubeflow Pipelines system  Consider using naming conventions
+    are stored or how much data they contain. Consider using naming conventions
     to indicate if inputs are expected to be small enough to pass by value. 
 
 1.  After your component finishes its task, the component's outputs are passed
@@ -555,7 +555,7 @@ See this [sample component][org-sample] for a real-life component example.
   [build lightweight Python function-based components](/docs/components/pipelines/sdk/python-function-components/)
   directly from Python functions.
 * See how to [export metrics from your
-  pipeline](/docs/components/pipelines/metrics/pipelines-metrics/).
+  pipeline](/docs/components/pipelines/sdk/pipelines-metrics/).
 * Visualize the output of your component by
   [adding metadata for an output
   viewer](/docs/components/pipelines/metrics/output-viewer/).

--- a/content/en/docs/components/pipelines/sdk/component-development.md
+++ b/content/en/docs/components/pipelines/sdk/component-development.md
@@ -1,85 +1,93 @@
 +++
-title = "Create Reusable Components"
-description = "A detailed tutorial on creating components that you can use in various pipelines"
+title = "Building Components"
+description = "A tutorial on how to create components and use them in a pipeline"
 weight = 40
-
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
-This page describes how to author a reusable component that you can
-load and use as part of a pipeline.
+A pipeline component is a self-contained set of code that performs one step in
+your ML workflow. This document describes the concepts required to build
+components, and demonstrates how to get started building components.
 
-If you're new to
-pipelines, see the conceptual guides to [pipelines](/docs/components/pipelines/concepts/pipeline/)
-and [components](/docs/components/pipelines/concepts/component/).
+## Before you begin
 
-This tutorial describes the manual way of writing a full component program (in any language) and a component definition for it.
-For quickly building component from a python function see [Build component from Python function](/docs/components/pipelines/sdk/lightweight-python-components/) and [Data Passing in Python components](https://github.com/kubeflow/pipelines/blob/master/samples/tutorials/Data%20passing%20in%20python%20components.ipynb).
+Run the following command to install the Kubeflow Pipelines SDK.
 
-## Summary
+```python
+$ pip3 install kfp --upgrade
+```
 
-Below is a summary of the steps involved in creating and using a component:
+For more information about the Kubeflow Pipelines SDK, see the [SDK reference guide][sdk-ref].
 
-1.  Write the program that contains your component's logic. The program must
-    use files and command-line arguments to pass data to and from the component.
-1.  Containerize the program.
-1.  Write a component specification in YAML format that describes the
-    component for the Kubeflow Pipelines system.
-1.  Use the Kubeflow Pipelines SDK to load your component, use it in a pipeline and run that pipeline.
+[sdk-ref]: https://kubeflow-pipelines.readthedocs.io/en/latest/index.html
 
-The rest of this page gives some explanation about input and output data,
-followed by detailed descriptions of the above steps.
+## Understanding pipeline components
 
-## Components and data passing
+Pipeline components are self-contained sets of code that perform one step in
+your ML workflow, such as preprocessing data or training a model. To create a
+component, you must _build the component's implementation_ and _define the
+component specification_.
 
-The concept of component is very similar to the concept of a function.
-Every component can have inputs and outputs (which must be declared in the component specification).
-The component code takes the data passed to its inputs and produces the data for its outputs.
-A pipeline then connects component instances together by passing data from outputs of some components to inputs of other components.
-That's very similar to how a function calls other functions and passes the results between them.
-The Pipelines system handles the actual data passing while the components are responsible for consuming the input data and producing the output data.
+Your component's implementation includes the component's executable code and
+the Docker container image that the code runs in.  [Learn more about designing
+a pipeline component](#design).
 
-## Passing the data to and from the containerized program
+Once you have built your component's implementation, you can define your
+component's interface as a component specification. A component specification
+defines:
 
-When creating a component you need to think about how the component
-will communicate with upstream and downstream components. That is, how it will consume
-the input data and produce the output data.
+*   The component's inputs and outputs.
+*   The container image that your component's code runs in, the command to use
+    to run your component's code, and the command-line arguments to pass to
+    your component's code.
+*   The component's metadata, such as the name and description.
 
-### Producing data
+[Learn more about creating a component specification](#component-spec).
 
-To output any piece of data, the component program must write the output data to some location and inform the system
-about that location so that the system can pass the data between steps.
-The program should accept the paths for the output data as command-line arguments. That is, you should not hardcode the paths.
+If your component's code is implemented as a Python function, use the
+Kubeflow Pipelines SDK to package your function as a component. [Learn more
+about building Python function-based components][python-function-components].
 
-In practical terms this means that the program should receive local paths for every output the component produces and write data to those paths.
-Usually an output is a single piece of data. In this case the program should treat the given output path as a file path, open it for writing and write the data there.
-In some cases there is a need to output a directory of files. In this case the program should treat the given output path as a directory path, create a directory at that location and then add files to that directory. In both cases it might be necessary to create parent directories if they do not exist.
+[python-function-components]: https://www.kubeflow.org/docs/pipelines/sdk/python-function-components/
 
-#### Advanced: Producing data in an external system
+<a name="design"></a>
+## Designing a pipeline component
 
-In some scenarios, the goal of the component is to create some data object in an external service (for example a BigQuery table).
-In this case the component program should do that and then output some identifier of the produced data location (for example BigQuery table name) instead of the data itself.
-This scenario should be limited to cases where the data must be put into external system instead of keeping it inside the Kubeflow Pipelines system.
-The class of components where this behavior is common is exporters (for example "upload data to GCS").
-Note that the Pipelines system cannot provide consistency and reproducibility guarantees for the data outside of its control.
+When Kubeflow Pipelines executes a component, a container image is started in a
+Kubernetes Pod and your component's inputs are passed in as command-line
+arguments. You can pass small inputs, such as strings and numbers, by value.
+Larger inputs, such as CSV data, must be passed as paths to files. When your
+component has finished, the component's outputs are returned as files.
 
-### Consuming data
+When you design your component's code, consider the following:
 
-There are two main ways a command-line program usually consumes data:
+*   Which inputs are small enough to pass by value? Examples of inputs that you
+    can pass by value include numbers, booleans, and short strings. All other
+    inputs must be stored as files, with the paths passed into your function.
+*   Your component's outputs must be stored as files. Kubeflow Pipelines passes
+    paths as inputs to your component paths you can use to store your
+    component's outputs.
+*   Your component's goal may be to create a dataset in an external service,
+    such as a BigQuery table. In this case, it may make sense for the component
+    to output an identifier for the produced data, such as a table name,
+    instead of the data itself. We recommend that you limit this pattern to
+    cases where the data must be put into external system instead of keeping it
+    inside the Kubeflow Pipelines system.
+*   Since your inputs and output paths are passed in as command-line
+    arguments, your component's code must be able to read inputs from the
+    command line. If your component is built with Python, libraries such as
+    [argparse](https://docs.python.org/3/library/argparse.html) and
+    [absl.flags](https://abseil.io/docs/python/guides/flags) make it easier to
+    read your component's inputs.
+*   Your component's code can be implemented in any language, so long as it can
+    run in a container image.
 
-* Small pieces of data are usually passed as command-line arguments: `program.py --param1 100`.
-* Bigger data or binary data is usually stored in files and then the file paths are passed to the program: `program.py --data1 /inputs/data1.txt`. The system needs to be aware about the need to put some data into files and pass their paths to the program.
+The following is an example program written using Python3. This program reads a
+given number of lines from an input file and writes those lines to an output
+file. This means that this function accepts three command-line parameters: 
 
-## Writing the program code
-
-This section describes an example program that has two inputs (for small and
-large pieces of data) and one output. Although the programming language in this example
-is Python 3, you can build your component in any language.
-
-### program.py
+*   The path to the input file.
+*   The number of lines to read.
+*   The path to the output file. 
 
 ```python
 #!/usr/bin/env python3
@@ -92,15 +100,20 @@ def do_work(input1_file, output1_file, param1):
     if x >= param1:
       break
     _ = output1_file.write(line)
-
+  
 # Defining and parsing the command-line arguments
 parser = argparse.ArgumentParser(description='My program description')
-parser.add_argument('--input1-path', type=str, help='Path of the local file containing the Input 1 data.') # Paths should be passed in, not hardcoded
-parser.add_argument('--param1', type=int, default=100, help='Parameter 1.')
-parser.add_argument('--output1-path', type=str, help='Path of the local file where the Output 1 data should be written.') # Paths should be passed in, not hardcoded
+# Paths must be passed in, not hardcoded
+parser.add_argument('--input1-path', type=str,
+  help='Path of the local file containing the Input 1 data.')
+parser.add_argument('--output1-path', type=str,
+  help='Path of the local file where the Output 1 data should be written.')
+parser.add_argument('--param1', type=int, default=100,
+  help='The number of lines to read from the input and write to the output.')
 args = parser.parse_args()
 
-# Creating the directory where the output file will be created (the directory may or may not exist).
+# Creating the directory where the output file is created (the directory
+# may or may not exist).
 Path(args.output1_path).parent.mkdir(parents=True, exist_ok=True)
 
 with open(args.input1_path, 'r') as input1_file:
@@ -108,272 +121,430 @@ with open(args.input1_path, 'r') as input1_file:
         do_work(input1_file, output1_file, args.param1)
 ```
 
-The command line invocation of this program is:
-
-```
-python3 program.py --input1-path <local file path to Input 1 data> \
-                   --param1 <value of Param1 input> \
-                   --output1-path <local file path for the Output 1 data>
-```
-
-## Writing a Dockerfile to containerize your application
-
-You need a [Docker](https://docs.docker.com/get-started/) container image that
-packages your program.
-
-The instructions on creating container images are not specific to Kubeflow
-Pipelines. To make things easier for you, this section provides some guidelines
-on standard container creation. You can use any procedure
-of your choice to create the Docker containers.
-
-Your [Dockerfile](https://docs.docker.com/engine/reference/builder/) must
-contain all program code, including the wrapper, and the dependencies (operating
-system packages, external libraries, etc).
-
-Ensure you have write access to a container registry where you can push
-the container image. Examples include
-[Google Container Registry](https://cloud.google.com/container-registry/docs/)
-and [Docker Hub](https://hub.docker.com/).
-
-Think of a name for your container image. This guide uses the name
-`gcr.io/my-org/my-image'.
-
-### Example Dockerfile
-
-```
-FROM python:3.7
-RUN python3 -m pip install keras
-COPY ./src /pipelines/component/src
-```
-
-Create a `build_image.sh` script (see example below) to build the container
-image based on the Dockerfile and push the container image to some container
-repository.
-
-Run the `build_image.sh` script to build the container image based on the Dockerfile
-and push it to your chosen container repository.
-
-Best practice: After pushing the image, get the strict image name with digest,
-and use the strict image name for reproducibility.
-
-### Example build_image.sh:
+If this program is saved as `program.py`, the command-line invocation of this
+program is:
 
 ```bash
-#!/bin/bash -e
-image_name=gcr.io/my-org/my-image # Specify the image name here
-image_tag=latest
-full_image_name=${image_name}:${image_tag}
-
-cd "$(dirname "$0")"
-docker build -t "${full_image_name}" .
-docker push "$full_image_name"
-
-# Output the strict image name (which contains the sha256 image digest)
-docker inspect --format="{{index .RepoDigests 0}}" "${full_image_name}"
+python3 program.py --input1-path <path-to-the-input-file> \
+  --param1 <number-of-lines-to-read> \
+  --output1-path <path-to-write-the-output-to> 
 ```
 
-Make your script executable:
+## Containerize your component's code
 
-```
-chmod +x build_image.sh
-```
+For Kubeflow Pipelines to run your component, your component must be packaged
+as a [Docker][docker] container image and published to a container registry
+that your Kubernetes cluster can access. The steps to create a container image
+are not specific to Kubeflow Pipelines. To make things easier for you, this
+section provides some guidelines on standard container creation.
 
-## Writing your component definition file
+1.  Create a [Dockerfile][dockerfile] for your container. A Dockerfile
+    specifies:
 
-To create a component from your containerized program you need to write component specification in YAML format that describes the
-component for the Kubeflow Pipelines system.
+    *   The base container image. For example, the operating system that your
+        code runs on.
+    *   Any dependencies that need to be installed for your code to run. 
+    *   Files to copy into the container, such as the runnable code for this
+        component.
 
-For the complete definition of a Kubeflow Pipelines component, see the
-[component specification](/docs/components/pipelines/reference/component-spec/).
-However, for this tutorial you don't need to know the full schema of the
-component specification. The tutorial provides enough information for the
-relevant the components.
+    The following is an example Dockerfile.
 
-Start writing the component definition (`component.yaml`) by specifying your
-container image in the component's implementation section:
+    ```
+    FROM python:3.7
+    RUN python3 -m pip install keras
+    COPY ./src /pipelines/component/src
+    ```
+    
+    In this example:
 
-```
-implementation:
-  container:
-    image: gcr.io/my-org/my-image@sha256:a172..752f # Name of a container image that you've pushed to a container repo.
-```
+    *   The base container image is [`python:3.7`][python37].
+    *   The `keras` Python package is installed in the container image.
+    *   Files in your `./src` directory are copied into
+        `/pipelines/component/src` in the container image.
+  
+1.  Create a script named `build_image.sh ` that uses Docker to build your
+    container image and push your container image to a container registry.
+    Your Kubernetes cluster must be able to access your container registry
+    to run your component. Examples of container registries include [Google
+    Container Registry][google-container-registry] and 
+    [Docker Hub][docker-hub].
 
-Complete the component's implementation section based on your program:
+    The following example builds a container image, pushes it to a container
+    registry, and outputs the strict image name. It is a best practice to use
+    the strict image name in your component specification to ensure that you
+    are using the expected version of a container image in each component
+    execution.
 
-```
+    ```bash
+    #!/bin/bash -e
+    image_name=gcr.io/my-org/my-image
+    image_tag=latest
+    full_image_name=${image_name}:${image_tag}
+
+    cd "$(dirname "$0")" 
+    docker build -t "${full_image_name}" .
+    docker push "$full_image_name"
+
+    # Output the strict image name, which contains the sha256 image digest
+    docker inspect --format="{{index .RepoDigests 0}}" "${full_image_name}"
+    ``` 
+
+    In the preceding example: 
+
+    *   The `image_name` specifies the full name of your container image in the
+        container registry.
+    *   The `image_tag` specifies that this image should be tagged as
+        **latest**.
+
+    Save this file and run the following to make this script executable.
+
+    ```bash
+    chmod +x build_image.sh
+    ```
+
+1.  Run your `build_image.sh` script to build your container image and push it
+    to a container registry.
+
+1.  [Use `docker run` to test your container image locally][docker-run]. If
+    necessary, revise your application and Dockerfile until your application
+    works as expected in the container.
+
+[python37]: https://hub.docker.com/layers/python/library/python/3.7/images/sha256-b007078db11636d951871b9652ae27008cf258d7bee7719b192441c88acf3027?context=explore
+[docker]: https://docs.docker.com/get-started/
+[dockerfile]: https://docs.docker.com/engine/reference/builder/
+[google-container-registry]: https://cloud.google.com/container-registry/docs/
+[docker-hub]: https://hub.docker.com/
+[docker-run]: https://docs.docker.com/engine/reference/commandline/run/
+
+<a name="component-spec"></a>
+## Creating a component specification
+
+To create a component from your containerized program, you must create a
+component specification that defines the component's interface and
+implementation. The following sections provide an overview of how to create a
+component specification by demonstrating how to define the component's
+implementation, interface, and metadata.
+
+To learn more about defining a component specification, see the 
+[component specification reference guide][component-spec].
+
+[component-spec]: /docs/components/pipelines/reference/component-spec/
+
+### Define your component's implementation
+
+The following example creates a component specification YAML and defines the
+component's implementation. 
+
+1.  Create a file named `component.yaml` and open it in a text editor.
+1.  Create your component's implementation section and specify the strict name
+    of your container image. The strict image name is provided when you run
+    your `build_image.sh` script.
+
+    ```yaml
+    implementation:
+      container:
+        # The strict name of a container image that you've pushed to a container registry.
+        image: gcr.io/my-org/my-image@sha256:a172..752f
+    ```
+
+1.  Define a `command` for your component's implementation. This field
+    specifies the command-line arguments that are used to run your program in
+    the container. 
+
+    ```yaml
+    implementation:
+      container:
+        image: gcr.io/my-org/my-image@sha256:a172..752f
+        # command is a list of strings (command-line arguments). 
+        # The YAML language has two syntaxes for lists and you can use either of them. 
+        # Here we use the "flow syntax" - comma-separated strings inside square brackets.
+        command: [
+          python3, 
+          # Path of the program inside the container
+          /pipelines/component/src/program.py,
+          --input1-path,
+          {inputPath: Input 1},
+          --param1, 
+          {inputValue: Parameter 1},
+          --output1-path, 
+          {outputPath: Output 1},
+        ]
+    ```
+
+    The `command` is formatted as a list of strings. Each string in the
+    `command` is a command-line argument or a placeholder. At runtime,
+    placeholders are replaced with an input or output. In the preceding
+    example, two inputs and one output path are passed into a Python script at
+    `/pipelines/component/src/program.py`.
+
+    There are three types of input/output placeholders:
+
+    *   `{inputValue: <input-name>}`:
+        This placeholder is replaced with the value of the specified input.
+        This is useful for small pieces of input data, such as numbers or small
+        strings.
+
+    *   `{inputPath: <input-name>}`:
+        This placeholder is replaced with the path to this input as a file.
+        Your component can read the content's of that input at that path during
+        the pipeline run.
+
+    *   `{outputPath: <output-name>}`:
+        This placeholder is replaced with the path where your program writes
+        this output's data. This lets the Kubeflow Pipelines system read the
+        contents of the file and store it as the value of the specified output.
+ 
+    The `<input-name>` name must match the name of an input in the `inputs`
+    section of your component specification. The `<output-name>` name must
+    match the name of an output in the `outputs` section of your component
+    specification.  
+
+### Define your component's interface
+
+The following examples demonstrate how to specify your component's interface. 
+
+1.  To define an input in your `component.yaml`, add an item to the
+    `inputs` list with the following attributes:
+
+    *   `name`: Human-readable name of this input. Each input's name must be
+        unique.
+    *   `description`: (Optional.) Human-readable description of the input.
+    *   `default`: (Optional.) Specifies the default value for this input.
+    *   `type`: (Optional.) Specifies the input’s type. Learn more about the
+        [types defined in the Kubeflow Pipelines SDK][dsl-types] and [how type
+        checking works in pipelines and components][dsl-type-checking].
+    *   `optional`: Specifies if this input is optional. The value of this
+        attribute is of type `Bool`, and defaults to **False**.
+
+    In this example, the Python program has two inputs: 
+
+    *   `Input 1` contains `String` data.
+    *   `Parameter 1` contains an `Integer`.
+
+    ```yaml
+    inputs:
+    - {name: Input 1, type: String, description: 'Data for input 1'}
+    - {name: Parameter 1, type: Integer, default: '100', description: 'Number of lines to copy'}
+    ```
+
+    Note: `Input 1` and `Parameter 1` do not specify any details about how they
+    are stored or how much data they contain. The Kubeflow Pipelines system  Consider using naming conventions
+    to indicate if inputs are expected to be small enough to pass by value. 
+
+1.  After your component finishes its task, the component's outputs are passed
+    to your pipeline as paths. At runtime, Kubeflow Pipelines creates a
+    path for each of your component's outputs. These paths are passed as inputs
+    to your component's implementation.
+
+    To define an output in your component specification YAML, add an item to
+    the `outputs` list with the following attributes:
+
+    *   `name`: Human-readable name of this output. Each output's name must be
+        unique.
+    *   `description`: (Optional.) Human-readable description of the output.
+    *   `type`: (Optional.) Specifies the output's type. Learn more about the
+        [types defined in the Kubeflow Pipelines SDK][dsl-types] and [how type
+        checking works in pipelines and components][dsl-type-checking].
+
+    In this example, the Python program returns one output. The output is named
+    `Output 1` and it contains `String` data.
+
+    ```yaml
+    outputs:
+    - {name: Output 1, type: String, description: 'Output 1 data.'}
+    ```
+
+    Note: Consider using naming conventions to indicate if this output is
+    expected to be small enough to pass by value. You should limit the amount
+    of data that is passed by value to 200 KB per pipeline run.
+
+1.  After you define your component's interface, the `component.yaml` should be
+    something like the following:
+
+    ```yaml
+    inputs:
+    - {name: Input 1, type: String, description: 'Data for input 1'}
+    - {name: Parameter 1, type: Integer, default: '100', description: 'Number of lines to copy'}
+    
+    outputs:
+    - {name: Output 1, type: String, description: 'Output 1 data.'}
+
+    implementation:
+      container:
+        image: gcr.io/my-org/my-image@sha256:a172..752f
+        # command is a list of strings (command-line arguments). 
+        # The YAML language has two syntaxes for lists and you can use either of them. 
+        # Here we use the "flow syntax" - comma-separated strings inside square brackets.
+        command: [
+          python3, 
+          # Path of the program inside the container
+          /pipelines/component/src/program.py,
+          --input1-path,
+          {inputPath: Input 1},
+          --param1, 
+          {inputValue: Parameter 1},
+          --output1-path, 
+          {outputPath: Output 1},
+        ]
+    ```
+
+[dsl-types]: https://github.com/kubeflow/pipelines/blob/master/sdk/python/kfp/dsl/types.py
+[dsl-type-checking]: https://www.kubeflow.org/docs/components/pipelines/sdk/static-type-checking/
+
+### Specify your component's metadata
+
+To define your component's metadata, add the `name` and `description`
+fields to your `component.yaml`
+
+```yaml
+name: Get Lines
+description: Gets the specified number of lines from the input file.
+
+inputs:
+- {name: Input 1, type: String, description: 'Data for input 1'}
+- {name: Parameter 1, type: Integer, default: '100', description: 'Number of lines to copy'}
+
+outputs:
+- {name: Output 1, type: String, description: 'Output 1 data.'}
+
 implementation:
   container:
     image: gcr.io/my-org/my-image@sha256:a172..752f
-    # command is a list of strings (command-line arguments).
-    # The YAML language has two syntaxes for lists and you can use either of them.
+    # command is a list of strings (command-line arguments). 
+    # The YAML language has two syntaxes for lists and you can use either of them. 
     # Here we use the "flow syntax" - comma-separated strings inside square brackets.
     command: [
-      python3, /kfp/component/src/program.py, # Path of the program inside the container
-      --input1-path, <local file path for the Input 1 data>,
-      --param1, <value of Param1 input>,
-      --output1-path, <local file path for the Output 1 data>,
-    ]
-```
-
-The `command` section still contains some dummy placeholders (in angle
-brackets). Let's replace them with real placeholders. A *placeholder* represents
-a command-line argument that is replaced with some value or path before the
-program is executed. In `component.yaml`, you specify the placeholders using
-YAML's mapping syntax to distinguish them from the verbatim strings. There are
-three placeholders available:
-
-*   `{inputValue: Some input name}`
-    This placeholder is replaced with the **value** of the argument to the
-    specified input. This is useful for small pieces of input data.
-*   `{inputPath: Some input name}`
-    This placeholder is replaced with the auto-generated **local path** where the
-    system will put the input data passed to the component during the pipeline run.
-    This placeholder instructs the system to write the input argument data to a file and pass the path of that data file to the component program.
-*   `{outputPath: Some output name}`
-    This placeholder is replaced with the auto-generated **local path** where the
-    program should write its output data. This instructs the system to read the
-    content of the file and store it as the value of the specified output.
-
-In addition to putting real placeholders in the command line, you need to add
-corresponding input and output specifications to the inputs and outputs
-sections. The input/output specification contains the input name, type,
-description and default value. Only the name is required. The input and output
-names are free-form strings, but be careful with the YAML syntax and use quotes
-if necessary. The input/output names do not need to be the same as the
-command-line flags which are usually quite short.
-
-Replace the placeholders as follows:
-
-+   Replace `<local file path for the Input 1 data>` with `{inputPath: Input 1}` and
-    add `Input 1` to the `inputs` section.
-    them in as command-line arguments.
-+   Replace `<value of Param1 input>` with `{inputValue: Parameter 1}` and add
-    `Parameter 1` to the `inputs` section. Integers are small, so we're passing
-    them in as command-line arguments.
-+   Replace `<local file path for the Output 1 data>` with `{outputPath: Output 1}`
-    and add `Output 1` to the `outputs` section.
-
-After replacing the placeholders and adding inputs/outputs, your
-`component.yaml` looks like this:
-
-```
-inputs: #List of input specs. Each input spec is a map.
-- {name: Input 1}
-- {name: Parameter 1}
-outputs:
-- {name: Output 1}
-implementation:
-  container:
-    image: gcr.io/my-org/my-image@sha256:a172..752f
-    command: [
-      python3, /pipelines/component/src/program.py,
-
+      python3, 
+      # Path of the program inside the container
+      /pipelines/component/src/program.py,
       --input1-path,
-      {inputPath: Input 1}, # Refers to the "Input 1" input
-
-      --param1,
-      {inputValue: Parameter 1}, # Refers to the "Parameter 1" input
-
-      --output1-path,
-      {outputPath: Output 1}, # Refers to the "Output 1" output
+      {inputPath: Input 1},
+      --param1, 
+      {inputValue: Parameter 1},
+      --output1-path, 
+      {outputPath: Output 1},
     ]
 ```
 
-The above component specification is sufficient, but you should add more
-metadata to make it more useful. The example below includes the following
-additions:
+## Using your component in a pipeline
 
-* Component name and description.
-* For each input and output: description, default value, and type.
+You can use the Kubeflow Pipelines SDK to load your component using methods
+such as the following:
 
-Final version of `component.yaml`:
+*   [`kfp.components.load_component_from_file`][kfp-load-comp-file]: 
+    Use this method to load your component from a `component.yaml` path.
+*   [`kfp.components.load_component_from_url`][kfp-load-comp-url]:
+    Use this method to load a `component.yaml` from a URL.
+*   [`kfp.components.load_component_from_text`][kfp-load-comp-text]:
+    Use this method to load your component specification YAML from a string.
+    This method is useful for rapidly iterating on your component
+    specification.
 
-```
-name: Do dummy work
-description: Performs some dummy work.
-inputs:
-- {name: Input 1, type: GCSPath, description: 'Data for Input 1'}
-- {name: Parameter 1, type: Integer, default: '100', description: 'Parameter 1 description'} # The default values must be specified as YAML strings.
-outputs:
-- {name: Output 1, description: 'Output 1 data'}
-implementation:
-  container:
-    image: gcr.io/my-org/my-image@sha256:a172..752f
-    command: [
-      python3, /pipelines/component/src/program.py,
-      --input1-path,  {inputPath:  Input 1},
-      --param1,       {inputValue: Parameter 1},
-      --output1-path, {outputPath: Output 1},
-    ]
-```
+These functions create a factory function that you can use to create
+[`ContainerOp`][kfp-containerop] instances to use as steps in your pipeline.
+This factory function's input arguments include your component's inputs and
+the paths to your component's outputs. The function signature may be modified
+in the following ways to ensure that it is valid and Pythonic.
 
-## Build your component into a pipeline with the Kubeflow Pipelines SDK
+*   Inputs with default values will come after the inputs without default
+    values and outputs.
+*   Input and output names are converted to Pythonic names (spaces and symbols
+    are replaced with underscores and letters are converted to lowercase). For
+    example, an input named `Input 1` is converted to `input_1`. 
 
-Here is a sample pipeline that shows how to load a component and use it to
-compose a pipeline.
+The following example demonstrates how to load the text of your component
+specification and run it in a single-step pipeline. Before you run this
+example, update the component specification to use the component
+specification you defined in the previous sections.
 
 ```python
-import os
-
 import kfp
-# Load the component by calling load_component_from_file or load_component_from_url
-# To load the component, the pipeline author only needs to have access to the component.yaml file.
-# The Kubernetes cluster executing the pipeline needs access to the container image specified in the component.
-dummy_op = kfp.components.load_component_from_file(os.path.join(component_root, 'component.yaml'))
-# dummy_op = kfp.components.load_component_from_url('http://....../component.yaml')
+import kfp.components as comp
 
-# Load two more components for importing and exporting the data:
-download_from_gcs_op = kfp.components.load_component_from_url('http://....../component.yaml')
-upload_to_gcs_op = kfp.components.load_component_from_url('http://....../component.yaml')
+create_step_get_lines = comp.load_component_from_text("""
+name: Get Lines
+description: Gets the specified number of lines from the input file.
 
-# dummy_op is now a "factory function" that accepts the arguments for the component's inputs
-# and produces a task object (e.g. ContainerOp instance).
-# Inspect the dummy_op function in Jupyter Notebook by typing "dummy_op(" and pressing Shift+Tab
-# You can also get help by writing help(dummy_op) or dummy_op? or dummy_op??
-# The signature of the dummy_op function corresponds to the inputs section of the component.
-# Some tweaks are performed to make the signature valid and pythonic:
-# 1) All inputs with default values will come after the inputs without default values
-# 2) The input names are converted to pythonic names (spaces and symbols replaced
-#    with underscores and letters lowercased).
+inputs:
+- {name: Input 1, type: String, description: 'Data for input 1'}
+- {name: Parameter 1, type: Integer, default: '100', description: 'Number of lines to copy'}
 
-# Define a pipeline and create a task from a component:
+outputs:
+- {name: Output 1, type: String, description: 'Output 1 data.'}
+
+implementation:
+  container:
+    image: gcr.io/my-org/my-image@sha256:a172..752f
+    # command is a list of strings (command-line arguments). 
+    # The YAML language has two syntaxes for lists and you can use either of them. 
+    # Here we use the "flow syntax" - comma-separated strings inside square brackets.
+    command: [
+      python3, 
+      # Path of the program inside the container
+      /pipelines/component/src/program.py,
+      --input1-path,
+      {inputPath: Input 1},
+      --param1, 
+      {inputValue: Parameter 1},
+      --output1-path, 
+      {outputPath: Output 1},
+    ]""")
+
+# create_step_get_lines is a "factory function" that accepts the arguments
+# for the component's inputs and output paths and returns a pipeline step
+# (ContainerOp instance).
+#
+# To inspect the get_lines_op function in Jupyter Notebook, enter 
+# "get_lines_op(" in a cell and press Shift+Tab.
+# You can also get help by entering `help(get_lines_op)`, `get_lines_op?`,
+# or `get_lines_op??`.
+
+# Define your pipeline 
 def my_pipeline():
-    dummy1_task = dummy_op(
+    get_lines_step = create_step_get_lines(
         # Input name "Input 1" is converted to pythonic parameter name "input_1"
-        input_1="one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten",
+        input_1='one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten',
         parameter_1='5',
     )
-    # The outputs of the dummy1_task can be referenced using the
-    # dummy1_task.outputs dictionary: dummy1_task.outputs['output_1']
-    # ! The output names are converted to pythonic ("snake_case") names.
 
-# This pipeline can be compiled, uploaded and submitted for execution.
-kfp.Client().create_run_from_pipeline_func(my_pipeline, arguments={})
+# If you run this command on a Jupyter notebook running on Kubeflow,
+# you can exclude the host parameter.
+# client = kfp.Client()
+client = kfp.Client(host='<your-kubeflow-pipelines-host-name>')
+
+# Compile, upload, and submit this pipeline for execution.
+client.create_run_from_pipeline_func(my_pipeline, arguments={})
 ```
+
+[kfp-load-comp-file]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_file
+[kfp-load-comp-url]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_url
+[kfp-load-comp-text]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_text
+[kfp-containerop]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.dsl.html#kfp.dsl.ContainerOp
 
 ## Organizing the component files
 
-This section provides a recommended way to organize the component files. There
-is no requirement that you must organize the files in this way. However, using
+This section provides a recommended way to organize a component's files. There
+is no requirement that you must organize the files in this way. However, using 
 the standard organization makes it possible to reuse the same scripts for
-testing, image building and component versioning.
-See this
-[sample component](https://github.com/kubeflow/pipelines/tree/master/components/sample/keras/train_classifier)
-for a real-life component example.
+testing, image building, and component versioning.
 
 ```
 components/<component group>/<component name>/
 
-    src/*            #Component source code files
-    tests/*          #Unit tests
-    run_tests.sh     #Small script that runs the tests
-    README.md        #Documentation. Move to docs/ if multiple files needed
+    src/*            # Component source code files
+    tests/*          # Unit tests
+    run_tests.sh     # Small script that runs the tests
+    README.md        # Documentation. If multiple files are needed, move to docs/.
 
-    Dockerfile       #Dockerfile to build the component container image
-    build_image.sh   #Small script that runs docker build and docker push
+    Dockerfile       # Dockerfile to build the component container image
+    build_image.sh   # Small script that runs docker build and docker push
 
-    component.yaml   #Component definition in YAML format
+    component.yaml   # Component definition in YAML format
 ```
+
+See this [sample component][org-sample] for a real-life component example.
+
+[org-sample]: https://github.com/kubeflow/pipelines/tree/master/components/sample/keras/train_classifier
 
 ## Next steps
 
@@ -381,7 +552,7 @@ components/<component group>/<component name>/
   [best practices](/docs/components/pipelines/sdk/best-practices) for designing and
   writing components.
 * For quick iteration,
-  [build lightweight components](/docs/components/pipelines/sdk/lightweight-python-components/)
+  [build lightweight Python function-based components](/docs/components/pipelines/sdk/python-function-components/)
   directly from Python functions.
 * See how to [export metrics from your
   pipeline](/docs/components/pipelines/metrics/pipelines-metrics/).


### PR DESCRIPTION
Revises the guide to building reusable components:

- Updates wording to clarify that this is how to build Kubeflow Pipeline Components (instead of a type of reusable pipeline component).
- Updates the guide to use a single example throughout the doc
- Updates the wording in general.