### PR TITLE
Upgrading the instance type in cluster launch

### DIFF
--- a/content/en/docs/distributions/aws/deploy/install-kubeflow.md
+++ b/content/en/docs/distributions/aws/deploy/install-kubeflow.md
@@ -59,7 +59,7 @@ For example:
 export AWS_CLUSTER_NAME=kubeflow-demo
 export AWS_REGION=us-west-2
 export K8S_VERSION=1.18
-export EC2_INSTANCE_TYPE=m5.large
+export EC2_INSTANCE_TYPE=m5.2xlarge
 ```
 
 Now, create a cluster configuration file for use with `eksctl`.


### PR DESCRIPTION
m5.large has 2 vCPU. When we do full kubeflow installation
most of its vCPU resources will be occupied and notebook server
will fail with error on unavailbale of vCPU resource. Upgrade the
instance type to m5.2xlarge so that vCPU limit will increase from
2 to 8.