### PR TITLE
Adds redirect for pipelines/sdk/build-component

### DIFF
--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -47,6 +47,8 @@
 /docs/pipelines/sdk/gcp/preemptible/           /docs/distributions/gke/pipelines/preemptible/
 /docs/pipelines/reusable-components/           /docs/examples/shared-resources/
 /docs/pipelines/sdk/reusable-components/       /docs/examples/shared-resources/
+/docs/pipelines/sdk/build-component/           /docs/components/pipelines/sdk/build-pipeline/
+/docs/components/pipelines/sdk/build-component/    /docs/components/pipelines/sdk/build-pipeline/
 
 # Moved the guide to monitoring GKE deployments.
 /docs/other-guides/monitoring/                 /docs/distributions/gke/monitoring/


### PR DESCRIPTION
The Kubeflow Pipelines UI has a link to `/docs/pipelines/sdk/build-component`. This URL has been changed to `/docs/components/pipelines/sdk/build-pipeline`. This change adds redirects to fix links to this doc.