### PR TITLE
Resolved broken link issue for pipeline sdk

### DIFF
--- a/content/en/docs/components/pipelines/sdk/install-sdk.md
+++ b/content/en/docs/components/pipelines/sdk/install-sdk.md
@@ -116,6 +116,6 @@ The response should be something like this:
 ## Next steps
 
 * [See how to use the SDK](/docs/components/pipelines/sdk/sdk-overview/).
-* [Build a component and a pipeline](/docs/components/pipelines/sdk/build-component/).
+* [Build a component and a pipeline](/docs/components/pipelines/sdk/component-development/).
 * [Get started with the UI](/docs/components/pipelines/pipelines-quickstart).
 * [Understand pipeline concepts](/docs/components/pipelines/concepts/).


### PR DESCRIPTION
Updated a link in the install Pipeline SDK page to create components and pipeline from Kubeflow Pipelines SDK.
#2780