### PR TITLE
fix typo in the MXNET training operator page

### DIFF
--- a/content/en/docs/components/training/mxnet.md
+++ b/content/en/docs/components/training/mxnet.md
@@ -43,7 +43,7 @@ Check that the Training operator is running via:
 kubectl get pods -n kubeflow
 ```
 
-The output should include `training-operaror-xxx` like the following:
+The output should include `training-operator-xxx` like the following:
 
 ```
 NAME                                READY   STATUS    RESTARTS   AGE


### PR DESCRIPTION
page - https://www.kubeflow.org/docs/components/training/mxnet/