### PR TITLE
improve navigation bar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -114,7 +114,7 @@ privacy_policy = "https://policies.google.com/privacy"
 gcs_engine_id = "007239566369470735695:624rglujm-w"
 
 # Text label for the version menu in the top bar of the website.
-version_menu = "Website Version"
+version_menu = "Kubeflow Version"
 
 # The major.minor version tag for the version of the docs represented in this
 # branch of the repository. Used in the "version-banner" partial to display a

--- a/config.toml
+++ b/config.toml
@@ -36,20 +36,19 @@ pygmentsStyle = "tango"
 # Top-level navigation (horizontal)
 
 [[menu.main]]
-    name = "What is Kubeflow?"
-    weight = -103
-    url = "/docs/about/kubeflow/"
-[[menu.main]]
     name = "Documentation"
     weight = -101
+    pre = "<i class='fas fa-book pr-2'></i>"
     url = "/docs/"
 [[menu.main]]
     name = "Blog"
     weight = -100
+    pre = "<i class='fas fa-rss pr-2'></i>"
     url = "https://blog.kubeflow.org/"
 [[menu.main]]
     name = "GitHub"
     weight = -99
+    pre = "<i class='fab fa-github pr-2'></i>"
     url = "https://github.com/kubeflow/"
 
 # Docsy: Configure the format of URLs per section.
@@ -115,7 +114,7 @@ privacy_policy = "https://policies.google.com/privacy"
 gcs_engine_id = "007239566369470735695:624rglujm-w"
 
 # Text label for the version menu in the top bar of the website.
-version_menu = "latest"
+version_menu = "Website Version"
 
 # The major.minor version tag for the version of the docs represented in this
 # branch of the repository. Used in the "version-banner" partial to display a
@@ -142,34 +141,24 @@ githubbranch = "master"
   url = "https://master.kubeflow.org"
 
 [[params.versions]]
-  version = "v0.2"
-  githubbranch = "v0.2-branch"
-  url = "https://v0-2.kubeflow.org"
+  version = "v1.4"
+  githubbranch = "v1.4-branch"
+  url = "https://v1-4-branch.kubeflow.org"
 
 [[params.versions]]
-  version = "v0.3"
-  githubbranch = "v0.3-branch"
-  url = "https://v0-3.kubeflow.org"
+  version = "v1.3"
+  githubbranch = "v1.3-branch"
+  url = "https://v1-3-branch.kubeflow.org"
 
 [[params.versions]]
-  version = "v0.4"
-  githubbranch = "v0.4-branch"
-  url = "https://v0-4.kubeflow.org"
+  version = "v1.2"
+  githubbranch = "v1.2-branch"
+  url = "https://v1-2-branch.kubeflow.org"
 
 [[params.versions]]
-  version = "v0.5"
-  githubbranch = "v0.5-branch"
-  url = "https://v0-5.kubeflow.org"
-
-[[params.versions]]
-  version = "v0.6"
-  githubbranch = "v0.6-branch"
-  url = "https://v0-6.kubeflow.org"
-
-[[params.versions]]
-  version = "v0.7"
-  githubbranch = "v0.7-branch"
-  url = "https://v0-7.kubeflow.org"
+  version = "v1.1"
+  githubbranch = "v1.1-branch"
+  url = "https://v1-1-branch.kubeflow.org"
 
 [[params.versions]]
   version = "v1.0"
@@ -177,24 +166,34 @@ githubbranch = "master"
   url = "https://v1-0-branch.kubeflow.org"
 
 [[params.versions]]
-  version = "v1.1"
-  githubbranch = "v1.1-branch"
-  url = "https://v1-1-branch.kubeflow.org"
-  
-[[params.versions]]
-  version = "v1.2"
-  githubbranch = "v1.2-branch"
-  url = "https://v1-2-branch.kubeflow.org"
-  
-[[params.versions]]
-  version = "v1.3"
-  githubbranch = "v1.3-branch"
-  url = "https://v1-3-branch.kubeflow.org"
+  version = "v0.7"
+  githubbranch = "v0.7-branch"
+  url = "https://v0-7.kubeflow.org"
 
 [[params.versions]]
-  version = "v1.4"
-  githubbranch = "v1.4-branch"
-  url = "https://v1-4-branch.kubeflow.org"
+  version = "v0.6"
+  githubbranch = "v0.6-branch"
+  url = "https://v0-6.kubeflow.org"
+
+[[params.versions]]
+  version = "v0.5"
+  githubbranch = "v0.5-branch"
+  url = "https://v0-5.kubeflow.org"
+
+[[params.versions]]
+  version = "v0.4"
+  githubbranch = "v0.4-branch"
+  url = "https://v0-4.kubeflow.org"
+
+[[params.versions]]
+  version = "v0.3"
+  githubbranch = "v0.3-branch"
+  url = "https://v0-3.kubeflow.org"
+
+[[params.versions]]
+  version = "v0.2"
+  githubbranch = "v0.2-branch"
+  url = "https://v0-2.kubeflow.org"
 
 # Docsy: User interface configuration
 [params.ui]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,33 +1,46 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}
-{{ if eq (getenv "HUGO_ENV") "production" }}
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
-{{ else }}
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-{{ end }}
+{{- $outputFormat := partial "outputformat.html" . -}}
+
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
-{{ partialCached "favicons.html" . }}
+
+{{ if and (eq (getenv "HUGO_ENV") "production") (ne $outputFormat "print") -}}
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+{{ else -}}
+<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+{{ end -}}
+
+<!-- include our custom Kubeflow "seo_schema" partial -->
 {{ partial "seo_schema" . }}
