### PR TITLE
Update Katib doc for restarting strategies of CMA-ES

### DIFF
--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -402,6 +402,7 @@ framework for its CMA-ES search.
 The [Covariance Matrix Adaptation Evolution Strategy](https://en.wikipedia.org/wiki/CMA-ES)
 is a stochastic derivative-free numerical optimization algorithm for optimization
 problems in continuous search spaces.
+You can also use [IPOP-CMA-ES](https://sci2s.ugr.es/sites/default/files/files/TematicWebSites/EAMHCO/contributionsCEC05/auger05ARCMA.pdf) and [BIPOP-CMA-ES](https://hal.inria.fr/inria-00382093/document), variant algorithms for restarting optimization when converges to local minimum.
 
 Katib supports the following algorithm settings:
 
@@ -425,6 +426,11 @@ Katib supports the following algorithm settings:
         <td>sigma</td>
         <td>[float]: Initial standard deviation of CMA-ES.</td>
         <td>0.001</td>
+      </tr>
+      <tr>
+        <td>restart_strategy</td>
+        <td>[string, "none", "ipop", or "bipop", default="none"]: Strategy for restarting CMA-ES optimization when converges to a local minimum.</td>
+        <td>"ipop"</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
In https://github.com/kubeflow/katib/pull/1519, I added two options for CMA-ES suggestion service.
I will make this ready for review after https://github.com/kubeflow/katib/pull/1519 is merged.

cc: @andreyvelich 