### PR TITLE
Fix the storage class yaml file

### DIFF
--- a/content/en/docs/distributions/aws/customizing-aws/storage.md
+++ b/content/en/docs/distributions/aws/customizing-aws/storage.md
@@ -35,6 +35,7 @@ If it's not already in place, specify a storage class for EFS and create it with
 ```shell
 cat << EOF > efs-sc.yaml
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
   name: efs-sc
 provisioner: efs.csi.aws.com


### PR DESCRIPTION
Before fix
```
$ k apply -f efs-sc.yaml 
error: error validating "efs-sc.yaml": error validating data: kind not set; if you choose to ignore these errors, turn validation off with --validate=false

```

After fix

```
storageclass.storage.k8s.io/efs-sc created

```