### PR TITLE
pipelines: update image to use for standalone

### DIFF
--- a/content/en/docs/components/pipelines/installation/standalone-deployment.md
+++ b/content/en/docs/components/pipelines/installation/standalone-deployment.md
@@ -40,7 +40,7 @@ Use the [gcloud container clusters create command](https://cloud.google.com/sdk/
 
 CLUSTER_NAME="kubeflow-pipelines-standalone"
 ZONE="us-central1-a"
-MACHINE_TYPE="e2-standard-2" # A machine with 2 CPUs and 8GB memory
+MACHINE_TYPE="e2-standard-2" # A machine with 2 CPUs and 8GB memory.
 SCOPES="cloud-platform" # This scope is needed for running some pipeline samples. Read the warning below for its security implication
 
 gcloud container clusters create $CLUSTER_NAME \
@@ -48,6 +48,8 @@ gcloud container clusters create $CLUSTER_NAME \
      --machine-type $MACHINE_TYPE \
      --scopes $SCOPES
 ```
+
+**Note**: `e2-standard-2` doesn't support GPU. You can choose machine types that meet your need by referring to guidance in [Cloud Machine families](http://cloud/compute/docs/machine-types).
 
 **Warning**: Using `SCOPES="cloud-platform"` grants all GCP permissions to the cluster. For a more secure cluster setup, refer to [Authenticating Pipelines to GCP](/docs/gke/authentication/#authentication-from-kubeflow-pipelines).
 

--- a/content/en/docs/components/pipelines/installation/standalone-deployment.md
+++ b/content/en/docs/components/pipelines/installation/standalone-deployment.md
@@ -40,7 +40,7 @@ Use the [gcloud container clusters create command](https://cloud.google.com/sdk/
 
 CLUSTER_NAME="kubeflow-pipelines-standalone"
 ZONE="us-central1-a"
-MACHINE_TYPE="n1-standard-2" # A machine with 2 CPUs and 7.50GB memory
+MACHINE_TYPE="e2-standard-2" # A machine with 2 CPUs and 8GB memory
 SCOPES="cloud-platform" # This scope is needed for running some pipeline samples. Read the warning below for its security implication
 
 gcloud container clusters create $CLUSTER_NAME \


### PR DESCRIPTION
N1 machine is costly and about to be deprecated. We are recommending to use new machine type.

Reference: https://cloud.google.com/compute/docs/general-purpose-machines#e2_machine_types