+
+{{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+<meta name="description" content="{{ .Site.Params.Description }}">
 {{- template "_internal/opengraph.html" . -}}
 {{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
+
+{{ partialCached "head-css.html" . "asdf" }}
+<script
+  src="https://code.jquery.com/jquery-3.5.1.min.js"
+  integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+  crossorigin="anonymous"></script>
+{{ if .Site.Params.offlineSearch }}
+<script
+  src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
+  integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
+  crossorigin="anonymous"></script>
+{{end}}
+{{ if .Site.Params.prism_syntax_highlighting }}
+<!-- stylesheet for Prism -->
+<link rel="stylesheet" href="{{ "/css/prism.css" | relURL }}"/>
+{{ end }}
+{{ partial "hooks/head-end.html" . }}
+<!--To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled -->
 {{ if eq (getenv "HUGO_ENV") "production" }}
 {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
-{{ partialCached "head-css.html" . "asdf" }}
-<script
-  src="https://code.jquery.com/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-  crossorigin="anonymous"></script>
-  {{ if .Site.Params.offlineSearch }}
-  <script
-    src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
-    integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
-    crossorigin="anonymous"></script>
-  {{end}}
-  {{ partial "hooks/head-end.html" . }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -15,13 +15,15 @@
 				{{ with .Page }}
 				{{ $active = or $active ( $.IsDescendant .)  }}
 				{{ end }}
+				{{ $pre := .Pre }}
+				{{ $post := .Post }}
 				{{ $url := urls.Parse .URL }}
 				{{ $baseurl := urls.Parse $.Site.Params.Baseurl }}
-				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}><span{{if $active }} class="active"{{end}}>{{ .Name }}</span></a>
+				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>{{ with .Pre}}{{ $pre }}{{ end }}<span{{if $active }} class="active"{{end}}>{{ .Name }}</span>{{ with .Post}}{{ $post }}{{ end }}</a>
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}
-      <li class="nav-item dropdown mt-1 mt-lg-0">
+      <li class="nav-item dropdown mt-1 mt-lg-0 mr-2">
         {{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -34,33 +34,33 @@
   </nav>
 </div>
 {{ define "section-tree-nav-section" }}
-{{ $s := .section }}
-{{ $p := .page }}
-{{ $shouldDelayActive := .shouldDelayActive }}
-{{ $sidebarMenuTruncate := .sidebarMenuTruncate }}
-{{ $treeRoot := cond (eq .ulNr 0) true false }}
-{{ $ulNr := .ulNr }}
-{{ $ulShow := .ulShow }}
-{{ $active := and (not $shouldDelayActive) (eq $s $p) }}
-{{ $activePath := and (not $shouldDelayActive) ($p.IsDescendant $s) }}
-{{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact)) true false }}
-{{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) }}
-{{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
-{{ $pages := $pages_tmp | first $sidebarMenuTruncate }}
-{{ $withChild := gt (len $pages) 0 }}
-{{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) }}
-{{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title }}
-<li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if not $show }} collapse{{ end }}" id="{{ $mid }}-li">
-  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 pr-2{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
-  {{if $withChild }}
-  {{ $ulNr := add $ulNr 1 }}
-  <ul class="pr-md-3 ul-{{ $ulNr }}">
-    {{ range $pages }}
-    {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) }}
-    {{ template "section-tree-nav-section" (dict "page" $p "section" . "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" $ulShow) }}
+  {{ $s := .section }}
+  {{ $p := .page }}
+  {{ $shouldDelayActive := .shouldDelayActive }}
+  {{ $sidebarMenuTruncate := .sidebarMenuTruncate }}
+  {{ $treeRoot := cond (eq .ulNr 0) true false }}
+  {{ $ulNr := .ulNr }}
+  {{ $ulShow := .ulShow }}
+  {{ $active := and (not $shouldDelayActive) (eq $s $p) }}
+  {{ $activePath := and (not $shouldDelayActive) ($p.IsDescendant $s) }}
+  {{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact)) true false }}
+  {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) }}
+  {{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
+  {{ $pages := $pages_tmp | first $sidebarMenuTruncate }}
+  {{ $withChild := gt (len $pages) 0 }}
+  {{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) }}
+  {{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title }}
+  <li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if not $show }} collapse{{ end }}" id="{{ $mid }}-li">
+    <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 pr-2{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
+    {{if $withChild }}
+      {{ $ulNr := add $ulNr 1 }}
+      <ul class="pr-md-3 ul-{{ $ulNr }}">
+        {{ range $pages }}
+          {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) }}
+            {{ template "section-tree-nav-section" (dict "page" $p "section" . "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" $ulShow) }}
+          {{ end }}
+        {{ end }}
+      </ul>
     {{ end }}
-    {{ end }}
-  </ul>
-  {{ end }}
-</li>
+  </li>
 {{ end }}


### PR DESCRIPTION
__This PR improves the header navigation bar:__
- adds icons beside the links (for example, the GitHub logo beside the GitHub link)
- the text for the version selector dropdown now says "Website Version" when you have not picked a specific version
- orders the "Website Version" in descending order (so the newest ones are at the top)
- removes the "What is Kubeflow?" link, for two reasons:
    1. The page it links to is extremely out of date (and doesn't really answer the question)
    2. Its presence significantly increases the size of the header (making it look bad on mobile)