### PR TITLE
Add specific version of Kustomize that works

### DIFF
--- a/content/en/docs/distributions/gke/deploy/deploy-cli.md
+++ b/content/en/docs/distributions/gke/deploy/deploy-cli.md
@@ -48,9 +48,9 @@ Before installing Kubeflow on the command line:
     Note: `kpt v1.0.0-beta.1` or above doesn't work due to a known issue: https://github.com/kubeflow/pipelines/issues/6100. Please downgrade gcloud or install kpt separately https://github.com/GoogleContainerTools/kpt/releases/tag/v0.39.2 for now.
 
 1. Install [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/).
-
-    **Note:** Prior to Kubeflow v1.2, Kubeflow was compatible only with Kustomize `v3.2.1`. Starting from Kubeflow v1.2, you can now use any `v3` Kustomize version to install Kubeflow. Kustomize `v4` is not supported out of the box yet. [Official Version](https://github.com/kubeflow/manifests/tree/master#prerequisites)
-
+    
+    Kustomize `v4.2.0` works with Kubeflow v1.3.x.
+    
     To deploy the latest version of Kustomize on a Linux or Mac machine, run the following commands:
 
     ```bash


### PR DESCRIPTION
I've tested that Kustomize 4.2.0 (the latest that the installation script pulls) works with Kubeflow 1.3.1. However, it is possible that not all paths would work. For example, some of the scripts use `--load_restrictor` instead of `--load-restrictor`. For the outlined steps Kustomize 4.2.0 works fine, though this is not mentioned anywhere. (The impression is that the user should use Kustomize 3.2.0 which didn't work for me)