### PR TITLE
examples: Put on warning for out-of-date examples

### DIFF
--- a/content/en/docs/started/kubeflow-examples.md
+++ b/content/en/docs/started/kubeflow-examples.md
@@ -6,7 +6,7 @@ weight = 30
 +++
 
 {{% alert title="Warning" color="warning" %}}
-This section introduces the examples in the 
+This section introduces some examples in the 
 [kubeflow/examples](https://github.com/kubeflow/examples) repository.
 There are out-of-date examples in this repository, check the sample's README file before using.
 {{% /alert %}}

--- a/content/en/docs/started/kubeflow-examples.md
+++ b/content/en/docs/started/kubeflow-examples.md
@@ -5,9 +5,12 @@ weight = 30
                     
 +++
 
+{{% alert title="Warning" color="warning" %}}
 This section introduces the examples in the 
 [kubeflow/examples](https://github.com/kubeflow/examples) repository.
-Before using a sample, check the sample's README file for known issues.
+There are out-of-date examples in this repository, check the sample's README file before using.
+{{% /alert %}}
+
 
 {{% blocks/sample-section title="MNIST image classification"
   kfctl="v1.0.0"

--- a/content/en/docs/started/kubeflow-examples.md
+++ b/content/en/docs/started/kubeflow-examples.md
@@ -6,9 +6,7 @@ weight = 30
 +++
 
 {{% alert title="Warning" color="warning" %}}
-This section introduces some examples in the 
-[kubeflow/examples](https://github.com/kubeflow/examples) repository.
-There are out-of-date examples in this repository, check the sample's README file before using.
+Some examples in [kubeflow/examples](https://github.com/kubeflow/examples) repository have not been tested with newer versions of Kubeflow. Please refer to the README of your chosen example.
 {{% /alert %}}
 
 


### PR DESCRIPTION
Before we clean up the examples repository, make sure we deliver the right message to users that there are out-of-date examples in this repo.