### PR TITLE
docs: new project issue should go to choose page

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -20,7 +20,7 @@
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 {{ if $gh_project_repo }}
-{{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
+{{ $project_issueURL := printf "%s/issues/new/choose" $gh_project_repo }}
 <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
 {{ end }}
 </div>


### PR DESCRIPTION
The create project issue link in website currently goes to https://github.com/kubeflow/kubeflow/issues/new,
but we want people to go to https://github.com/kubeflow/kubeflow/issues/new/choose instead (so that they can find other repos).