### PR TITLE
change title of page and video to Introduction to Kubeflow

### DIFF
--- a/content/en/docs/about/kubeflow.md
+++ b/content/en/docs/about/kubeflow.md
@@ -23,7 +23,7 @@ your environment and install Kubeflow.
 
 Watch the following video which provides an introduction to Kubeflow.
 
-{{< youtube cTZArDgbIWw title="Introduction to Kubeflow">}}
+{{< youtube id="cTZArDgbIWw" title="Introduction to Kubeflow">}}
 
 ## What is Kubeflow?
 

--- a/content/en/docs/about/kubeflow.md
+++ b/content/en/docs/about/kubeflow.md
@@ -1,5 +1,5 @@
 +++
-title = "Kubeflow"
+title = "Introduction to Kubeflow"
 description = "An introduction to Kubeflow"
 weight = 1
 aliases = ["/docs/", "/docs/about/", "/docs/kubeflow/"]
@@ -23,7 +23,7 @@ your environment and install Kubeflow.
 
 Watch the following video which provides an introduction to Kubeflow.
 
-{{< youtube cTZArDgbIWw >}}
+{{< youtube cTZArDgbIWw title="Introduction to Kubeflow">}}
 
 ## What is Kubeflow?
 


### PR DESCRIPTION
This is an effort to fix #2618  The only place the expression "An error occurred." occurs on the page is inside the <noscript> tag for the embedded video. 

My theory is that either:
1. Google is attempting to find a better title for this page than a title that is exactly the same as the domain name (the current title) and ended up using the `<h1>An error occurred.</h1>` inside the <noscript> tag. 
2. There was a transient error when Google crawled the page.

In either case, I think these changes slightly improve the page and should encourage Google to reindex the page.

We should also directly request a re-index from the Google Search Console.

cc: @RFMVasconcelos 