### PR TITLE
Update aws-e2e.md

### DIFF
--- a/content/en/docs/distributions/aws/aws-e2e.md
+++ b/content/en/docs/distributions/aws/aws-e2e.md
@@ -383,8 +383,8 @@ metadata:
 type: Opaque
 data:
   # echo -ne "AKIAxxx" | base64
-  awsAccessKeyID: QUtJQVhxxxVXVjQ=
-  awsSecretAccessKey: QzR0UnxxxVNOd0NQQQ==
+  AWS_ACCESS_KEY_ID: QUtJQVhxxxVXVjQ=
+  AWS_SECRET_ACCESS_KEY: QzR0UnxxxVNOd0NQQQ==
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
In kfserving 0.4.0, awsAccessKeyID and awsSecretAccessKey have been replaced by AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.

refer issue: https://github.com/kubeflow/kfserving/issues/999