### PR TITLE
Fix link to MLRun docs from main page

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -93,7 +93,7 @@ title = "Kubeflow"
             TensorFlow models to Kubernetes. Kubeflow is also integrated with
             <a target="_blank" rel="noopener" href="/docs/external-add-ons/serving/seldon/">Seldon Core</a>, an open source platform for deploying machine learning
             models on Kubernetes, <a target="_blank" rel="noopener" href="/docs/external-add-ons/serving/tritoninferenceserver/">NVIDIA Triton Inference Server</a> for
-            maximized GPU utilization when deploying ML/DL models at scale, and <a target="_blank" rel="noopener" href="</docs/external-add-ons/serving/mlrun.md/">MLRun Serving</a>, an open-source serverless framework for deployment and monitoring of real-time ML/DL pipelines.
+            maximized GPU utilization when deploying ML/DL models at scale, and <a target="_blank" rel="noopener" href="/docs/external-add-ons/serving/mlrun/">MLRun Serving</a>, an open-source serverless framework for deployment and monitoring of real-time ML/DL pipelines.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Simply removed an extra character that was breaking the link.