### PR TITLE
add v1.4 dropdown entry

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -191,6 +191,11 @@ githubbranch = "master"
   githubbranch = "v1.3-branch"
   url = "https://v1-3-branch.kubeflow.org"
 
+[[params.versions]]
+  version = "v1.4"
+  githubbranch = "v1.4-branch"
+  url = "https://v1-4-branch.kubeflow.org"
+
 # Docsy: User interface configuration
 [params.ui]
 # Docsy: Enable to show the side bar menu in its compact state.


### PR DESCRIPTION
Adding a 1.4 dropdown entry in prep for cutting the 1.4 website branch.

Fixes #3013 