### PR TITLE
Add Charmed Kubeflow Operators to list of available Kubeflow distributions

### DIFF
--- a/content/en/docs/distributions/aws/_index.md
+++ b/content/en/docs/distributions/aws/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Kubeflow on AWS"
 description = "Running Kubeflow on Kubernetes Engine and Amazon Web Services"
-weight = 50
+weight = 20
 +++

--- a/content/en/docs/distributions/azure/_index.md
+++ b/content/en/docs/distributions/azure/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Kubeflow on Azure"
 description = "Running Kubeflow on Kubernetes Engine and Microsoft Azure"
-weight = 50
+weight = 20
 +++

--- a/content/en/docs/distributions/charmed/OWNERS
+++ b/content/en/docs/distributions/charmed/OWNERS
@@ -2,5 +2,4 @@ approvers:
   - RFMVasconcelos
   - knkski
 reviewers:
-  - evilnick
   - DomFleischmann

--- a/content/en/docs/distributions/charmed/OWNERS
+++ b/content/en/docs/distributions/charmed/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - RFMVasconcelos
+  - knkski
+reviewers:
+  - evilnick
+  - DomFleischmann

--- a/content/en/docs/distributions/charmed/_index.md
+++ b/content/en/docs/distributions/charmed/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Charmed Kubeflow"
-description = "Running Kubeflow on Kubernetes Engine and Microsoft Azure"
+title = "Kubeflow Charmed Operators"
+description = "Charmed Operators for Kubeflow deployment and day-2 operations"
 weight = 50
 +++

--- a/content/en/docs/distributions/charmed/_index.md
+++ b/content/en/docs/distributions/charmed/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Charmed Kubeflow"
+description = "Running Kubeflow on Kubernetes Engine and Microsoft Azure"
+weight = 50
++++

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -1,6 +1,6 @@
 +++
 title = "Installing Kubeflow"
