### PR TITLE
Fix docs for Training Operators 1.3

### DIFF
--- a/content/en/docs/components/training/mpi.md
+++ b/content/en/docs/components/training/mpi.md
@@ -1,11 +1,11 @@
 +++
-title = "MPI Training"
+title = "MPI Training (MPIJob)"
 description = "Instructions for using MPI for training"
-weight = 25
+weight = 30
                     
 +++
 
-{{% alpha-status 
+{{% alpha-status
   feedbacklink="https://github.com/kubeflow/mpi-operator/issues" %}}
 
 This guide walks you through using MPI for training.

--- a/content/en/docs/components/training/mxnet.md
+++ b/content/en/docs/components/training/mxnet.md
@@ -1,6 +1,6 @@
 +++
-title = "MXNet Training"
-description = "Instructions for using MXNet"
+title = "MXNet Training (MXJob)"
+description = "Using MXJob to train a model with Apache MXNet"
 weight = 25
                     
 +++
@@ -12,16 +12,17 @@ Apache MXNet jobs (training and tuning) and other extended framework like [ByteP
 jobs on Kubernetes. Using a Custom Resource Definition (CRD) gives users the ability to create
 and manage Apache MXNet jobs just like built-in K8S resources.
 
+The Kubeflow implementation of `MXJob` is in [`training-operator`](https://github.com/kubeflow/tf-operator).
+
 ## Installing MXNet Operator
 
 If you haven't already done so please follow the [Getting Started Guide](/docs/started/getting-started/) to deploy Kubeflow.
 
 > By default, MXNet Operator will be deployed as a controller in training operator.
 
+### Verify that MXJob support is included in your Kubeflow deployment
 
-### Verify that MXJob Support is included in your Kubeflow Deployment
-
-Check that the Apache MXNet custom resource is installed via:
+Check that the Apache MXNet custom resource is installed:
 
 ```
 kubectl get crd
@@ -30,16 +31,16 @@ kubectl get crd
 The output should include `mxjobs.kubeflow.org` like the following:
 
 ```
-NAME                                           AGE
+NAME                                             CREATED AT
 ...
-mxjobs.kubeflow.org                            4d
+mxjobs.kubeflow.org                              2021-09-06T18:33:57Z
 ...
 ```
 
-Check that the Apache MXNet operator is running via:
+Check that the Training operator is running via:
 
 ```
-kubectl get pods
+kubectl get pods -n kubeflow
 ```
 
 The output should include `training-operaror-xxx` like the following:
@@ -49,60 +50,62 @@ NAME                                READY   STATUS    RESTARTS   AGE
 training-operator-d466b46bc-xbqvs   1/1     Running   0          4m37s
 ```
 
-### Creating a Apache MXNet training job
+## Creating a Apache MXNet training job
 
 You create a training job by defining a `MXJob` with `MXTrain` mode and then creating it with.
 
 ```
-kubectl create -f examples/train/mx_job_dist_gpu_v1.yaml
+kubectl create -f https://raw.githubusercontent.com/kubeflow/tf-operator/master/examples/mxnet/train/mx_job_dist_gpu_v1.yaml
 ```
 
-Each `replicaSpec` defines a set of Apache MXNet processes.
+Each `mxReplicaSpecs` defines a set of Apache MXNet processes.
 The `mxReplicaType` defines the semantics for the set of processes.
 The semantics are as follows:
 
 **scheduler**
-  * A job must have 1 and only 1 scheduler
-  * The pod must contain a container named mxnet
-  * The overall status of the `MXJob` is determined by the exit code of the
-    mxnet container
-      * 0 = success
-      * 1 || 2 || 126 || 127 || 128 || 139 = permanent errors:
-          * 1: general errors
-          * 2: misuse of shell builtins
-          * 126: command invoked cannot execute
-          * 127: command not found
-          * 128: invalid argument to exit
-          * 139: container terminated by SIGSEGV(Invalid memory reference)
-      * 130 || 137 || 143 = retryable error for unexpected system signals:
-          * 130: container terminated by Control-C
-          * 137: container received a SIGKILL
-          * 143: container received a SIGTERM
-      * 138 = reserved in tf-operator for user specified retryable errors
-      * others = undefined and no guarantee
+
+- A job must have 1 and only 1 scheduler
+- The pod must contain a container named `mxnet`
+- The overall status of the `MXJob` is determined by the exit code of the
+  mxnet container
+  - 0 = success
+  - 1 || 2 || 126 || 127 || 128 || 139 = permanent errors:
+    - 1: general errors
+    - 2: misuse of shell builtins
+    - 126: command invoked cannot execute
+    - 127: command not found
+    - 128: invalid argument to exit
+    - 139: container terminated by SIGSEGV(Invalid memory reference)
+  - 130 || 137 || 143 = retryable error for unexpected system signals:
+    - 130: container terminated by Control-C
+    - 137: container received a SIGKILL
+    - 143: container received a SIGTERM
+  - 138 = reserved in tf-operator for user specified retryable errors
+  - others = undefined and no guarantee
 
 **worker**
-  * A job can have 0 to N workers
-  * The pod must contain a container named mxnet
-  * Workers are automatically restarted if they exit
+
+- A job can have 0 to N workers
+- The pod must contain a container named mxnet
+- Workers are automatically restarted if they exit
 
 **server**
-  * A job can have 0 to N servers
-  * parameter servers are automatically restarted if they exit
 
+- A job can have 0 to N servers
+- parameter servers are automatically restarted if they exit
 
 For each replica you define a **template** which is a K8S
-[PodTemplateSpec](https://kubernetes.io/docs/api-reference/v1.8/#podtemplatespec-v1-core).
+[PodTemplateSpec](https://v1-21.docs.kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec).
 The template allows you to specify the containers, volumes, etc... that
 should be created for each replica.
 
-### Creating a TVM tuning job (AutoTVM)
+## Creating a TVM tuning job (AutoTVM)
 
 [TVM](https://docs.tvm.ai/tutorials/) is a end to end deep learning compiler stack, you can easily run AutoTVM with mxnet-operator.
 You can create a auto tuning job by define a type of MXTune job and then creating it with
 
 ```
-kubectl create -f examples/mxnet/tune/mx_job_tune_gpu_v1.yaml
+kubectl create -f https://raw.githubusercontent.com/kubeflow/tf-operator/master/examples/mxnet/tune/mx_job_tune_gpu_v1.yaml
 ```
 
 Before you use the auto-tuning example, there is some preparatory work need to be finished in advance.
@@ -112,7 +115,7 @@ For more details, please see [tutorials](https://docs.tvm.ai/tutorials/autotvm/t
 Finally, you need a startup script to start the auto-tuning program. In fact, mxnet-operator will set all the parameters as environment variables and the startup script need to reed these variable and then transmit them to auto-tuning script.
 We provide an example under `examples/tune/`, tuning result will be saved in a log file like resnet-18.log in the example we gave. You can refer it for details.
 
-### Using GPUs
+## Using GPUs
 
 MXNet Operator supports training with GPUs.
 
@@ -128,7 +131,7 @@ resources:
     nvidia.com/gpu: 1
 ```
 
-### Monitoring your Apache MXNet job
+## Monitoring your Apache MXNet job
 
 To get the status of your job
 
@@ -162,12 +165,12 @@ spec:
           creationTimestamp: null
         spec:
           containers:
-          - image: mxjob/mxnet:gpu
-            name: mxnet
-            ports:
-            - containerPort: 9091
-              name: mxjob-port
-            resources: {}
+            - image: mxjob/mxnet:gpu
+              name: mxnet
+              ports:
+                - containerPort: 9091
+                  name: mxjob-port
+              resources: {}
     Server:
       replicas: 1
       restartPolicy: Never
@@ -176,12 +179,12 @@ spec:
           creationTimestamp: null
         spec:
           containers:
-          - image: mxjob/mxnet:gpu
-            name: mxnet
-            ports:
-            - containerPort: 9091
-              name: mxjob-port
-            resources: {}
+            - image: mxjob/mxnet:gpu
+              name: mxnet
+              ports:
+                - containerPort: 9091
+                  name: mxjob-port
+              resources: {}
     Worker:
       replicas: 1
       restartPolicy: Never
@@ -190,47 +193,47 @@ spec:
           creationTimestamp: null
         spec:
           containers:
-          - args:
-            - /incubator-mxnet/example/image-classification/train_mnist.py
-            - --num-epochs
-            - "10"
-            - --num-layers
-            - "2"
-            - --kv-store
-            - dist_device_sync
-            - --gpus
-            - "0"
-            command:
-            - python
-            image: mxjob/mxnet:gpu
-            name: mxnet
-            ports:
-            - containerPort: 9091
-              name: mxjob-port
-            resources:
-              limits:
-                nvidia.com/gpu: "1"
+            - args:
+                - /incubator-mxnet/example/image-classification/train_mnist.py
+                - --num-epochs
+                - "10"
+                - --num-layers
+                - "2"
+                - --kv-store
+                - dist_device_sync
+                - --gpus
+                - "0"
+              command:
+                - python
+              image: mxjob/mxnet:gpu
+              name: mxnet
+              ports:
+                - containerPort: 9091
+                  name: mxjob-port
+              resources:
+                limits:
+                  nvidia.com/gpu: "1"
 status:
   completionTime: 2021-03-24T09:25:11Z
   conditions:
-  - lastTransitionTime: 2021-03-24T15:37:27Z
-    lastUpdateTime: 2021-03-24T15:37:27Z
-    message: MXJob mxnet-job is created.
-    reason: MXJobCreated
-    status: "True"
-    type: Created
-  - lastTransitionTime: 2021-03-24T15:37:27Z
-    lastUpdateTime: 2021-03-24T15:37:29Z
-    message: MXJob mxnet-job is running.
-    reason: MXJobRunning
-    status: "False"
-    type: Running
-  - lastTransitionTime: 2021-03-24T15:37:27Z
-    lastUpdateTime: 2021-03-24T09:25:11Z
-    message: MXJob mxnet-job is successfully completed.
-    reason: MXJobSucceeded
-    status: "True"
-    type: Succeeded
+    - lastTransitionTime: 2021-03-24T15:37:27Z
+      lastUpdateTime: 2021-03-24T15:37:27Z
+      message: MXJob mxnet-job is created.
+      reason: MXJobCreated
+      status: "True"
+      type: Created
+    - lastTransitionTime: 2021-03-24T15:37:27Z
+      lastUpdateTime: 2021-03-24T15:37:29Z
+      message: MXJob mxnet-job is running.
+      reason: MXJobRunning
+      status: "False"
+      type: Running
+    - lastTransitionTime: 2021-03-24T15:37:27Z
+      lastUpdateTime: 2021-03-24T09:25:11Z
+      message: MXJob mxnet-job is successfully completed.
+      reason: MXJobSucceeded
+      status: "True"
+      type: Succeeded
   mxReplicaStatuses:
     Scheduler: {}
     Server: {}
@@ -246,16 +249,18 @@ As with other K8S resources status provides information about the state
 of the resource.
 
 **phase** - Indicates the phase of a job and will be one of
- - Creating
- - Running
- - CleanUp
- - Failed
- - Done
+
+- Creating
+- Running
+- CleanUp
+- Failed
+- Done
 
 **state** - Provides the overall status of the job and will be one of
-  - Running
-  - Succeeded
-  - Failed
+
+- Running
+- Succeeded
+- Failed
 
 For each replica type in the job, there will be a `ReplicaStatus` that
 provides the number of replicas of that type in each state.

--- a/content/en/docs/components/training/mxnet.md
+++ b/content/en/docs/components/training/mxnet.md
@@ -281,10 +281,7 @@ server-76no-0
 server-76no-1
 ```
 
-## Contributing
+## More Information
 
-Please refer to the [this document](./CONTRIBUTING.md) for contributing guidelines.
-
-## Community
-
-Please check out [Kubeflow community page](https://www.kubeflow.org/docs/about/community/) for more information on how to get involved in our community.
+- Check out [Kubeflow community page](https://www.kubeflow.org/docs/about/community/)
+  for more information on how to get involved in our community.

--- a/content/en/docs/components/training/pytorch.md
+++ b/content/en/docs/components/training/pytorch.md
@@ -1,65 +1,81 @@
 +++
-title = "PyTorch Training"
-description = "Instructions for using PyTorch"
+title = "PyTorch Training (PyTorchJob)"
+description = "Using PyTorchJob to train a model with PyTorch"
 weight = 15
                     
 +++
 
 {{% stable-status %}}
 
-This page describes PyTorchJob for training a machine learning model with PyTorch.
+This page describes `PyTorchJob` for training a machine learning model with [PyTorch](https://pytorch.org/).
+
+`PyTorchJob` is a Kubernetes [custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to run PyTorch training jobs on Kubernetes. The Kubeflow implementation of `PyTorchJob` is in [`training-operator`](https://github.com/kubeflow/tf-operator).
 
 ## Installing PyTorch Operator
 
 If you haven't already done so please follow the [Getting Started Guide](/docs/started/getting-started/) to deploy Kubeflow.
 
+> By default, PyTorch Operator will be deployed as a controller in training operator.
 
-## Verify that PyTorch support is included in your Kubeflow deployment
+## Verify that `PyTorchJob` support is included in your Kubeflow deployment
 
-Check that the PyTorch custom resource is installed
+Check that the PyTorch custom resource is installed:
 
 ```
 kubectl get crd
 ```
 
-The output should include `pytorchjobs.kubeflow.org`
+The output should include `pytorchjobs.kubeflow.org` like the following:
 
 ```
-NAME                                           AGE
+NAME                                             CREATED AT
 ...
-pytorchjobs.kubeflow.org                       4d
+pytorchjobs.kubeflow.org                         2021-09-06T18:33:58Z
 ...
 ```
 
-
-## Creating a PyTorch Job
-
-You can create PyTorch Job by defining a PyTorchJob config file. See the manifests for the [distributed MNIST example](https://github.com/kubeflow/tf-operator/blob/master/examples/pytorch/simple.yaml). You may change the config file based on your requirements.
+Check that the Training operator is running via:
 
 ```
-cat simple.yaml
+kubectl get pods -n kubeflow
 ```
-Deploy the PyTorchJob resource to start training:
+
+The output should include `training-operaror-xxx` like the following:
 
 ```
-kubectl create -f simple.yaml
+NAME                                READY   STATUS    RESTARTS   AGE
+training-operator-d466b46bc-xbqvs   1/1     Running   0          4m37s
 ```
+
+## Creating a PyTorch training job
+
+You can create a training job by defining a `PyTorchJob` config file. See the manifests for the [distributed MNIST example](https://github.com/kubeflow/tf-operator/blob/master/examples/pytorch/simple.yaml). You may change the config file based on your requirements.
+
+Deploy the `PyTorchJob` resource to start training:
+
+```
+kubectl create -f https://raw.githubusercontent.com/kubeflow/tf-operator/master/examples/pytorch/simple.yaml
+```
+
 You should now be able to see the created pods matching the specified number of replicas.
 
 ```
 kubectl get pods -l job-name=pytorch-simple -n kubeflow
 ```
+
 Training takes 5-10 minutes on a cpu cluster. Logs can be inspected to see its training progress.
 
 ```
 PODNAME=$(kubectl get pods -l job-name=pytorch-simple,replica-type=master,replica-index=0 -o name -n kubeflow)
 kubectl logs -f ${PODNAME} -n kubeflow
 ```
+
 ## Monitoring a PyTorch Job
 
 ```
 kubectl get -o yaml pytorchjobs pytorch-simple -n kubeflow
 ```
+
 See the status section to monitor the job status. Here is sample output when the job is successfully completed.
 
 ```

--- a/content/en/docs/components/training/pytorch.md
+++ b/content/en/docs/components/training/pytorch.md
@@ -17,7 +17,7 @@ If you haven't already done so please follow the [Getting Started Guide](/docs/s
 
 > By default, PyTorch Operator will be deployed as a controller in training operator.
 
-## Verify that `PyTorchJob` support is included in your Kubeflow deployment
+### Verify that PyTorchJob support is included in your Kubeflow deployment
 
 Check that the PyTorch custom resource is installed:
 

--- a/content/en/docs/components/training/tftraining.md
+++ b/content/en/docs/components/training/tftraining.md
@@ -9,7 +9,7 @@ weight = 10
 
 This page describes `TFJob` for training a machine learning model with [TensorFlow](https://www.tensorflow.org/).
 
-## What is TFJob?
+## What is `TFJob`?
 
 `TFJob` is a Kubernetes
 [custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to run TensorFlow training jobs on Kubernetes. The Kubeflow

--- a/content/en/docs/components/training/tftraining.md
+++ b/content/en/docs/components/training/tftraining.md
@@ -9,7 +9,7 @@ weight = 10
 
 This page describes `TFJob` for training a machine learning model with [TensorFlow](https://www.tensorflow.org/).
 
-## What is `TFJob`?
+## What is TFJob?
 
 `TFJob` is a Kubernetes
 [custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to run TensorFlow training jobs on Kubernetes. The Kubeflow
@@ -135,7 +135,7 @@ spec:
 If you are not familiar with Kubernetes resources please refer to the page [Understanding Kubernetes Objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/).
 
 What makes `TFJob` different from built in [controllers](https://kubernetes.io/docs/concepts/workloads/controllers/) is the `TFJob` spec is designed to manage
-[distributed TensorFlow training jobs](https://www.tensorflow.org/deploy/distributed).
+[distributed TensorFlow training jobs](https://www.tensorflow.org/guide/distributed_training).
 
 A distributed TensorFlow job typically contains 0 or more of the following processes
 
@@ -209,15 +209,13 @@ consists of 3 fields
     of reasons (e.g. node becomes unhealthy) and this will prevent the job from
     recovering.
 
-## Quick start
-
-### Installing TensorFlow Operator
+## Installing TensorFlow Operator
 
 If you haven't already done so please follow the [Getting Started Guide](/docs/started/getting-started/) to deploy Kubeflow.
 
 > By default, `TFJob` Operator will be deployed as a controller in training operator.
 
-## Verify that `TFJob` support is included in your Kubeflow deployment
+### Verify that TFJob support is included in your Kubeflow deployment
 
 Check that the TensorFlow custom resource is installed:
 
@@ -247,7 +245,7 @@ NAME                                READY   STATUS    RESTARTS   AGE
 training-operator-d466b46bc-xbqvs   1/1     Running   0          4m37s
 ```
 
-### Running the Mnist example
+## Running the Mnist example
 
 See the manifests for the [distributed MNIST example](https://github.com/kubeflow/tf-operator/blob/master/examples/tensorflow/simple.yaml). You may change the config file based on your requirements.
 
@@ -269,7 +267,7 @@ Delete it
 kubectl -n kubeflow delete tfjob tfjob-simple
 ```
 
-### Customizing the `TFJob`
+## Customizing the TFJob
 
 Typically you can change the following values in the `TFJob` yaml file:
 

--- a/content/en/docs/components/training/tftraining.md
+++ b/content/en/docs/components/training/tftraining.md
@@ -1,6 +1,5 @@
 +++
 title = "TensorFlow Training (TFJob)"
-linkTitle = "TensorFlow Training (TFJob)"
 description = "Using TFJob to train a model with TensorFlow"
 weight = 10
                     
@@ -8,18 +7,18 @@ weight = 10
 
 {{% stable-status %}}
 
-This page describes TFJob for training a machine learning model with TensorFlow.
+This page describes `TFJob` for training a machine learning model with [TensorFlow](https://www.tensorflow.org/).
 
 ## What is TFJob?
 
-TFJob is a Kubernetes 
-[custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) that you can use to run TensorFlow training jobs on Kubernetes. The Kubeflow
-implementation of TFJob is in
+`TFJob` is a Kubernetes
+[custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to run TensorFlow training jobs on Kubernetes. The Kubeflow
+implementation of `TFJob` is in
 [`training-operator`](https://github.com/kubeflow/tf-operator).
 
-**Note**: TFJob doesn't work in a user namespace by default because of Istio [automatic sidecar injection](https://istio.io/v1.3/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection). In order to get TFJob running, it needs annotation `sidecar.istio.io/inject: "false"` to disable it for TFJob pods.
+**Note**: `TFJob` doesn't work in a user namespace by default because of Istio [automatic sidecar injection](https://istio.io/v1.3/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection). In order to get `TFJob` running, it needs annotation `sidecar.istio.io/inject: "false"` to disable it for `TFJob` pods.
 
-A TFJob is a resource with a YAML representation like the one below (edit to use the container image and command for your own training code):
+A `TFJob` is a resource with a YAML representation like the one below (edit to use the container image and command for your own training code):
 
 ```yaml
 apiVersion: kubeflow.org/v1
@@ -38,14 +37,14 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-          - name: tensorflow
-            image: gcr.io/your-project/your-image
-            command:
-              - python
-              - -m
-              - trainer.task
-              - --batch_size=32
-              - --training_steps=1000
+            - name: tensorflow
+              image: gcr.io/your-project/your-image
+              command:
+                - python
+                - -m
+                - trainer.task
+                - --batch_size=32
+                - --training_steps=1000
     Worker:
       replicas: 3
       restartPolicy: OnFailure
@@ -55,17 +54,17 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-          - name: tensorflow
-            image: gcr.io/your-project/your-image
-            command:
-              - python
-              - -m
-              - trainer.task
-              - --batch_size=32
-              - --training_steps=1000
+            - name: tensorflow
+              image: gcr.io/your-project/your-image
+              command:
+                - python
+                - -m
+                - trainer.task
+                - --batch_size=32
+                - --training_steps=1000
 ```
 
-If you want to give your TFJob pods access to credentials secrets, such as the GCP credentials automatically created when you do a GKE-based Kubeflow installation, you can mount and use a secret like this:
+If you want to give your `TFJob` pods access to credentials secrets, such as the GCP credentials automatically created when you do a GKE-based Kubeflow installation, you can mount and use a secret like this:
 
 ```yaml
 apiVersion: kubeflow.org/v1
@@ -84,25 +83,25 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-          - name: tensorflow
-            image: gcr.io/your-project/your-image
-            command:
-              - python
-              - -m
-              - trainer.task
-              - --batch_size=32
-              - --training_steps=1000
-            env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: "/etc/secrets/user-gcp-sa.json"
-            volumeMounts:
-            - name: sa
-              mountPath: "/etc/secrets"
-              readOnly: true
+            - name: tensorflow
+              image: gcr.io/your-project/your-image
+              command:
+                - python
+                - -m
+                - trainer.task
+                - --batch_size=32
+                - --training_steps=1000
+              env:
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: "/etc/secrets/user-gcp-sa.json"
+              volumeMounts:
+                - name: sa
+                  mountPath: "/etc/secrets"
+                  readOnly: true
           volumes:
-          - name: sa
-            secret:
-              secretName: user-gcp-sa
+            - name: sa
+              secret:
+                secretName: user-gcp-sa
     Worker:
       replicas: 1
       restartPolicy: OnFailure
@@ -112,143 +111,174 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-          - name: tensorflow
-            image: gcr.io/your-project/your-image
-            command:
-              - python
-              - -m
-              - trainer.task
-              - --batch_size=32
-              - --training_steps=1000
-            env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: "/etc/secrets/user-gcp-sa.json"
-            volumeMounts:
-            - name: sa
-              mountPath: "/etc/secrets"
-              readOnly: true
+            - name: tensorflow
+              image: gcr.io/your-project/your-image
+              command:
+                - python
+                - -m
+                - trainer.task
+                - --batch_size=32
+                - --training_steps=1000
+              env:
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: "/etc/secrets/user-gcp-sa.json"
+              volumeMounts:
+                - name: sa
+                  mountPath: "/etc/secrets"
+                  readOnly: true
           volumes:
-          - name: sa
-            secret:
-              secretName: user-gcp-sa
+            - name: sa
+              secret:
+                secretName: user-gcp-sa
 ```
 
 If you are not familiar with Kubernetes resources please refer to the page [Understanding Kubernetes Objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/).
 
-What makes TFJob different from built in [controllers](https://kubernetes.io/docs/concepts/workloads/controllers/) is the TFJob spec is designed to manage 
+What makes `TFJob` different from built in [controllers](https://kubernetes.io/docs/concepts/workloads/controllers/) is the `TFJob` spec is designed to manage
 [distributed TensorFlow training jobs](https://www.tensorflow.org/deploy/distributed).
 
 A distributed TensorFlow job typically contains 0 or more of the following processes
 
-* **Chief** The chief is responsible for orchestrating training and performing tasks
-like checkpointing the model. 
-* **Ps** The ps are parameter servers; these servers provide a distributed data store
-for the model parameters.
-* **Worker** The workers do the actual work of training the model. In some cases, 
-worker 0 might also act as the chief.
-* **Evaluator** The evaluators can be used to compute evaluation metrics as the model
-is trained.
+- **Chief** The chief is responsible for orchestrating training and performing tasks
+  like checkpointing the model.
+- **Ps** The ps are parameter servers; these servers provide a distributed data store
+  for the model parameters.
+- **Worker** The workers do the actual work of training the model. In some cases,
+  worker 0 might also act as the chief.
+- **Evaluator** The evaluators can be used to compute evaluation metrics as the model
+  is trained.
 
-The field **tfReplicaSpecs** in TFJob spec contains a map from the type of
+The field **tfReplicaSpecs** in `TFJob` spec contains a map from the type of
 replica (as listed above) to the **TFReplicaSpec** for that replica. **TFReplicaSpec**
 consists of 3 fields
 
-* **replicas** The number of replicas of this type to spawn for this TFJob.
-* **template** A [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podtemplatespec-v1-core) that describes the pod to create
- for each replica. 
-    * **The pod must include a container named `tensorflow`**.
+- **replicas** The number of replicas of this type to spawn for this `TFJob`.
+- **template** A [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podtemplatespec-v1-core) that describes the pod to create
+  for each replica.
 
-* **restartPolicy** Determines whether pods will be restarted when they exit. The
- allowed values are as follows
-    * **Always** means the pod will always be restarted. This policy is good 
-      for parameter servers since they never exit and should always be restarted
-      in the event of failure.
-    * **OnFailure** means the pod will be restarted if the pod exits due to failure.
-        * A non-zero exit code indicates a failure. 
-        * An exit code of 0 indicates success and the pod will not be restarted. 
-        * This policy is good for chief and workers.
+  - **The pod must include a container named `tensorflow`**.
 
-    * **ExitCode** means the restart behavior is dependent on the exit code of
-      the `tensorflow` container as follows:
+- **restartPolicy** Determines whether pods will be restarted when they exit. The
+  allowed values are as follows
 
-        * Exit code `0` indicates the process completed successfully and will 
-          not be restarted.
+  - **Always** means the pod will always be restarted. This policy is good
+    for parameter servers since they never exit and should always be restarted
+    in the event of failure.
+  - **OnFailure** means the pod will be restarted if the pod exits due to failure.
 
-        * The following exit codes indicate a permanent error and the container 
-          will not be restarted:
+    - A non-zero exit code indicates a failure.
+    - An exit code of 0 indicates success and the pod will not be restarted.
+    - This policy is good for chief and workers.
 
-          * `1`: general errors
-          * `2`: misuse of shell builtins
-          * `126`: command invoked cannot execute
-          * `127`: command not found
-          * `128`: invalid argument to exit
-          * `139`: container terminated by SIGSEGV (invalid memory reference)
+  - **ExitCode** means the restart behavior is dependent on the exit code of
+    the `tensorflow` container as follows:
 
-        * The following exit codes indicate a retryable error and the container 
-          will be restarted:
+    - Exit code `0` indicates the process completed successfully and will
+      not be restarted.
 
-          * `130`: container terminated by SIGINT (keyboard Control-C)
-          * `137`: container received a SIGKILL
-          * `143`: container received a SIGTERM
+    - The following exit codes indicate a permanent error and the container
+      will not be restarted:
 
-        * Exit code `138` corresponds to SIGUSR1 and is reserved for 
-          user-specified retryable errors.
+      - `1`: general errors
+      - `2`: misuse of shell builtins
+      - `126`: command invoked cannot execute
+      - `127`: command not found
+      - `128`: invalid argument to exit
+      - `139`: container terminated by SIGSEGV (invalid memory reference)
 
-        * Other exit codes are undefined and there is no guarantee about the
-          behavior.
+    - The following exit codes indicate a retryable error and the container
+      will be restarted:
 
-        For background information on exit codes, see the [GNU guide to 
-        termination signals](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html)
-        and the  [Linux Documentation 
-        Project](http://tldp.org/LDP/abs/html/exitcodes.html).
+      - `130`: container terminated by SIGINT (keyboard Control-C)
+      - `137`: container received a SIGKILL
+      - `143`: container received a SIGTERM
 
-    * **Never** means pods that terminate will never be restarted. This policy
-      should rarely be used because Kubernetes will terminate pods for any number
-      of reasons (e.g. node becomes unhealthy) and this will prevent the job from
-      recovering.
+    - Exit code `138` corresponds to SIGUSR1 and is reserved for
+      user-specified retryable errors.
+
+    - Other exit codes are undefined and there is no guarantee about the
+      behavior.
+
+    For background information on exit codes, see the [GNU guide to
+    termination signals](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html)
+    and the [Linux Documentation
+    Project](http://tldp.org/LDP/abs/html/exitcodes.html).
+
+  - **Never** means pods that terminate will never be restarted. This policy
+    should rarely be used because Kubernetes will terminate pods for any number
+    of reasons (e.g. node becomes unhealthy) and this will prevent the job from
+    recovering.
 
 ## Quick start
-### Submitting a TensorFlow training job
 
-**Note:** Before submitting a training job, you should have [deployed kubeflow to your cluster](https://www.kubeflow.org/docs/started/getting-started/#installing-kubeflow). Doing so ensures that
-the [`TFJob` custom resource](https://github.com/kubeflow/tf-operator) is available when you submit the training job.
+### Installing TensorFlow Operator
+
+If you haven't already done so please follow the [Getting Started Guide](/docs/started/getting-started/) to deploy Kubeflow.
+
+> By default, `TFJob` Operator will be deployed as a controller in training operator.
+
+## Verify that `TFJob` support is included in your Kubeflow deployment
+
+Check that the TensorFlow custom resource is installed:
+
+```
+kubectl get crd
+```
+
+The output should include `tfjobs.kubeflow.org` like the following:
+
+```
+NAME                                             CREATED AT
+...
+tfjobs.kubeflow.org                         2021-09-06T18:33:58Z
+...
+```
+
+Check that the Training operator is running via:
+
+```
+kubectl get pods -n kubeflow
+```
+
+The output should include `training-operaror-xxx` like the following:
+
+```
+NAME                                READY   STATUS    RESTARTS   AGE
+training-operator-d466b46bc-xbqvs   1/1     Running   0          4m37s
+```
 
 ### Running the Mnist example
 
 See the manifests for the [distributed MNIST example](https://github.com/kubeflow/tf-operator/blob/master/examples/tensorflow/simple.yaml). You may change the config file based on your requirements.
 
-```
-cat simple.yaml
-```
-
-Deploy the TFJob resource to start training:
+Deploy the `TFJob` resource to start training:
 
 ```
-kubectl create -f simple.yaml
+kubectl create -f https://raw.githubusercontent.com/kubeflow/tf-operator/master/examples/tensorflow/simple.yaml
 ```
 
 Monitor the job (see the [detailed guide below](#monitoring-your-job)):
 
 ```
-kubectl -n kubeflow get tfjob mnist -o yaml
+kubectl -n kubeflow get tfjob tfjob-simple -o yaml
 ```
 
 Delete it
 
 ```
-kubectl -n kubeflow delete tfjob tfjob-simple 
+kubectl -n kubeflow delete tfjob tfjob-simple
 ```
 
-### Customizing the TFJob
+### Customizing the `TFJob`
 
-Typically you can change the following values in the TFJob yaml file:
+Typically you can change the following values in the `TFJob` yaml file:
 
 1. Change the image to point to the docker image containing your code
 1. Change the number and types of replicas
 1. Change the resources (requests and limits) assigned to each resource
 1. Set any environment variables
 
-   * For example, you might need to configure various environment variables to talk to datastores like GCS or S3
+   - For example, you might need to configure various environment variables to talk to datastores like GCS or S3
 
 1. Attach PVs if you want to use PVs for storage.
 
@@ -256,13 +286,13 @@ Typically you can change the following values in the TFJob yaml file:
 
 To use GPUs your cluster must be configured to use GPUs.
 
-  * Nodes must have GPUs attached.
-  * The Kubernetes cluster must recognize the `nvidia.com/gpu` resource type.
-  * GPU drivers must be installed on the cluster.
-  * For more information:
-      * [Kubernetes instructions for scheduling GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/)
-      * [GKE instructions](https://cloud.google.com/kubernetes-engine/docs/concepts/gpus)
-      * [EKS instructions](https://docs.aws.amazon.com/eks/latest/userguide/gpu-ami.html)
+- Nodes must have GPUs attached.
+- The Kubernetes cluster must recognize the `nvidia.com/gpu` resource type.
+- GPU drivers must be installed on the cluster.
+- For more information:
+  - [Kubernetes instructions for scheduling GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/)
+  - [GKE instructions](https://cloud.google.com/kubernetes-engine/docs/concepts/gpus)
+  - [EKS instructions](https://docs.aws.amazon.com/eks/latest/userguide/gpu-ami.html)
 
 To attach GPUs specify the GPU resource on the container in the replicas
 that should contain the GPUs; for example.
@@ -281,26 +311,26 @@ spec:
           creationTimestamp: null
         spec:
           containers:
-          - args:
-            - python
-            - tf_cnn_benchmarks.py
-            - --batch_size=32
-            - --model=resnet50
-            - --variable_update=parameter_server
-            - --flush_stdout=true
-            - --num_gpus=1
-            - --local_parameter_device=cpu
-            - --device=cpu
-            - --data_format=NHWC
-            image: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3
-            name: tensorflow
-            ports:
-            - containerPort: 2222
-              name: tfjob-port
-            resources:
-              limits:
-                cpu: '1'
-            workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
+            - args:
+                - python
+                - tf_cnn_benchmarks.py
+                - --batch_size=32
+                - --model=resnet50
+                - --variable_update=parameter_server
+                - --flush_stdout=true
+                - --num_gpus=1
+                - --local_parameter_device=cpu
+                - --device=cpu
+                - --data_format=NHWC
+              image: gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3
+              name: tensorflow
+              ports:
+                - containerPort: 2222
+                  name: tfjob-port
+              resources:
+                limits:
+                  cpu: "1"
+              workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
           restartPolicy: OnFailure
     Worker:
       replicas: 1
@@ -309,26 +339,26 @@ spec:
           creationTimestamp: null
         spec:
           containers:
-          - args:
-            - python
-            - tf_cnn_benchmarks.py
-            - --batch_size=32
-            - --model=resnet50
-            - --variable_update=parameter_server
-            - --flush_stdout=true
-            - --num_gpus=1
-            - --local_parameter_device=cpu
-            - --device=gpu
-            - --data_format=NHWC
-            image: gcr.io/kubeflow/tf-benchmarks-gpu:v20171202-bdab599-dirty-284af3
-            name: tensorflow
-            ports:
-            - containerPort: 2222
-              name: tfjob-port
-            resources:
-              limits:
-                nvidia.com/gpu: 1
-            workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
+            - args:
+                - python
+                - tf_cnn_benchmarks.py
+                - --batch_size=32
+                - --model=resnet50
+                - --variable_update=parameter_server
+                - --flush_stdout=true
+                - --num_gpus=1
+                - --local_parameter_device=cpu
+                - --device=gpu
+                - --data_format=NHWC
+              image: gcr.io/kubeflow/tf-benchmarks-gpu:v20171202-bdab599-dirty-284af3
+              name: tensorflow
+              ports:
+                - containerPort: 2222
+                  name: tfjob-port
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+              workingDir: /opt/tf-benchmarks/scripts/tf_cnn_benchmarks
           restartPolicy: OnFailure
 ```
 
@@ -340,7 +370,7 @@ for using GPUs.
 To get the status of your job
 
 ```bash
-kubectl -n kubeflow get -o yaml tfjobs tfjob-simple 
+kubectl -n kubeflow get -o yaml tfjobs tfjob-simple
 ```
 
 Here is sample output for an example job
@@ -364,71 +394,71 @@ spec:
       template:
         spec:
           containers:
-          - command:
-            - python
-            - /var/tf_mnist/mnist_with_summaries.py
-            image: gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0
-            name: tensorflow
+            - command:
+                - python
+                - /var/tf_mnist/mnist_with_summaries.py
+              image: gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0
+              name: tensorflow
 status:
   completionTime: "2021-09-06T11:49:30Z"
   conditions:
-  - lastTransitionTime: "2021-09-06T11:48:09Z"
-    lastUpdateTime: "2021-09-06T11:48:09Z"
-    message: TFJob tfjob-simple is created.
-    reason: TFJobCreated
-    status: "True"
-    type: Created
-  - lastTransitionTime: "2021-09-06T11:48:12Z"
-    lastUpdateTime: "2021-09-06T11:48:12Z"
-    message: TFJob kubeflow/tfjob-simple is running.
-    reason: TFJobRunning
-    status: "False"
-    type: Running
-  - lastTransitionTime: "2021-09-06T11:49:30Z"
-    lastUpdateTime: "2021-09-06T11:49:30Z"
-    message: TFJob kubeflow/tfjob-simple successfully completed.
-    reason: TFJobSucceeded
-    status: "True"
-    type: Succeeded
+    - lastTransitionTime: "2021-09-06T11:48:09Z"
+      lastUpdateTime: "2021-09-06T11:48:09Z"
+      message: TFJob tfjob-simple is created.
+      reason: TFJobCreated
+      status: "True"
+      type: Created
+    - lastTransitionTime: "2021-09-06T11:48:12Z"
+      lastUpdateTime: "2021-09-06T11:48:12Z"
+      message: TFJob kubeflow/tfjob-simple is running.
+      reason: TFJobRunning
+      status: "False"
+      type: Running
+    - lastTransitionTime: "2021-09-06T11:49:30Z"
+      lastUpdateTime: "2021-09-06T11:49:30Z"
+      message: TFJob kubeflow/tfjob-simple successfully completed.
+      reason: TFJobSucceeded
+      status: "True"
+      type: Succeeded
   replicaStatuses:
     Worker:
       succeeded: 2
   startTime: "2021-09-06T11:48:10Z"
-
 ```
 
 ### Conditions
 
-A TFJob has a TFJobStatus, which has an array of TFJobConditions through which the TFJob has or has not passed. Each element of the TFJobCondition array has six possible fields:
+A `TFJob` has a `TFJobStatus`, which has an array of `TFJobConditions` through which the `TFJob` has or has not passed.
+Each element of the `TFJobCondition` array has six possible fields:
 
-* The **lastUpdateTime** field provides the last time this condition was updated.
-* The **lastTransitionTime** field provides the last time the condition transitioned from one status to another.
-* The **message** field is a human readable message indicating details about the transition.
-* The **reason** field is a unique, one-word, CamelCase reason for the condition's
+- The **lastUpdateTime** field provides the last time this condition was updated.
+- The **lastTransitionTime** field provides the last time the condition transitioned from one status to another.
+- The **message** field is a human readable message indicating details about the transition.
+- The **reason** field is a unique, one-word, CamelCase reason for the condition's
   last transition.
-* The **status** field is a string with possible values "True", "False", and "Unknown".
-* The **type** field is a string with the following possible values:
-  * **TFJobCreated** means the tfjob has been accepted by the system,
+- The **status** field is a string with possible values "True", "False", and "Unknown".
+- The **type** field is a string with the following possible values:
+  - **TFJobCreated** means the `TFJob` has been accepted by the system,
     but one or more of the pods/services has not been started.
-  * **TFJobRunning** means all sub-resources (e.g. services/pods) of this TFJob
-	  have been successfully scheduled and launched and the job is running.
-  * **TFJobRestarting** means one or more sub-resources (e.g. services/pods) 
-      of this TFJob had a problem and is being restarted.
-  * **TFJobSucceeded** means the job completed successfully.
-  * **TFJobFailed** means the job has failed.
+  - **TFJobRunning** means all sub-resources (e.g. services/pods) of this `TFJob`
+    have been successfully scheduled and launched and the job is running.
+  - **TFJobRestarting** means one or more sub-resources (e.g. services/pods)
+    of this `TFJob` had a problem and is being restarted.
+  - **TFJobSucceeded** means the job completed successfully.
+  - **TFJobFailed** means the job has failed.
 
 Success or failure of a job is determined as follows
 
-* If a job has a **chief**, success or failure is determined by the status
+- If a job has a **chief**, success or failure is determined by the status
   of the chief.
-* If a job has no chief, success or failure is determined by the workers.
-* In both cases, the TFJob succeeds if the process being monitored exits
+- If a job has no chief, success or failure is determined by the workers.
+- In both cases, the `TFJob` succeeds if the process being monitored exits
   with exit code 0.
-* In the case of non-zero exit code, the behavior is determined by the restartPolicy
+- In the case of non-zero exit code, the behavior is determined by the restartPolicy
   for the replica.
-* If the restartPolicy allows for restarts then the process will just be restarted and the TFJob will continue to execute.
-  * For the restartPolicy ExitCode the behavior is exit code dependent.
-  * If the restartPolicy doesn't allow restarts a non-zero exit code is considered
+- If the restartPolicy allows for restarts then the process will just be restarted and the `TFJob` will continue to execute.
+  - For the restartPolicy ExitCode the behavior is exit code dependent.
+  - If the restartPolicy doesn't allow restarts a non-zero exit code is considered
     a permanent failure and the job is marked failed.
 
 ### tfReplicaStatuses
@@ -436,14 +466,13 @@ Success or failure of a job is determined as follows
 tfReplicaStatuses provides a map indicating the number of pods for each
 replica in a given state. There are three possible states
 
-  * **Active** is the number of currently running pods.
-  * **Succeeded** is the number of pods that completed successfully.
-  * **Failed** is the number of pods that completed with an error.
-
+- **Active** is the number of currently running pods.
+- **Succeeded** is the number of pods that completed successfully.
+- **Failed** is the number of pods that completed with an error.
 
 ### Events
 
-During execution, TFJob will emit events to indicate whats happening such
+During execution, `TFJob` will emit events to indicate whats happening such
 as the creation/deletion of pods and services. Kubernetes doesn't retain
 events older than 1 hour by default. To see recent events for a job run
 
@@ -567,7 +596,7 @@ Here the events indicate that the pods and services were successfully created.
 
 Logging follows standard K8s logging practices.
 
-You can use kubectl to get standard output/error for any pods 
+You can use kubectl to get standard output/error for any pods
 that haven't been **deleted**.
 
 First find the pod created by the job controller for the replica of
@@ -576,21 +605,22 @@ interest. Pods will be named
 ```
 ${JOBNAME}-${REPLICA-TYPE}-${INDEX}
 ```
+
 Once you've identified your pod you can get the logs using kubectl.
 
 ```
 kubectl logs ${PODNAME}
 ```
 
-The **CleanPodPolicy** in the TFJob spec controls deletion of pods when a job terminates. 
+The **CleanPodPolicy** in the `TFJob` spec controls deletion of pods when a job terminates.
 The policy can be one of the following values
 
-* The **Running** policy means that only pods still running when a job completes 
+- The **Running** policy means that only pods still running when a job completes
   (e.g. parameter servers) will be deleted immediately; completed pods will
   not be deleted so that the logs will be preserved. This is the default value.
-* The **All** policy means all pods even completed pods will be deleted immediately
+- The **All** policy means all pods even completed pods will be deleted immediately
   when the job finishes.
-* The **None** policy means that no pods will be deleted when the job completes.
+- The **None** policy means that no pods will be deleted when the job completes.
 
 If your cluster takes advantage of Kubernetes
 [cluster logging](https://kubernetes.io/docs/concepts/cluster-administration/logging/)
@@ -599,12 +629,12 @@ further analysis.
 
 ### Stackdriver on GKE
 
-See the guide to [logging and monitoring](/docs/gke/monitoring/) for 
+See the guide to [logging and monitoring](/docs/gke/monitoring/) for
 instructions on getting logs using Stackdriver.
 
-As described in the guide to 
+As described in the guide to
 [logging and monitoring](https://www.kubeflow.org/docs/gke/monitoring/#filter-with-labels),
-it's possible to fetch the logs for a particular replica based on pod labels. 
+it's possible to fetch the logs for a particular replica based on pod labels.
 
 Using the Stackdriver UI you can use a query like
 
@@ -626,40 +656,43 @@ QUERY="${QUERY} metadata.userLabels.replica-type=\"${TYPE}\" "
 QUERY="${QUERY} metadata.userLabels.replica-index=\"${INDEX}\" "
 gcloud --project=${PROJECT} logging read  \
      --freshness=24h \
-     --order asc  ${QUERY}        
+     --order asc  ${QUERY}
 ```
-
 
 ## Troubleshooting
 
 Here are some steps to follow to troubleshoot your job
 
 1. Is a status present for your job? Run the command
-    ```
-    kubectl -n ${USER_NAMESPACE} get tfjobs -o yaml ${JOB_NAME}
-    ```
 
-   * **USER_NAMESPACE** is the namespace created for your user profile.
+   ```
+   kubectl -n ${USER_NAMESPACE} get tfjobs -o yaml ${JOB_NAME}
+   ```
 
-   * If the resulting output doesn't include a status for your job then this typically
+   - **USER_NAMESPACE** is the namespace created for your user profile.
+
+   - If the resulting output doesn't include a status for your job then this typically
      indicates the job spec is invalid.
 
-   * If the TFJob spec is invalid there should be a log message in the tf operator logs
+   - If the `TFJob` spec is invalid there should be a log message in the tf operator logs
 
-      ```
-      kubectl -n ${KUBEFLOW_NAMESPACE} logs `kubectl get pods --selector=name=tf-job-operator -o jsonpath='{.items[0].metadata.name}'` 
-      ```
-     * **KUBEFLOW_NAMESPACE** Is the namespace you deployed the TFJob operator in.
+     ```
+     kubectl -n ${KUBEFLOW_NAMESPACE} logs `kubectl get pods --selector=name=tf-job-operator -o jsonpath='{.items[0].metadata.name}'`
+     ```
+
+     - **KUBEFLOW_NAMESPACE** Is the namespace you deployed the `TFJob` operator in.
+
 1. Check the events for your job to see if the pods were created
 
-   * There are a number of ways to get the events; if your job is less than **1 hour old**
- 	 then you can do
+   - There are a number of ways to get the events; if your job is less than **1 hour old**
+     then you can do
 
      ```
- 	   kubectl -n ${USER_NAMESPACE} describe tfjobs -o yaml ${JOB_NAME}
+      kubectl -n ${USER_NAMESPACE} describe tfjobs -o yaml ${JOB_NAME}
      ```
 
-   * The bottom of the output should include a list of events emitted by the job; e.g.
+   - The bottom of the output should include a list of events emitted by the job; e.g.
+
      ```
      Events:
      Type     Reason                          Age                From         Message
@@ -670,45 +703,48 @@ Here are some steps to follow to troubleshoot your job
      Normal   SuccessfulCreatePod             19s                tf-operator  Created pod: tfjob2-ps-0
      Normal   SuccessfulCreateService         19s                tf-operator  Created service: tfjob2-ps-0
      ```
-	
-	* Kubernetes only preserves events for **1 hour** (see [kubernetes/kubernetes#52521](https://github.com/kubernetes/kubernetes/issues/52521))
 
-	  * Depending on your cluster setup events might be persisted to external storage and accessible for longer periods
-	  * On GKE events are persisted in stackdriver and can be accessed using the instructions in the previous section.
-	* If the pods and services aren't being created then this suggests the TFJob isn't being processed; common causes are
+   - Kubernetes only preserves events for **1 hour** (see [kubernetes/kubernetes#52521](https://github.com/kubernetes/kubernetes/issues/52521))
 
-	  * The TFJob spec is invalid (see above)
-	  * The TFJob operator isn't running
-	
+     - Depending on your cluster setup events might be persisted to external storage and accessible for longer periods
+     - On GKE events are persisted in stackdriver and can be accessed using the instructions in the previous section.
+
+   - If the pods and services aren't being created then this suggests the `TFJob` isn't being processed; common causes are
+
+     - The `TFJob` spec is invalid (see above)
+     - The `TFJob` operator isn't running
+
 1. Check the events for the pods to ensure they are scheduled.
 
-   * There are a number of ways to get the events; if your pod is less than **1 hour old**
+   - There are a number of ways to get the events; if your pod is less than **1 hour old**
      then you can do
 
-        ```
-         kubectl -n ${USER_NAMESPACE} describe pods ${POD_NAME}
-        ```
+     ```
+      kubectl -n ${USER_NAMESPACE} describe pods ${POD_NAME}
+     ```
 
-   * The bottom of the output should contain events like the following
+   - The bottom of the output should contain events like the following
 
- 	    ```
-      Events:
-      Type    Reason                 Age   From                                                  Message
-      ----    ------                 ----  ----                                                  -------
-      Normal  Scheduled              18s   default-scheduler                                     Successfully assigned tfjob2-ps-0 to gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt
-      Normal  SuccessfulMountVolume  17s   kubelet, gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt  MountVolume.SetUp succeeded for volume "default-token-h8rnv"
-      Normal  Pulled                 17s   kubelet, gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt  Container image "gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3" already present on machine
-      Normal  Created                17s   kubelet, gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt  Created container
-      Normal  Started                16s   kubelet, gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt  Started container
- 	    ```       
-   * Some common problems that can prevent a container from starting are
- 	   * Insufficient resources to schedule the pod
- 	   * The pod tries to mount a volume (or secret) that doesn't exist or is unavailable
- 	   * The docker image doesn't exist or can't be accessed (e.g due to permission issues)
+     ```
+     Events:
+     Type    Reason                 Age   From                                                  Message
+     ----    ------                 ----  ----                                                  -------
+     Normal  Scheduled              18s   default-scheduler                                     Successfully assigned tfjob2-ps-0 to gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt
+     Normal  SuccessfulMountVolume  17s   kubelet, gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt  MountVolume.SetUp succeeded for volume "default-token-h8rnv"
+     Normal  Pulled                 17s   kubelet, gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt  Container image "gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3" already present on machine
+     Normal  Created                17s   kubelet, gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt  Created container
+     Normal  Started                16s   kubelet, gke-jl-kf-v0-2-2-default-pool-347936c1-1qkt  Started container
+     ```
+
+   - Some common problems that can prevent a container from starting are
+     - Insufficient resources to schedule the pod
+     - The pod tries to mount a volume (or secret) that doesn't exist or is unavailable
+     - The docker image doesn't exist or can't be accessed (e.g due to permission issues)
+
 1. If the containers start; check the logs of the containers following the instructions
    in the previous section.
 
 ## More information
 
-* Explore the [TFJob reference documentation](/docs/reference/tfjob).
-* See how to [run a job with gang-scheduling](/docs/use-cases/job-scheduling#running-jobs-with-gang-scheduling).
+- Explore the [`TFJob` reference documentation](/docs/reference/tfjob).
+- See how to [run a job with gang-scheduling](/docs/use-cases/job-scheduling#running-jobs-with-gang-scheduling).


### PR DESCRIPTION
I fixed some problems mentioned in these PRs: https://github.com/kubeflow/website/pull/2918, https://github.com/kubeflow/website/pull/2917.

Also, I modified docs to be consistent across Training Operators.
I used direct link for the examples, so users don't need to clone the repo.

Please take a look @kubeflow/wg-training-leads @RFMVasconcelos 