### PR TITLE
setup community-owned Google Analytics v4

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -72,7 +72,7 @@ anchor = "smart"
 
 [services]
 [services.googleAnalytics]
-id = "UA-135379910-1"
+id = "G-DG00RNX3X1"
 
 # Docsy: Language configuration
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,14 +1,17 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}
+
 {{ if eq (getenv "HUGO_ENV") "production" }}
 <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 {{ else }}
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 {{ end }}
+
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
+
 {{ partialCached "favicons.html" . }}
 {{ partial "seo_schema" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
@@ -16,18 +19,24 @@
 {{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
-{{ if eq (getenv "HUGO_ENV") "production" }}
-{{ template "_internal/google_analytics_async.html" . }}
-{{ end }}
+
 {{ partialCached "head-css.html" . "asdf" }}
 <script
   src="https://code.jquery.com/jquery-3.3.1.min.js"
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
   crossorigin="anonymous"></script>
-  {{ if .Site.Params.offlineSearch }}
-  <script
-    src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
-    integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
-    crossorigin="anonymous"></script>
-  {{end}}
-  {{ partial "hooks/head-end.html" . }}
+{{ if .Site.Params.offlineSearch }}
+<script
+  src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
+  integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
+  crossorigin="anonymous"></script>
+{{ end }}
+{{ partial "hooks/head-end.html" . }}
+<!--To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled -->
+{{ if eq (getenv "HUGO_ENV") "production" }}
+{{ if hasPrefix .Site.GoogleAnalytics "G-" }}
+{{ template "_internal/google_analytics.html" . }}
+{{ else }}
+{{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
fixes https://github.com/kubeflow/website/issues/2522 (which has been open since March 2021)

__This PR does two things:__
1. Upgrade the Google Analytics code to V4
2. Sets up a community-owned Google Analytics

This PR is important because currently no one has access to important information like "page views", and the "feedback" buttons at the bottom of the pages.

I am currently the only admin on the new Google Analytics dashboard, but we can easily add the approvers from [OWNERS](https://github.com/kubeflow/website/blob/master/OWNERS) based on their Gmail account.