### PR TITLE
AI Platform Pipelines work with private GKE clusters

### DIFF
--- a/content/en/docs/components/pipelines/installation/overview.md
+++ b/content/en/docs/components/pipelines/installation/overview.md
@@ -196,7 +196,7 @@ Google Cloud Integrations
   * A Kubeflow Pipelines public endpoint with auth support is **auto-configured** for you.
   * (Optional) You can choose to persist your data in Google Cloud managed storage services (Cloud SQL and Cloud Storage).
   * You can [authenticate to Google Cloud with the Compute Engine default service account](/docs/gke/pipelines/authentication-pipelines/#compute-engine-default-service-account). However, this method may not be suitable if you need workload permission separation.
-  * You can deploy AI Platform Pipelines on both public and private GKE clusters as long as the cluster adhere to [these](https://cloud.google.com/ai-platform/pipelines/docs/configure-gke-cluster#ensure) requirements.
+  * You can deploy AI Platform Pipelines on both public and private GKE clusters as long as the cluster adheres to [these](https://cloud.google.com/ai-platform/pipelines/docs/configure-gke-cluster#ensure) requirements.
 
 Notes on specific features
 :

--- a/content/en/docs/components/pipelines/installation/overview.md
+++ b/content/en/docs/components/pipelines/installation/overview.md
@@ -196,7 +196,7 @@ Google Cloud Integrations
   * A Kubeflow Pipelines public endpoint with auth support is **auto-configured** for you.
   * (Optional) You can choose to persist your data in Google Cloud managed storage services (Cloud SQL and Cloud Storage).
   * You can [authenticate to Google Cloud with the Compute Engine default service account](/docs/gke/pipelines/authentication-pipelines/#compute-engine-default-service-account). However, this method may not be suitable if you need workload permission separation.
-  * You can deploy AI Platform Pipelines on both public and private GKE clusters as long as the cluster adheres to [these](https://cloud.google.com/ai-platform/pipelines/docs/configure-gke-cluster#ensure) requirements.
+  * You can deploy AI Platform Pipelines on both public and private GKE clusters as long as the cluster [has sufficient resources for AI Platform Pipelines](https://cloud.google.com/ai-platform/pipelines/docs/configure-gke-cluster#ensure).
 
 Notes on specific features
 :

--- a/content/en/docs/components/pipelines/installation/overview.md
+++ b/content/en/docs/components/pipelines/installation/overview.md
@@ -196,6 +196,7 @@ Google Cloud Integrations
   * A Kubeflow Pipelines public endpoint with auth support is **auto-configured** for you.
   * (Optional) You can choose to persist your data in Google Cloud managed storage services (Cloud SQL and Cloud Storage).
   * You can [authenticate to Google Cloud with the Compute Engine default service account](/docs/gke/pipelines/authentication-pipelines/#compute-engine-default-service-account). However, this method may not be suitable if you need workload permission separation.
+  * You can deploy AI Platform Pipelines on both public and private GKE clusters as long as the cluster adhere to [these](https://cloud.google.com/ai-platform/pipelines/docs/configure-gke-cluster#ensure) requirements.
 
 Notes on specific features
 :


### PR DESCRIPTION
Update documentation to mention that AI Platform Pipelines 
work with private GKE clusters.
Kubeflow has many components and currently the
full deployment does not work on private GKE clusters.
However, the managed version of the component "Pipelines"
on GCP named "AI Platform Pipelines" does work with
private GKE cluster. This change makes it clear in the
documentation, in hopes to save time for developers
looking for the answer.