### PR TITLE
Correcting the table entry to reflect Red Hat as Maintainers to Openshift stack

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -73,7 +73,7 @@ Packaged distributions are developed and supported by their respective maintaine
         <td>OpenShift</td>
         <td>1.3</td>
         <td><a href="/docs/distributions/openshift/">Docs</a></td>
-        <td></td>
+        <td><a href="https://opendatahub.io/docs/kubeflow.html">External Website</a></td>
       </tr>
       <tr>
         <td>Argoflow</td>

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -69,7 +69,7 @@ Packaged distributions are developed and supported by their respective maintaine
       </tr>
       <tr>
         <td>Kubeflow on OpenShift</td>
-        <td>IBM Cloud</td>
+        <td>Red Hat</td>
         <td>OpenShift</td>
         <td>1.3</td>
         <td><a href="/docs/distributions/openshift/">Docs</a></td>


### PR DESCRIPTION
Red Hat project Open Data Hub is the maintainer of the Openshift distribution in Kubeflow. Corrected that and added a link to the opendatahub.io Kubeflow documentation. 