### PR TITLE
Fix broken url link

### DIFF
--- a/content/en/docs/components/pipelines/overview/concepts/run.md
+++ b/content/en/docs/components/pipelines/overview/concepts/run.md
@@ -15,7 +15,7 @@ output artifacts, and logs for each step in the run.
 A *recurring run*, or job in the Kubeflow Pipelines [backend APIs](https://github.com/kubeflow/pipelines/tree/06e4dc660498ce10793d566ca50b8d0425b39981/backend/api/go_http_client/job_client), is a repeatable run of
 a pipeline. The configuration for a recurring run includes a copy of a pipeline
 with all parameter values specified and a 
-[run trigger](/docs/components/pipelines/concepts/run-trigger/).
+[run trigger](/docs/components/pipelines/overview/concepts/run-trigger/).
 You can start a recurring run inside any experiment, and it will periodically
 start a new copy of the run configuration. You can enable/disable the recurring
 run from the Kubeflow Pipelines UI. You can also specify the maximum number of


### PR DESCRIPTION
Current link is broken: https://www.kubeflow.org/docs/components/pipelines/concepts/run-trigger/

Updated link: https://www.kubeflow.org/docs/components/pipelines/overview/concepts/run-trigger/