### PR TITLE
fix: update argo-workflow links

### DIFF
--- a/content/en/docs/components/pipelines/overview/pipelines-overview.md
+++ b/content/en/docs/components/pipelines/overview/pipelines-overview.md
@@ -243,7 +243,7 @@ At a high level, the execution of a pipeline proceeds as follows:
   execute the containers needed to complete the pipeline.
   The containers execute within Kubernetes Pods on virtual machines.
   An example controller is the
-  **[Argo Workflow](https://github.com/argoproj/argo)** controller,
+  **[Argo Workflow](https://github.com/argoproj/argo-workflows)** controller,
   which orchestrates task-driven workflows.
 * **Artifact storage**: The Pods store two kinds of data: 
 

--- a/content/en/docs/components/pipelines/sdk/manipulate-resources.md
+++ b/content/en/docs/components/pipelines/sdk/manipulate-resources.md
@@ -23,7 +23,7 @@ is rendered easy in the common case.
 
 This class represents a step of the pipeline which manipulates Kubernetes resources.
 It implements
-[Argo's resource template](https://github.com/argoproj/argo/tree/master/examples#kubernetes-resources).
+[Argo's resource template](https://github.com/argoproj/argo-workflows/tree/master/examples#kubernetes-resources).
 
 This feature allows users to perform some action (`get`, `create`, `apply`,
 `delete`, `replace`, `patch`) on Kubernetes resources.


### PR DESCRIPTION
`argo workflow` repo got renamed from `argo` to `argo-workflows` earlier this year.
This PR fixes the remaining link that pointed to the old URL