### PR TITLE
remove mention of Kubeflow 1.3 on OpenShift distro page

### DIFF
--- a/content/en/docs/distributions/openshift/_index.md
+++ b/content/en/docs/distributions/openshift/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Kubeflow on OpenShift"
-description = "Running Kubeflow 1.3 on OpenShift 4.x"
+description = "Running Kubeflow on OpenShift 4.x"
 weight = 60
 +++


### PR DESCRIPTION
It seems out place to mention 1.3 on this page. Maintenance of docs easier if we keep version information for distributions in one location here.
https://www.kubeflow.org/docs/started/installing-kubeflow/