-description = "Instructions for Kubeflow deployment with Charmed Kubeflow"
+description = "Instructions for Kubeflow deployment with Kubeflow Charmed Operators"
 weight = 10
 +++
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -74,7 +74,7 @@ Once you have a model, you can simply `juju deploy` any of the provided [Kubeflo
 juju deploy kubeflow-lite
 ```
 
-**Congratulations, Kubeflow is now installing !**
+and your Kubeflow installation should begin!
 
 You can observe your Kubeflow deployment getting spun-up with the command:
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -1,5 +1,5 @@
 +++
-title = "Installing Kubeflow"
+title = "Installing Kubeflow with Charmed Operators"
 description = "Instructions for Kubeflow deployment with Kubeflow Charmed Operators"
 weight = 10
 +++

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -83,7 +83,7 @@ watch -c juju status --color
 
 #### 6. Add an RBAC role for istio
 
-Currently, in order to setup Kubeflow with Istio correctly, you need to provide the `istio-ingressgateway` operator access to Kubernetes resources. The following command will create the appropriate role:
+At the time of writing this guide, to set up Kubeflow with [Istio](https://istio.io) correctly, you need to provide the `istio-ingressgateway` operator access to Kubernetes resources. Use the  following command to create the appropriate role:
 
 ```bash
 kubectl patch role -n kubeflow istio-ingressgateway-operator -p '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"istio-ingressgateway-operator"},"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]}'

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -4,7 +4,7 @@ description = "Instructions for Kubeflow deployment with Kubeflow Charmed Operat
 weight = 10
 +++
 
-This guide lists the steps necessary to install Kubeflow on any conformant Kubernetes, including AKS, EKS, GKE, Openshift and any kubeadm-deployed cluster,  provided that you have access to it via `kubectl`. 
+This guide outlines the steps you need to install and deploy Kubeflow with [Charmed Operators](https://juju.is/tutorials/get-started-charmed-kubernetes#1-overview) and [Juju](https://juju.is/docs/kubernetes) on any conformant Kubernetes, including [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/), [Amazon Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/index.html), [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/), [OpenShift](https://docs.openshift.com), and any [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/)-deployed cluster (provided that you have access to it via `kubectl`). 
 
 #### 1. Install the Juju client
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -91,7 +91,7 @@ kubectl patch role -n kubeflow istio-ingressgateway-operator -p '{"apiVersion":"
 
 #### 7. Set URL in authentication methods 
 
-A final step to enable your Kubeflow dashboard access is to provide your dashboard public URL to dex-auth and oidc-gatekeeper via the following commands:
+Finally, you need to enable your Kubeflow dashboard access. Provide the dashboard's public URL to dex-auth and oidc-gatekeeper as follows:
 
 ```bash
 juju config dex-auth public-url=http://<URL>

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -105,4 +105,5 @@ Where `<URL>` is the hostname that the Kubeflow dashboard responds to.
 For more documentation visit [Charmed Kubeflow docs](https://charmed-kubeflow.io/docs)
 
 #### Having issues?
-If you face any difficulties following these instructions, please create an issue [here](https://github.com/juju-solutions/bundle-kubeflow/issues).
+
+If you have any issues or questions, feel free to create a GitHub issue [here](https://github.com/juju-solutions/bundle-kubeflow/issues).

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -35,7 +35,8 @@ Finally, to use a different config file, you can set the `KUBECONFIG` environmen
 ```bash
 KUBECONFIG=path/to/file juju add-k8s myk8s
 ```
-For more details, see the [Juju documentation](https://juju.is/docs/clouds).
+
+For more details, go to the [official Juju documentation](https://juju.is/docs/clouds).
 
 #### 3. Create a controller
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -20,7 +20,7 @@ If you use macOS, you can use [Homebrew](https://brew.sh) and type `brew install
 
 To operate workloads in your Kubernetes cluster with Juju, you have to add the cluster to the list of *clouds* in Juju via the `add-k8s` command.
 
-If your Kubernetes config file is in the standard location (`~/.kube/config` on Linux), and you only have one cluster, you can simply run:
+If your Kubernetes config file is in the default location (such as `~/.kube/config` on Linux) and you only have one cluster, you can simply run:
 
 ```bash
 juju add-k8s myk8s

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -64,7 +64,7 @@ You can list your models with the `juju models` command.
 #### 5. Deploy Kubeflow
 
 [note type="caution" status="MIN RESOURCES"]
-The minimum resources to deploy `kubeflow` are - 50Gb of disk, 14Gb of RAM and 2 CPUs - available to your Linux machine or VM. 
+To deploy `kubeflow`, you'll need at least 50Gb available of disk, 14Gb of RAM, and 2 CPUs available in your machine/VM.
 If you have fewer resources, deploy `kubeflow-lite` or `kubeflow-edge`.
 [/note]
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -4,7 +4,7 @@ description = "Instructions for Kubeflow deployment with Charmed Kubeflow"
 weight = 10
 +++
 
-This guide lists the steps necessary to install Kubeflow on any conformant Kubernetes, including AKS, EKS, GKE, Openshift and any kubeadm-deployed cluster,  provided that you have access to it via `kubectl`.
+This guide lists the steps necessary to install Kubeflow on any conformant Kubernetes, including AKS, EKS, GKE, Openshift and any kubeadm-deployed cluster,  provided that you have access to it via `kubectl`. 
 
 #### 1. Install the Juju client
 
@@ -99,6 +99,10 @@ juju config oidc-gatekeeper public-url=http://<URL>
 ```
 
 Where `<URL>` is the hostname that the Kubeflow dashboard responds to. 
+
+#### More documentation
+
+For more documentation visit [Charmed Kubeflow docs](https://charmed-kubeflow.io/docs)
 
 #### Having issues?
 If you face any difficulties following these instructions, please create an issue [here](https://github.com/juju-solutions/bundle-kubeflow/issues).

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -68,7 +68,7 @@ The minimum resources to deploy `kubeflow` are - 50Gb of disk, 14Gb of RAM and 2
 If you have fewer resources, deploy `kubeflow-lite` or `kubeflow-edge`.
 [/note]
 
-Once you have a model, you can simply `juju deploy` any of the provided [Kubeflow bundles](https://charmed-kubeflow.io/docs/operators-and-bundles) into your cluster. For the Kubeflow lite bundle, run:
+Once you have a model, you can simply `juju deploy` any of the provided [Kubeflow bundles](https://charmed-kubeflow.io/docs/operators-and-bundles) into your cluster. For the _Kubeflow lite_ bundle, run:
 
 ```bash
 juju deploy kubeflow-lite

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -98,7 +98,7 @@ juju config dex-auth public-url=http://<URL>
 juju config oidc-gatekeeper public-url=http://<URL>
 ```
 
-Where `<URL>` is the hostname that the Kubeflow dashboard responds to. 
+where in place of `<URL>` you should use the hostname that the Kubeflow dashboard responds to.
 
 #### More documentation
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -14,7 +14,7 @@ On Linux, install `juju` via [snap](https://snapcraft.io/docs/installing-snapd) 
 snap install juju --classic
 ```
 
-Alternatively,  `brew install juju` on macOS or [download the Windows installer](https://launchpad.net/juju/2.8/2.8.5/+download/juju-setup-2.8.5-signed.exe). 
+If you use macOS, you can use [Homebrew](https://brew.sh) and type `brew install juju` in the command line. For Windows, download the Windows [installer for Juju](https://launchpad.net/juju/2.8/2.8.5/+download/juju-setup-2.8.5-signed.exe).
 
 #### 2. Connect Juju to your Kubernetes cluster
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -4,7 +4,7 @@ description = "Instructions for Kubeflow deployment with Kubeflow Charmed Operat
 weight = 10
 +++
 
-This guide outlines the steps you need to install and deploy Kubeflow with [Charmed Operators](https://juju.is/tutorials/get-started-charmed-kubernetes#1-overview) and [Juju](https://juju.is/docs/kubernetes) on any conformant Kubernetes, including [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/), [Amazon Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/index.html), [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/), [OpenShift](https://docs.openshift.com), and any [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/)-deployed cluster (provided that you have access to it via `kubectl`). 
+This guide outlines the steps you need to install and deploy Kubeflow with [Charmed Operators](https://charmed-kubeflow.io/docs) and [Juju](https://juju.is/docs/kubernetes) on any conformant Kubernetes, including [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/), [Amazon Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/index.html), [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/), [OpenShift](https://docs.openshift.com), and any [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/)-deployed cluster (provided that you have access to it via `kubectl`). 
 
 #### 1. Install the Juju client
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -103,7 +103,7 @@ where in place of `<URL>` you should use the hostname that the Kubeflow dashboar
 
 #### More documentation
 
-For more documentation visit [Charmed Kubeflow docs](https://charmed-kubeflow.io/docs)
+For more documentation, visit the [Charmed Kubeflow website](https://charmed-kubeflow.io/docs).
 
 #### Having issues?
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -1,0 +1,104 @@
++++
+title = "Installing Kubeflow"
+description = "Instructions for Kubeflow deployment with Charmed Kubeflow"
+weight = 10
++++
+
+This guide lists the steps necessary to install Kubeflow on any conformant Kubernetes, including AKS, EKS, GKE, Openshift and any kubeadm-deployed cluster,  provided that you have access to it via `kubectl`.
+
+#### 1. Install the Juju client
+
+On Linux, install `juju` via [snap](https://snapcraft.io/docs/installing-snapd) with the following command:
+
+```bash
+snap install juju --classic
+```
+
+Alternatively,  `brew install juju` on macOS or [download the Windows installer](https://launchpad.net/juju/2.8/2.8.5/+download/juju-setup-2.8.5-signed.exe). 
+
+#### 2. Connect Juju to your Kubernetes cluster
+
+In order to operate workloads in your Kubernetes cluster with Juju, you have to add your cluster to the list of *clouds* in juju via the `add-k8s` command.
+
+If your Kubernetes config file is in the standard location (`~/.kube/config` on Linux), and you only have one cluster, you can simply run:
+
+```bash
+juju add-k8s myk8s
+```
+If your kubectl config file contains multiple clusters, you can specify the appropriate one by name:
+
+```bash
+juju add-k8s myk8s --cluster-name=foo
+```
+Finally, to use a different config file, you can set the `KUBECONFIG` environment variable to point to the relevant file. For example:
+
+```bash
+KUBECONFIG=path/to/file juju add-k8s myk8s
+```
+For more details, see the [Juju documentation](https://juju.is/docs/clouds).
+
+#### 3. Create a controller
+
+To operate workloads on your Kubernetes cluster, Juju uses controllers. You can create a controller with the  `bootstrap`  command:
+
+```bash
+juju bootstrap myk8s my-controller
+```
+
+This command will create a couple of pods under the `my-controller` namespace. You can see your controllers with the `juju controllers` command.
+
+You can read more about controllers in the [Juju documentation](https://juju.is/docs/creating-a-controller).
+
+#### 4. Create a model
+
+A model in Juju is a blank canvas where your operators will be deployed, and it holds a 1:1 relationship with a Kubernetes namespace.
+
+You can create a model and give it a name, e.g. `kubeflow`, with the `add-model` command, and you will also be creating a Kubernetes namespace of the same name:
+
+```bash
+juju add-model kubeflow
+```
+You can list your models with the `juju models` command.
+
+#### 5. Deploy Kubeflow
+
+[note type="caution" status="MIN RESOURCES"]
+The minimum resources to deploy `kubeflow` are - 50Gb of disk, 14Gb of RAM and 2 CPUs - available to your Linux machine or VM. 
+If you have fewer resources, deploy `kubeflow-lite` or `kubeflow-edge`.
+[/note]
+
+Once you have a model, you can simply `juju deploy` any of the provided [Kubeflow bundles](https://charmed-kubeflow.io/docs/operators-and-bundles) into your cluster. For the Kubeflow lite bundle, run:
+
+```bash
+juju deploy kubeflow-lite
+```
+
+**Congratulations, Kubeflow is now installing !**
+
+You can observe your Kubeflow deployment getting spun-up with the command:
+
+```bash
+watch -c juju status --color
+```
+
+#### 6. Add an RBAC role for istio
+
+Currently, in order to setup Kubeflow with Istio correctly, you need to provide the `istio-ingressgateway` operator access to Kubernetes resources. The following command will create the appropriate role:
+
+```bash
+kubectl patch role -n kubeflow istio-ingressgateway-operator -p '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"istio-ingressgateway-operator"},"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]}'
+```
+
+#### 7. Set URL in authentication methods 
+
+A final step to enable your Kubeflow dashboard access is to provide your dashboard public URL to dex-auth and oidc-gatekeeper via the following commands:
+
+```bash
+juju config dex-auth public-url=http://<URL>
+juju config oidc-gatekeeper public-url=http://<URL>
+```
+
+Where `<URL>` is the hostname that the Kubeflow dashboard responds to. 
+
+#### Having issues?
+If you face any difficulties following these instructions, please create an issue [here](https://github.com/juju-solutions/bundle-kubeflow/issues).

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -18,7 +18,7 @@ If you use macOS, you can use [Homebrew](https://brew.sh) and type `brew install
 
 #### 2. Connect Juju to your Kubernetes cluster
 
-In order to operate workloads in your Kubernetes cluster with Juju, you have to add your cluster to the list of *clouds* in juju via the `add-k8s` command.
+To operate workloads in your Kubernetes cluster with Juju, you have to add the cluster to the list of *clouds* in Juju via the `add-k8s` command.
 
 If your Kubernetes config file is in the standard location (`~/.kube/config` on Linux), and you only have one cluster, you can simply run:
 

--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -81,7 +81,7 @@ You can observe your Kubeflow deployment getting spun-up with the command:
 watch -c juju status --color
 ```
 
-#### 6. Add an RBAC role for istio
+#### 6. Add an RBAC role for Istio
 
 At the time of writing this guide, to set up Kubeflow with [Istio](https://istio.io) correctly, you need to provide the `istio-ingressgateway` operator access to Kubernetes resources. Use the  following command to create the appropriate role:
 

--- a/content/en/docs/distributions/gke/_index.md
+++ b/content/en/docs/distributions/gke/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Kubeflow on GCP"
 description = "Running Kubeflow on Kubernetes Engine and Google Cloud Platform"
-weight = 50
+weight = 20
 +++

--- a/content/en/docs/distributions/ibm/_index.md
+++ b/content/en/docs/distributions/ibm/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Kubeflow on IBM Cloud"
 description = "Running Kubeflow on IBM Cloud Kubernetes Service (IKS)"
-weight = 50
+weight = 20
 +++


### PR DESCRIPTION
As we organize the list of [available distributions of Kubeflow](https://master.kubeflow.org/docs/distributions/), on Canonical's side, we're happy to list the work we've been doing to provide an open-source day-2 story for Kubeflow and hence solve some of the known issues with operating Kubeflow with `kfctl` or alternative tooling.

Thank you @knkski for all the great work that has allowed this contribution to happen :tada: 

## Motivation
![Screenshot from 2021-03-30 16-47-08](https://user-images.githubusercontent.com/27001378/113008745-990f8900-9177-11eb-96b8-945ef9516674.png)

With this listing, we aim at solving the problem of many users expressed in the community slack, in a way that is respectful to other members of the community with alternative tooling. 