### PR TITLE
Remove reference to insecure password-hashing site

### DIFF
--- a/content/en/docs/distributions/aws/deploy/install-kubeflow.md
+++ b/content/en/docs/distributions/aws/deploy/install-kubeflow.md
@@ -233,7 +233,9 @@ staticPasswords:
 
 # If you want to add a static user (test@kubeflow.org: 123456789)
 # The password (123456789) must be hashed with bcrypt with an at least 10 difficulty level.
-# You can use an online tool like: https://passwordhashing.com/BCrypt
+# You can use an online tool, but BE CAREFUL!
+# At least one such site will display your plain-text password, apparently for all other users to see.
+
 # After change, the example of configmap:
 staticPasswords:
 - email: admin@kubeflow.org


### PR DESCRIPTION
The site referenced in the previous revision, passwordhashing.com, is profoundly insecure. It seems to the display last 10 BCrypt requests, *from any user worldwide*, in plain text. Clearly this is not an appropriate page to which users should be directed. 

Should references to this site also be forcibly removed from older revisions of this document?