### PR TITLE
[WIP] Update aws distro approvers in owners

### DIFF
--- a/content/en/docs/distributions/aws/OWNERS
+++ b/content/en/docs/distributions/aws/OWNERS
@@ -1,4 +1,3 @@
 approvers:
-  - Jeffwan
-  - PatrickXYS
-
+  - goswamig
+  - jlbutler


### PR DESCRIPTION
The currently assigned AWS approvers no longer work on the AWS distro. This PR updates to people working on the project and docs.

/cc @goswamig 