### PR TITLE
Updating naming to fit latest naming convention

### DIFF
--- a/content/en/docs/started/getting-started.md
+++ b/content/en/docs/started/getting-started.md
@@ -84,7 +84,7 @@ Packaged distributions are developed and supported by their respective maintaine
         <td></td>
       </tr>
       <tr>
-        <td>Charmed Kubeflow</td>
+        <td>Kubeflow Charmed Operators</td>
         <td>Canonical</td>
         <td>Conformant Kubernetes</td>
         <td><a href="/docs/distributions/charmed/">Docs</a></td>


### PR DESCRIPTION
Canonical is standardizing Charmed Operators naming across industries and projects for simplicity.

@knkski could you PTAL