### PR TITLE
Remove "outdated" banners from MPI + MXnet operators

### DIFF
--- a/content/en/docs/components/training/mpi.md
+++ b/content/en/docs/components/training/mpi.md
@@ -4,10 +4,6 @@ description = "Instructions for using MPI for training"
 weight = 25
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 {{% alpha-status 
   feedbacklink="https://github.com/kubeflow/mpi-operator/issues" %}}

--- a/content/en/docs/components/training/mxnet.md
+++ b/content/en/docs/components/training/mxnet.md
@@ -4,10 +4,6 @@ description = "Instructions for using MXNet"
 weight = 25
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 {{% alpha-status 
   feedbacklink="https://github.com/kubeflow/mxnet-operator/issues" %}}


### PR DESCRIPTION
@andreyvelich this tackles your [comment](https://github.com/kubeflow/website/pull/2584#pullrequestreview-627989055). 