### PR TITLE
State how to install standalone training operators

### DIFF
--- a/content/en/docs/components/training/mxnet.md
+++ b/content/en/docs/components/training/mxnet.md
@@ -20,6 +20,9 @@ If you haven't already done so please follow the [Getting Started Guide](/docs/s
 
 > By default, MXNet Operator will be deployed as a controller in training operator.
 
+If you want to install a standalone version of the training operator without Kubeflow,
+see the [kubeflow/training-operator's README](https://github.com/kubeflow/training-operator#installation).
+
 ### Verify that MXJob support is included in your Kubeflow deployment
 
 Check that the Apache MXNet custom resource is installed:

--- a/content/en/docs/components/training/pytorch.md
+++ b/content/en/docs/components/training/pytorch.md
@@ -20,6 +20,9 @@ If you haven't already done so please follow the [Getting Started Guide](/docs/s
 
 > By default, PyTorch Operator will be deployed as a controller in training operator.
 
+If you want to install a standalone version of the training operator without Kubeflow,
+see the [kubeflow/training-operator's README](https://github.com/kubeflow/training-operator#installation).
+
 ### Verify that PyTorchJob support is included in your Kubeflow deployment
 
 Check that the PyTorch custom resource is installed:

--- a/content/en/docs/components/training/tftraining.md
+++ b/content/en/docs/components/training/tftraining.md
@@ -215,6 +215,9 @@ If you haven't already done so please follow the [Getting Started Guide](/docs/s
 
 > By default, `TFJob` Operator will be deployed as a controller in training operator.
 
+If you want to install a standalone version of the training operator without Kubeflow,
+see the [kubeflow/training-operator's README](https://github.com/kubeflow/training-operator#installation).
+
 ### Verify that TFJob support is included in your Kubeflow deployment
 
 Check that the TensorFlow custom resource is installed:

--- a/content/en/docs/components/training/xgboost.md
+++ b/content/en/docs/components/training/xgboost.md
@@ -20,6 +20,9 @@ If you haven't already done so please follow the [Getting Started Guide](/docs/s
 
 > By default, XGBoost Operator will be deployed as a controller in training operator.
 
+If you want to install a standalone version of the training operator without Kubeflow,
+see the [kubeflow/training-operator's README](https://github.com/kubeflow/training-operator#installation).
+
 ## Verify that XGBoost support is included in your Kubeflow deployment
 
 Check that the XGboost custom resource is installed


### PR DESCRIPTION
without installing rest of Kubeflow by linking to
https://github.com/kubeflow/training-operator#installation.

Use case: I have a cluster with some core Kubeflow components installed
already. I just want to test out the training operators and don't want
to upgrade my existing Kubeflow components. Or I have a cluster without
Kubeflow and want to try out the training operators by itself.
