### PR TITLE
Fixing the VPC Id retrieval command

### DIFF
--- a/content/en/docs/distributions/aws/customizing-aws/rds.md
+++ b/content/en/docs/distributions/aws/customizing-aws/rds.md
@@ -23,9 +23,7 @@ export AWS_CLUSTER_NAME=<your_cluster_name>
 # Retrieve your VpcId
 aws ec2 describe-vpcs \
     --filters Name=tag:alpha.eksctl.io/cluster-name,Values=$AWS_CLUSTER_NAME \
-    | jq -r '.Vpcs[].VpcIdaws ec2 describe-vpcs \
-    --filters Name=tag:alpha.eksctl.io/cluster-name,Values=$AWS_CLUSTER_NAME \
-    | jq -r '.Vpcs[].VpcId''
+    | jq -r '.Vpcs[].VpcId'
 
 # Retrieve the list of SubnetId's of your cluster's Private subnets, select at least two
 aws ec2 describe-subnets \


### PR DESCRIPTION
Existing command was wrong

```
$ aws ec2 describe-vpcs \
>     --filters Name=tag:alpha.eksctl.io/cluster-name,Values=$AWS_CLUSTER_NAME \
>     | jq -r '.Vpcs[].VpcIdaws ec2 describe-vpcs \
>     --filters Name=tag:alpha.eksctl.io/cluster-name,Values=$AWS_CLUSTER_NAME \
>     | jq -r '.Vpcs[].VpcId''
jq: error: syntax error, unexpected IDENT, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
.Vpcs[].VpcIdaws ec2 describe-vpcs \                 
jq: 1 compile error
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

New command
```
$ aws ec2 describe-vpcs \
>     --filters Name=tag:alpha.eksctl.io/cluster-name,Values=$AWS_CLUSTER_NAME \
> | jq -r '.Vpcs[].VpcId'
vpc-0xxxxxxxxxxxxxx
```