### PR TITLE
Katib: Fix links for all examples

### DIFF
--- a/content/en/docs/components/katib/early-stopping.md
+++ b/content/en/docs/components/katib/early-stopping.md
@@ -28,7 +28,7 @@ stopped. Currently, early stopping works only with
 **Note**: Your training container must print training logs with the timestamp,
 because early stopping algorithms need to know the sequence of reported metrics.
 Check the
-[`MXNet` example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/mxnet-mnist/mnist.py#L36)
+[`MXNet` example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-images/mxnet-mnist/mnist.py#L36)
 to learn how to add a date format to your logs.
 
 ## Configure the experiment with early stopping

--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -146,11 +146,11 @@ These are the fields in the experiment configuration spec:
 
   - [Kubeflow `PyTorchJob`](/docs/components/training/pytorch/)
 
-  - [Kubeflow `MPIJob`](/docs/components/training/mpi)
+  - [Kubeflow `MXJob`](/docs/components/training/mxnet)
 
   - [Kubeflow `XGBoostJob`](/docs/components/training/xgboost)
 
-  - [Kubeflow `MXJob`](/docs/components/training/mxnet)
+  - [Kubeflow `MPIJob`](/docs/components/training/mpi)
 
   - [Tekton `Pipelines`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/tekton)
 

--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -32,7 +32,7 @@ optimize, the objective metric to use when determining optimal values, the
 search algorithm to use during optimization, and other configurations.
 
 As a reference, you can use the YAML file of the
-[random algorithm example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/random-example.yaml).
+[random search algorithm example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/random.yaml).
 
 The list below describes the fields in the YAML file for an experiment. The
 Katib UI offers the corresponding fields. You can choose to configure and run
@@ -100,7 +100,7 @@ These are the fields in the experiment configuration spec:
 
   where the Katib controller is searching for the best maximum from the all
   latest reported `accuracy` metrics for each trial. Check the
-  [metrics strategies example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metric-strategy-example.yaml).
+  [metrics strategies example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml).
   The default strategy type for each metric is equal to the objective `type`.
 
   Refer to the
@@ -480,7 +480,7 @@ Katib supports the following algorithm settings:
       </tr>
       <tr>
         <td>n_startup_trials</td>
-        <td>[int]: Number of initial Trials for which the random algorithm generates
+        <td>[int]: Number of initial Trials for which the random search algorithm generates
         hyperparameters.</td>
         <td>5</td>
       </tr>
@@ -652,7 +652,7 @@ For more information, check:
   [Efficient Neural Architecture Search (ENAS)](https://github.com/kubeflow/katib/tree/master/pkg/suggestion/v1beta1/nas/enas).
 
 - The ENAS example —
-  [`enas-example-gpu.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/nas/enas-example-gpu.yaml) —
+  [`enas-gpu.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/nas/enas-gpu.yaml) —
   which attempts to show all possible operations. Due to the large search
   space, the example is not likely to generate a good result.
 
@@ -781,7 +781,7 @@ For more information, check:
   [Differentiable Architecture Search](https://github.com/kubeflow/katib/tree/master/pkg/suggestion/v1beta1/nas/darts).
 
 - The DARTS example —
-  [`darts-example-gpu.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/nas/darts-example-gpu.yaml).
+  [`darts-gpu.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/nas/darts-gpu.yaml).
 
 <a id="metrics-collector"></a>
 
@@ -806,23 +806,23 @@ To define the metrics collector for your experiment:
      output location (_standard output_). This is the default metrics collector.
 
    - `File`: Katib collects the metrics from an arbitrary file, which
-     you specify in the `.source.fileSystemPath.path` field. Training container should log metrics to this file.
-     Check the
-     [file metrics collector example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/file-metricscollector-example.yaml#L15-L22).
+     you specify in the `.source.fileSystemPath.path` field. Training container
+     should log metrics to this file. Check the
+     [file metrics collector example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metrics-collector/file-metrics-collector.yaml#L13-L22).
      The default file path is `/var/log/katib/metrics.log`.
 
    - `TensorFlowEvent`: Katib collects the metrics from a directory path
      containing a [tf.Event](https://www.tensorflow.org/api_docs/python/tf/compat/v1/Event).
      You should specify the path in the `.source.fileSystemPath.path` field.
      Check the
-     [TFJob example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/tfjob-example.yaml#L16-L22).
+     [TFJob example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml#L16-L22).
      The default directory path is `/var/log/katib/tfevent/`.
 
    - `Custom`: Specify this value if you need to use a custom way to collect
      metrics. You must define your custom metrics collector container
      in the `.collector.customCollector` field.
      Check the
-     [custom metrics collector example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/custom-metricscollector-example.yaml#L15-L35).
+     [custom metrics collector example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml#L13-L35).
 
    - `None`: Specify this value if you don't need to use Katib's metrics
      collector. For example, your training code may handle the persistent
@@ -879,10 +879,10 @@ kubectl apply -f <your-path/your-experiment-config.yaml>
   [getting-started guide](/docs/components/katib/hyperparameter/#examples).
 
 Run the following command to launch an experiment
-using the random algorithm example:
+using the random search algorithm example:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1beta1/random-example.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1beta1/hp-tuning/random.yaml
 ```
 
 Check the experiment status:
@@ -891,10 +891,10 @@ Check the experiment status:
 kubectl -n kubeflow describe experiment <your-experiment-name>
 ```
 
-For example, to check the status of the random algorithm example:
+For example, to check the status of the random search algorithm experiment run:
 
 ```shell
-kubectl -n kubeflow describe experiment random-example
+kubectl -n kubeflow describe experiment random
 ```
 
 ### Running the experiment from the Katib UI
@@ -961,7 +961,7 @@ View the results of the experiment in the Katib UI:
 ## Next steps
 
 - Learn how to run the
-  [random algorithm and other Katib examples](/docs/components/katib/hyperparameter/#random-algorithm).
+  [random search algorithm and other Katib examples](/docs/components/katib/hyperparameter/#random-search).
 
 - How to
   [restart your experiment and use the resume policies](/docs/components/katib/resume-experiment/).

--- a/content/en/docs/components/katib/hyperparameter.md
+++ b/content/en/docs/components/katib/hyperparameter.md
@@ -163,9 +163,9 @@ if you want to contribute to Katib UI.
 
 This section introduces some examples that you can run to try Katib.
 
-<a id="random-algorithm"></a>
+<a id="random-search"></a>
 
-### Example using random algorithm
+### Example using random search algorithm
 
 You can create an experiment for Katib by defining the experiment in a YAML
 configuration file. The YAML file defines the configurations for the experiment,
@@ -173,28 +173,28 @@ including the hyperparameter feasible space, optimization parameter,
 optimization goal, suggestion algorithm, and so on.
 
 This example uses the [YAML file for the
-random algorithm example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/random-example.yaml).
+random search example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/random.yaml).
 
-The random algorithm example uses an MXNet neural network to train an image
+The random search algorithm example uses an MXNet neural network to train an image
 classification model using the MNIST dataset. You can check training container source code
-[here](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/mxnet-mnist).
+[here](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/trial-images/mxnet-mnist).
 The experiment runs twelve training jobs with various hyperparameters and saves the results.
 
 If you installed Katib as part of Kubeflow, you can't run experiments in the
 Kubeflow namespace. Run the following commands to change namespace and launch
-an experiment using the random algorithm example:
+an experiment using the random search example:
 
 1. Download the example:
 
    ```shell
-   curl https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1beta1/random-example.yaml --output random-example.yaml
+   curl https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1beta1/hp-tuning/random.yaml --output random.yaml
    ```
 
-1. Edit `random-example.yaml` and change the following line to use your Kubeflow
-   user profile namespace:
+1. Edit `random.yaml` and change the following line to use your Kubeflow
+   user profile namespace (e.g. `kubeflow-user-example-com`):
 
    ```shell
-   Namespace: kubeflow
+   namespace: kubeflow
    ```
 
 1. (Optional) **Note:** Katib's experiments don't work with
@@ -203,10 +203,10 @@ an experiment using the random algorithm example:
    Istio, you have to disable sidecar injection. To do that, specify this annotation:
    `sidecar.istio.io/inject: "false"` in your experiment's trial template.
 
-   For the provided random example with Kubernetes
+   For the provided random search example with Kubernetes
    [`Job`](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
    trial template, annotation should be under
-   [`.trialSpec.spec.template.metadata.annotations`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/random-example.yaml#L52).
+   [`.trialSpec.spec.template.metadata.annotations`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/random.yaml#L52).
    For the Kubeflow `TFJob` or other training operators check
    [here](/docs/components/training/tftraining/#what-is-tfjob)
    how to set the annotation.
@@ -214,7 +214,7 @@ an experiment using the random algorithm example:
 1. Deploy the example:
 
    ```shell
-   kubectl apply -f random-example.yaml
+   kubectl apply -f random.yaml
    ```
 
 This example embeds the hyperparameters as arguments. You can embed
@@ -236,7 +236,7 @@ This example randomly generates the following hyperparameters:
 Check the experiment status:
 
 ```shell
-kubectl -n <YOUR_USER_PROFILE_NAMESPACE> get experiment random-example -o yaml
+kubectl -n <YOUR_USER_PROFILE_NAMESPACE> get experiment random -o yaml
 ```
 
 The output of the above command should look similar to this:
@@ -245,15 +245,10 @@ The output of the above command should look similar to this:
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:
-  creationTimestamp: "2020-10-23T21:27:53Z"
-  finalizers:
-    - update-prometheus-metrics
-  generation: 1
-  name: random-example
-  namespace: "<YOUR_USER_PROFILE_NAMESPACE>"
-  resourceVersion: "147081981"
-  selfLink: /apis/kubeflow.org/v1beta1/namespaces/<YOUR_USER_PROFILE_NAMESPACE>/experiments/random-example
-  uid: fb3776e8-0f83-4783-88b6-80d06867ca0b
+  ...
+  name: random
+  namespace: kubeflow-user-example-com
+  ...
 spec:
   algorithm:
     algorithmName: random
@@ -324,52 +319,52 @@ spec:
                   - --lr=${trialParameters.learningRate}
                   - --num-layers=${trialParameters.numberLayers}
                   - --optimizer=${trialParameters.optimizer}
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 name: training-container
             restartPolicy: Never
 status:
   conditions:
-    - lastTransitionTime: "2020-10-23T21:27:53Z"
-      lastUpdateTime: "2020-10-23T21:27:53Z"
+    - lastTransitionTime: "2021-10-07T21:12:06Z"
+      lastUpdateTime: "2021-10-07T21:12:06Z"
       message: Experiment is created
       reason: ExperimentCreated
       status: "True"
       type: Created
-    - lastTransitionTime: "2020-10-23T21:28:13Z"
-      lastUpdateTime: "2020-10-23T21:28:13Z"
+    - lastTransitionTime: "2021-10-07T21:12:28Z"
+      lastUpdateTime: "2021-10-07T21:12:28Z"
       message: Experiment is running
       reason: ExperimentRunning
       status: "True"
       type: Running
   currentOptimalTrial:
-    bestTrialName: random-example-smpc6ws2
+    bestTrialName: random-hpsrsdqp
     observation:
       metrics:
-        - latest: "0.993170"
-          max: "0.993170"
-          min: "0.920293"
+        - latest: "0.993054"
+          max: "0.993054"
+          min: "0.917694"
           name: Train-accuracy
-        - latest: "0.978006"
-          max: "0.978603"
-          min: "0.959295"
+        - latest: "0.979598"
+          max: "0.979598"
+          min: "0.957106"
           name: Validation-accuracy
     parameterAssignments:
       - name: lr
-        value: "0.02889324678979306"
+        value: "0.024736875661534784"
       - name: num-layers
-        value: "5"
+        value: "4"
       - name: optimizer
         value: sgd
   runningTrialList:
-    - random-example-26d5wzn2
-    - random-example-98fpd29m
-    - random-example-x2vjlzzv
-  startTime: "2020-10-23T21:27:53Z"
+    - random-2dwxbwcg
+    - random-6jd8hmnd
+    - random-7gks8bmf
+  startTime: "2021-10-07T21:12:06Z"
   succeededTrialList:
-    - random-example-n9c4j4cv
-    - random-example-qfb68jpb
-    - random-example-s96tq48v
-    - random-example-smpc6ws2
+    - random-xhpcrt2p
+    - random-hpsrsdqp
+    - random-kddxqqg9
+    - random-4lkr5cjp
   trials: 7
   trialsRunning: 3
   trialsSucceeded: 4
@@ -425,19 +420,19 @@ View the results of the experiment in the Katib UI:
 
 If you installed Katib as part of Kubeflow, you can’t run experiments in the
 Kubeflow namespace. Run the following commands to launch an experiment using
-the Kubeflow's TensorFlow training job operator, TFJob:
+the Kubeflow's [TensorFlow training job operator](/docs/components/training/tftraining), `TFJob`:
 
-1. Download `tfjob-example.yaml`:
+1. Download `tfjob-mnist-with-summaries.yaml`:
 
    ```shell
-   curl https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1beta1/tfjob-example.yaml --output tfjob-example.yaml
+   curl https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml --output tfjob-mnist-with-summaries.yaml
    ```
 
-1. Edit `tfjob-example.yaml` and change the following line to use your Kubeflow
-   user profile namespace:
+1. Edit `tfjob-mnist-with-summaries.yaml` and change the following line to use your Kubeflow
+   user profile namespace (e.g. `kubeflow-user-example-com`):
 
    ```shell
-   Namespace: kubeflow
+   namespace: kubeflow
    ```
 
 1. (Optional) **Note:** Katib's experiments don't work with
@@ -452,35 +447,35 @@ the Kubeflow's TensorFlow training job operator, TFJob:
 1. Deploy the example:
 
    ```shell
-   kubectl apply -f tfjob-example.yaml
+   kubectl apply -f tfjob-mnist-with-summaries.yaml
    ```
 
 1. You can check the status of the experiment:
 
    ```shell
-   kubectl -n <YOUR_USER_PROFILE_NAMESPACE> get experiment tfjob-example -o yaml
+   kubectl -n <YOUR_USER_PROFILE_NAMESPACE> get experiment tfjob-mnist-with-summaries -o yaml
    ```
 
-Follow the steps as described for the _random algorithm example_
+Follow the steps as described for the _random search algorithm example_
 [above](#view-ui) to obtain the results of the experiment in the Katib UI.
 
 ### PyTorch example
 
 If you installed Katib as part of Kubeflow, you can’t run experiments in the
 Kubeflow namespace. Run the following commands to launch an experiment
-using Kubeflow's PyTorch training job operator, PyTorchJob:
+using Kubeflow's [PyTorch training job operator](/docs/components/training/pytorch), `PyTorchJob`:
 
-1. Download `pytorchjob-example.yaml`:
+1. Download `pytorchjob-mnist.yaml`:
 
    ```shell
-   curl https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1beta1/pytorchjob-example.yaml --output pytorchjob-example.yaml
+   curl https://raw.githubusercontent.com/kubeflow/katib/master/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml --output pytorchjob-mnist.yaml
    ```
 
-1. Edit `pytorchjob-example.yaml` and change the following line to use your
-   Kubeflow user profile namespace:
+1. Edit `pytorchjob-mnist.yaml` and change the following line to use your
+   Kubeflow user profile namespace (e.g. `kubeflow-user-example-com`):
 
    ```shell
-   Namespace: kubeflow
+   namespace: kubeflow
    ```
 
 1. (Optional) **Note:** Katib's experiments don't work with
@@ -494,16 +489,16 @@ using Kubeflow's PyTorch training job operator, PyTorchJob:
 1. Deploy the example:
 
    ```shell
-   kubectl apply -f pytorchjob-example.yaml
+   kubectl apply -f pytorchjob-mnist.yaml
    ```
 
 1. You can check the status of the experiment:
 
    ```shell
-   kubectl -n <YOUR_USER_PROFILE_NAMESPACE> describe experiment pytorchjob-example
+   kubectl -n <YOUR_USER_PROFILE_NAMESPACE> describe experiment pytorchjob-mnist
    ```
 
-Follow the steps as described for the _random algorithm example_
+Follow the steps as described for the _random search algorithm example_
 [above](#view-ui) to get the results of the experiment in the Katib UI.
 
 ## Cleaning up

--- a/content/en/docs/components/katib/hyperparameter.md
+++ b/content/en/docs/components/katib/hyperparameter.md
@@ -193,7 +193,7 @@ an experiment using the random search example:
 1. Edit `random.yaml` and change the following line to use your Kubeflow
    user profile namespace (e.g. `kubeflow-user-example-com`):
 
-   ```shell
+   ```
    namespace: kubeflow
    ```
 
@@ -236,7 +236,7 @@ This example randomly generates the following hyperparameters:
 Check the experiment status:
 
 ```shell
-kubectl -n <YOUR_USER_PROFILE_NAMESPACE> get experiment random -o yaml
+kubectl -n kubeflow-user-example-com get experiment random -o yaml
 ```
 
 The output of the above command should look similar to this:
@@ -431,7 +431,7 @@ the Kubeflow's [TensorFlow training job operator](/docs/components/training/tftr
 1. Edit `tfjob-mnist-with-summaries.yaml` and change the following line to use your Kubeflow
    user profile namespace (e.g. `kubeflow-user-example-com`):
 
-   ```shell
+   ```
    namespace: kubeflow
    ```
 
@@ -453,7 +453,7 @@ the Kubeflow's [TensorFlow training job operator](/docs/components/training/tftr
 1. You can check the status of the experiment:
 
    ```shell
-   kubectl -n <YOUR_USER_PROFILE_NAMESPACE> get experiment tfjob-mnist-with-summaries -o yaml
+   kubectl -n kubeflow-user-example-com get experiment tfjob-mnist-with-summaries -o yaml
    ```
 
 Follow the steps as described for the _random search algorithm example_
@@ -474,7 +474,7 @@ using Kubeflow's [PyTorch training job operator](/docs/components/training/pytor
 1. Edit `pytorchjob-mnist.yaml` and change the following line to use your
    Kubeflow user profile namespace (e.g. `kubeflow-user-example-com`):
 
-   ```shell
+   ```
    namespace: kubeflow
    ```
 
@@ -495,7 +495,7 @@ using Kubeflow's [PyTorch training job operator](/docs/components/training/pytor
 1. You can check the status of the experiment:
 
    ```shell
-   kubectl -n <YOUR_USER_PROFILE_NAMESPACE> describe experiment pytorchjob-mnist
+   kubectl -n kubeflow-user-example-com describe experiment pytorchjob-mnist
    ```
 
 Follow the steps as described for the _random search algorithm example_
@@ -506,7 +506,7 @@ Follow the steps as described for the _random search algorithm example_
 To remove Katib from your Kubernetes cluster run:
 
 ```shell
-make undeploy
+kubectl delete -k "github.com/kubeflow/katib.git/manifests/v1beta1/installs/katib-standalone?ref=master"
 ```
 
 ## Next steps

--- a/content/en/docs/components/katib/overview.md
+++ b/content/en/docs/components/katib/overview.md
@@ -211,11 +211,11 @@ Katib has these CRD examples in upstream:
 
 - [Kubeflow `PyTorchJob`](/docs/components/training/pytorch/)
 
-- [Kubeflow `MPIJob`](/docs/components/training/mpi)
+- [Kubeflow `MXJob`](/docs/components/training/mxnet)
 
 - [Kubeflow `XGBoostJob`](/docs/components/training/xgboost)
 
-- [Kubeflow `MXJob`](/docs/components/training/mxnet)
+- [Kubeflow `MPIJob`](/docs/components/training/mpi)
 
 - [Tekton `Pipelines`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/tekton)
 

--- a/content/en/docs/components/katib/resume-experiment.md
+++ b/content/en/docs/components/katib/resume-experiment.md
@@ -75,7 +75,7 @@ Learn more about Katib concepts
 in the [overview guide](/docs/components/katib/overview/#katib-concepts).
 
 Check the
-[`never-resume.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/resume-experiment/never-resume.yaml#L20)
+[`never-resume.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/resume-experiment/never-resume.yaml#L18)
 example for more details.
 
 ### Resume policy: LongRunning

--- a/content/en/docs/components/katib/trial-template.md
+++ b/content/en/docs/components/katib/trial-template.md
@@ -20,9 +20,9 @@ Katib has these CRD examples in upstream:
 
 - [Kubeflow `PyTorchJob`](/docs/components/training/pytorch/)
 
-- [Kubeflow `XGBoostJob`](/docs/components/training/xgboost)
-
 - [Kubeflow `MXJob`](/docs/components/training/mxnet)
+
+- [Kubeflow `XGBoostJob`](/docs/components/training/xgboost)
 
 - [Kubeflow `MPIJob`](/docs/components/training/mpi)
 
@@ -151,7 +151,7 @@ If parameter has the default value, it can be **omitted** in the experiment YAML
   The default value for Kubernetes `Job` is
   `status.conditions.#(type=="Complete")#|#(status=="True")#`
 
-  The default value for Kubeflow `TFJob` and `PyTorchJob` is
+  The default value for Kubeflow `TFJob`, `PyTorchJob`, `MXJob`, and `XGBoostJob` is
   `status.conditions.#(type=="Succeeded")#|#(status=="True")#`
 
   The `successCondition` default value works only if you specify your template
@@ -167,7 +167,7 @@ If parameter has the default value, it can be **omitted** in the experiment YAML
   The default value for Kubernetes `Job` is
   `status.conditions.#(type=="Failed")#|#(status=="True")#`
 
-  The default value for Kubeflow `TFJob` and `PyTorchJob` is
+  The default value for Kubeflow `TFJob`, `PyTorchJob`, `MXJob`, and `XGBoostJob` is
   `status.conditions.#(type=="Failed")#|#(status=="True")#`
 
   The `failureCondition` default value works only if you specify your template
@@ -237,8 +237,8 @@ In Katib examples you can find the following trial worker types:
 [Kubernetes `Job`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/random.yaml),
 [Kubeflow `TFJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml),
 [Kubeflow `PyTorchJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml),
-[Kubeflow `XGBoostJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/xgboostjob-lightgbm.yaml),
 [Kubeflow `MXJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/mxjob-byteps.yaml),
+[Kubeflow `XGBoostJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/xgboostjob-lightgbm.yaml),
 [Kubeflow `MPIJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/mpijob-horovod.yaml),
 [Tekton `Pipelines`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/tekton),
 and [Argo `Workflows`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/argo).

--- a/content/en/docs/components/katib/trial-template.md
+++ b/content/en/docs/components/katib/trial-template.md
@@ -20,11 +20,11 @@ Katib has these CRD examples in upstream:
 
 - [Kubeflow `PyTorchJob`](/docs/components/training/pytorch/)
 
-- [Kubeflow `MPIJob`](/docs/components/training/mpi)
-
 - [Kubeflow `XGBoostJob`](/docs/components/training/xgboost)
 
 - [Kubeflow `MXJob`](/docs/components/training/mxnet)
+
+- [Kubeflow `MPIJob`](/docs/components/training/mpi)
 
 - [Tekton `Pipelines`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/tekton)
 
@@ -69,10 +69,10 @@ To define experiment's trial, you should specify these parameters in `.spec.tria
   - `reference` - the parameter name that experiment's suggestion returns.
     Usually, for the hyperparameter tuning parameter references are equal to the
     experiment search space. For example, in grid example search space has
-    [three parameters](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/grid-example.yaml#L19-L36)
+    [three parameters](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/grid.yaml#L18-L36)
     (`lr`, `num-layers` and `optimizer`) and `trialParameters` contains each of
     these parameters in
-    [`reference`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/grid-example.yaml#L39-L48).
+    [`reference`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/grid.yaml#L39-L48).
 
 - You have to define your experiment's trial template in **one** of the `trialSpec`
   or `configMap` sources.
@@ -85,14 +85,14 @@ To define experiment's trial, you should specify these parameters in `.spec.tria
   experiment's suggestion.
 
   For example,
-  [`--lr=${trialParameters.learningRate}`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/grid-example.yaml#L62)
-  is the [`learningRate`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/grid-example.yaml#L40)
+  [`--lr=${trialParameters.learningRate}`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/grid.yaml#L62)
+  is the [`learningRate`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/grid.yaml#L40)
   parameter.
 
   - `trialSpec` - the experiment's trial template in
     [unstructured](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured)
     format. The template should be a valid YAML. Check the
-    [grid example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/grid-example.yaml#L49-L65).
+    [grid example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/grid.yaml#L49-L65).
 
   - `configMap` - Kubernetes ConfigMap specification where the experiment's
     trial template is located. This ConfigMap must have the label
@@ -109,7 +109,7 @@ To define experiment's trial, you should specify these parameters in `.spec.tria
     1. `templatePath` - the ConfigMap's data path to the template.
 
     Check the example with
-    [ConfigMap source](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-configmap-source.yaml#L50-L53)
+    [ConfigMap source](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-template/trial-configmap-source.yaml#L50-L53)
     for the trial template.
 
 `.spec.trialTemplate` parameters below are used to control trial behavior.
@@ -130,9 +130,9 @@ If parameter has the default value, it can be **omitted** in the experiment YAML
   all worker's Pods. Learn more about Katib metrics collector in
   [running an experiment guide](/docs/components/katib/experiment/#metrics-collector).
   Check the example with
-  [`primaryPodLabels`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/mpijob-horovod.yaml#L29-L30).
+  [`primaryPodLabels`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/mpijob-horovod.yaml#L29-L30).
 
-  The default value for Kubeflow `TFJob` and `PyTorchJob` is `job-role: master`
+  The default value for Kubeflow `TFJob`, `PyTorchJob`, `MXJob`, and `XGBoostJob` is `job-role: master`
 
   The `primaryPodLabels` default value works only if you specify your template
   in `.spec.trialTemplate.trialSpec`. For the `configMap` template source you
@@ -227,21 +227,21 @@ The table below shows the connection between
 </div>
 
 Check the example of
-[using trial metadata](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-metadata-substitution.yaml).
+[using trial metadata](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-template/trial-metadata-substitution.yaml).
 
 <a id="custom-resource"></a>
 
 ## Use custom Kubernetes resource as a trial template
 
 In Katib examples you can find the following trial worker types:
-[Kubernetes `Job`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/random-example.yaml),
-[Kubeflow `TFJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/tfjob-example.yaml),
-[Kubeflow `PyTorchJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/pytorchjob-example.yaml),
-[Kubeflow `MPIJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/mpijob-horovod.yaml),
-[Kubeflow `XGBoostJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/xgboost-lightgbm.yaml),
+[Kubernetes `Job`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/hp-tuning/random.yaml),
+[Kubeflow `TFJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml),
+[Kubeflow `PyTorchJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml),
+[Kubeflow `XGBoostJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/xgboostjob-lightgbm.yaml),
 [Kubeflow `MXJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/mxjob-byteps.yaml),
+[Kubeflow `MPIJob`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/mpijob-horovod.yaml),
 [Tekton `Pipelines`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/tekton),
-and [Argo `Workflows`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/argo)
+and [Argo `Workflows`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/argo).
 
 It is possible to use your own Kubernetes CRD or other Kubernetes resource
 (e.g. [Kubernetes `Deployment`](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/))


### PR DESCRIPTION
This PR: https://github.com/kubeflow/katib/pull/1691 introduces the new structure for Katib examples.
I made the appropriate doc changes.

/assign @gaocegege @johnugeorge @shannonbradshaw @kimwnasptd 