### PR TITLE
fix: compatibility with hugo v0.87.0

### DIFF
--- a/content/en/docs/components/central-dash/_index.md
+++ b/content/en/docs/components/central-dash/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Central Dashboard"
 description = "The central user interface (UI) in Kubeflow"
-weight = 05
+weight = 5
 +++

--- a/content/en/docs/reference/version-policy.md
+++ b/content/en/docs/reference/version-policy.md
@@ -1,7 +1,7 @@
 +++
 title = "Kubeflow Versioning Policies"
 description = "Versioning policies and status of Kubeflow applications and other components"
-weight = 05
+weight = 5
                     
 +++
 


### PR DESCRIPTION
I got the following error using hugo v0.87.0 to compile the website

> Error: Error building site: "/home/gongyuan_kubeflow_org/github/kf/website/content/en/docs/components/central-dash/_index.md:4:11": unmarshal failed: toml: expected newline but got U+0035 '5'

with this PR, they are fixed