### PR TITLE
fix broken Slack link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -220,7 +220,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/kubeflow/website/is
         desc = "Development takes place here!"
 [[params.links.user]]
 	name = "Slack"
-	url = "https://kubeflow.slack.com/join/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ"
+	url = "https://kubeflow.slack.com/join/shared_invite/zt-n73pfj05-l206djXlXk5qdQKs4o1Zkg#/"
 	icon = "fab fa-slack"
         desc = "Chat with other project contributors"
 [[params.links.user]]

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -157,7 +157,7 @@ title = "Kubeflow"
           <p class="card-text text-white">
             We are an open and welcoming community of software developers, data
             scientists, and organizations! Join our <a target="_blank" rel="noopener"
-		    href="https://kubeflow.slack.com/join/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ">Slack workspace</a> 
+		    href="https://kubeflow.slack.com/join/shared_invite/zt-n73pfj05-l206djXlXk5qdQKs4o1Zkg#/">Slack workspace</a> 
             for help with any issues you may face, and read <a target="_blank" rel="noopener" href="/docs/about/community/">more about the community</a>.
           </p>
         </div>

--- a/content/en/docs/distributions/minikf/minikf-vagrant.md
+++ b/content/en/docs/distributions/minikf/minikf-vagrant.md
@@ -27,7 +27,7 @@ Join the discussion on the
 ask questions, request features, and get support for MiniKF.
 
 To join the Kubeflow Slack workspace, please [request an
-invite](https://kubeflow.slack.com/join/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ).
+invite](https://kubeflow.slack.com/join/shared_invite/zt-n73pfj05-l206djXlXk5qdQKs4o1Zkg#/).
 
 ### System requirements
 For a smooth experience we recommend that your system meets the


### PR DESCRIPTION
I noticed the kubeflow.org footer link for Slack did not work when I
first clicked on it, ie:
	"This link is no longer active"

Now, I was not a member of the Slack workspace when I first clicked
it.  Having subsequently found a working link elsewhere and
successfully signed up for the Slack workspace for Kubeflow, that
link does actually try to redirect me to the workspace.

I'm not sure how these redirects are implemented, or if this patch
represents an appropriate fix, but...

Using the url to the one listed for an invite in the
content/en/docs/about/contributing.md did succeed for me, both before
(ie: takes me to a sign up page) and after (takes me to the workspace)
membership.

Signed-off-by: Tim Pepper <tpepper@vmware.com>