### PR TITLE
Patch no longer needed in v1.3

### DIFF
--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -82,15 +82,7 @@ You can observe your Kubeflow deployment getting spun-up with the command:
 watch -c juju status --color
 ```
 
-#### 6. Add an RBAC role for Istio
-
-At the time of writing this guide, to set up Kubeflow with [Istio](https://istio.io) correctly, you need to provide the `istio-ingressgateway` operator access to Kubernetes resources. Use the  following command to create the appropriate role:
-
-```bash
-kubectl patch role -n kubeflow istio-ingressgateway-operator -p '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"istio-ingressgateway-operator"},"rules":[{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}]}'
-```
-
-#### 7. Set URL in authentication methods 
+#### 6. Set URL in authentication methods 
 
 Finally, you need to enable your Kubeflow dashboard access. Provide the dashboard's public URL to dex-auth and oidc-gatekeeper as follows:
 


### PR DESCRIPTION
The documented patch was only required in v1.2, we can now remove it from this docs page. 

@DomFleischmann can you ptal?