### PR TITLE
Update url

### DIFF
--- a/content/en/docs/components/pipelines/overview/concepts/component.md
+++ b/content/en/docs/components/pipelines/overview/concepts/component.md
@@ -57,11 +57,11 @@ deserialize the data for use in the downstream component.
 
 ## Next steps
 
-* Read an [overview of Kubeflow Pipelines](/docs/components/pipelines/pipelines-overview/).
+* Read an [overview of Kubeflow Pipelines](/docs/components/pipelines/overview/pipelines-overview/).
 * Follow the [pipelines quickstart guide](/docs/components/pipelines/pipelines-quickstart/) 
   to deploy Kubeflow and run a sample pipeline directly from the Kubeflow 
   Pipelines UI.
 * Build your own 
-  [component and pipeline](/docs/components/pipelines/sdk/build-component/).
-* Build a [reusable component](/docs/components/pipelines/sdk/component-development/) for
+  [component and pipeline](/docs/components/pipelines/sdk/component-development/).
+* Build a [reusable component](/docs/examples/shared-resources/) for
   sharing in multiple pipelines.


### PR DESCRIPTION
1. update url of pipeline overview
2. update "Build your own component  and pipeline" link to build component since the old link likely about it
3.  change the link of "reusable component" to "Shared Resources and Components " page instead of  "component-development" page