### PR TITLE
Add instructions to add AWS Fargate profiles before deploying

### DIFF
--- a/content/en/docs/distributions/aws/deploy/install-kubeflow.md
+++ b/content/en/docs/distributions/aws/deploy/install-kubeflow.md
@@ -187,6 +187,16 @@ The method of attaching required IAM policies to the EKS node instance role is s
 
 ## Deploy Kubeflow
 
+1. (Skip if your EKS nodes are not managed by AWS Fargate). If your EKS cluster is running on AWS Fargate, you will need to create a Fargate profile for your nodes.
+    ```
+    export AWS_FARGATE_POD_EXECUTION_ROLE=$(aws iam list-roles | jq -r '.Roles[] | select(.RoleName|contains("FargatePodExecutionRole")).Arn')
+    aws eks create-fargate-profile \
+            --fargate-profile-name kubeflow \
+            --cluster-name $AWS_CLUSTER_NAME \
+            --pod-execution-role-arn $AWS_FARGATE_POD_EXECUTION_ROLE \
+            --selectors namespace=kubeflow,namespace=istio-system,namespace=cert-manager
+    ```
+
 1. Run the following commands to initialize the Kubeflow cluster:
 
     ```


### PR DESCRIPTION
Without a fargate profile, the deployment will fail, as at some point `cert-manager` won't be able to start. 

An error like this shows up, which doesn't have any clues as to what's happening.
```
WARN[0261] Encountered error applying application cert-manager:  (kubeflow.error): Code 500 with message: Apply.Run : error when creating "/tmp/kout108981562": Internal error occurred: failed calling webhook "webhook.cert-manager.io": the server is currently unable to handle the request  filename="kustomize/kustomize.go:284
```

But when I looked at the deployments `kfctl` was creating, specifically at `kubectl get deployments -n cert-manager` - I saw none of them were available, because all of them were lacking a Fargate profile in the new namespace.

I'll check in kfctl itself if there's any way to bootstrap the profile automatically, is this something that would be accepted? Perhaps some users wouldn't want `kfctl` to automatically create a Fargate profile (it's an equivalent procedure of creating nodes in a k8s cluster, so basically running the command could cost you $ without realizing it). Thoughts?