### PR TITLE
fix(pipelines): image reference path correction

### DIFF
--- a/content/en/docs/components/pipelines/sdk/output-viewer.md
+++ b/content/en/docs/components/pipelines/sdk/output-viewer.md
@@ -398,7 +398,7 @@ def table_vis(mlpipeline_ui_metadata_path: kfp.components.OutputPath()):
 
 **Visualization on the Kubeflow Pipelines UI:**
 
-<img src="/docs/images/taxi-tip-prediction-step-output-table.png" 
+<img src="/docs/images/pipelines/taxi-tip-prediction-step-output-table.png" 
   alt="Table-based visualization from a pipeline component"
   class="mt-3 mb-3 border border-info rounded">
 


### PR DESCRIPTION
The link to table visualization image was not correct before.