### PR TITLE
Fix typo: vs ==> v2

### DIFF
--- a/content/en/docs/components/pipelines/sdk/v2/build-pipeline.md
+++ b/content/en/docs/components/pipelines/sdk/v2/build-pipeline.md
@@ -63,7 +63,7 @@ $ pip install kfp==1.6.0rc0
 ```python
 import kfp
 import kfp.components as comp
-import kfp.vs.dsl as dsl
+import kfp.v2.dsl as dsl
 from kfp.v2 import compiler
 from kfp.v2.dsl import component
 from kfp.v2.dsl import (


### PR DESCRIPTION
## What

Fix a typo on sample code for Kubeflow Pipelines.
