### PR TITLE
Update docs for XGBoost

### DIFF
--- a/content/en/docs/components/training/xgboost.md
+++ b/content/en/docs/components/training/xgboost.md
@@ -1,5 +1,5 @@
 +++
-title = "XGBoost Training"
+title = "XGBoost Training (XGBoostJob)"
 description = "Instructions for using XGBoost"
 weight = 30
                     
@@ -31,6 +31,18 @@ xgboostjobs.kubeflow.org                       4d
 ...
 ```
 
+Check that the Training operator is running via:
+
+```
+kubectl get pods -n kubeflow
+```
+
+The output should include `training-operator-xxx` like the following:
+
+```
+NAME                                READY   STATUS    RESTARTS   AGE
+training-operator-d466b46bc-xbqvs   1/1     Running   0          4m37s
+```
 
 ## Creating a XGBoost Job
 


### PR DESCRIPTION
1. Add the name of 'XGBoost' crd in title
2. Add command to fetch pods explicitly in 'kubeflow' namespace

These changes are aimed to improve the readability of the XGBoost page
and also to catch up with latest doc changes of others like MXNet,
pytorch