### PR TITLE
minor: fix broken link in kubeflow installation for openshift

### DIFF
--- a/content/en/docs/distributions/openshift/install-kubeflow.md
+++ b/content/en/docs/distributions/openshift/install-kubeflow.md
@@ -39,8 +39,7 @@ Minimal:
 
 Use the following steps to install Kubeflow 1.0 on OpenShift 4.x.
 
-1. Download the example "kfdef" for Kubeflow 1.3 on Openshift from [kubeflow/manifests/distributions/kfdef]
-(https://raw.githubusercontent.com/kubeflow/manifests/master/distributions/kfdef/kfctl_openshift_v1.3.0.yaml).
+1. Download the example "kfdef" for Kubeflow 1.3 on Openshift from [kubeflow/manifests/distributions/kfdef](https://raw.githubusercontent.com/kubeflow/manifests/master/distributions/kfdef/kfctl_openshift_v1.3.0.yaml).
 
 
 1. Build the deployment configuration using the example OpenShift KFDef file.


### PR DESCRIPTION
The new line prevented the link from showing up correctly.