### PR TITLE
[IBM] update kubeflow version to 1.3 in getting started

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -63,7 +63,7 @@ Packaged distributions are developed and supported by their respective maintaine
         <td>Kubeflow on IBM Cloud</td>
         <td>IBM Cloud</td>
         <td>IBM Cloud Kubernetes Service (IKS) </td>
-        <td>1.2</td>
+        <td>1.3</td>
         <td><a href="/docs/distributions/ibm/">Docs</a></td>
         <td></td>
       </tr>


### PR DESCRIPTION
IBM Cloud Kubeflow docs has been on 1.3 since release. This is just to update the getting started page to the correct version.