### PR TITLE
Revert "Update getting-started.md (#2934)"

### DIFF
--- a/content/en/docs/components/multi-tenancy/getting-started.md
+++ b/content/en/docs/components/multi-tenancy/getting-started.md
@@ -69,7 +69,7 @@ user in the Kubeflow cluster.  Here an administrator is a person who has
 [*cluster-admin*](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)
 role binding in the Kubernetes cluster. This person has permissions to create
 and modify Kubernetes resources in the cluster. For example, the person who
-deployed Kubeflow will have administrative privileges in the cluster.
+deployed Kubeflow will have administration privileges in the cluster.
 
 ### Pre-requisites: grant user minimal Kubernetes cluster access
 
@@ -173,11 +173,12 @@ The following resources are created as part of the profile creation:
 
   - A Kubernetes namespace that shares the same name with the corresponding
     profile.
-  - Kubernetes RBAC ([Role-based access control](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)) role binding for the namespace: *Admin*. This makes the
+  - Kubernetes RBAC ([Role-based access control](https://kubernetes.io/docs/reference/access-authn-authz/rbac/))
+    role binding role binding for the namespace: *Admin*. This makes the
     profile owner the namespace administrator, thus giving them access to the
     namespace using kubectl (via the Kubernetes API).
   - Istio namespace-scoped AuthorizationPolicy: *user-userid-email-com-clusterrole-edit*.
-    This allows the `user` to access data belonging to the namespace the AuthorizationPolicy was created in 
+    This allows the `user` to access data beloging to the namespace the AuthorizationPolicy was created in 
   - Namespace-scoped service-accounts *default-editor* and *default-viewer* to be used by
     user-created pods in the namespace.
   - Namespace scoped resource quota limits will be placed.
@@ -315,11 +316,11 @@ subjects:
   name: userid@email.com   # replace with the email of the user from your Active Directory case sensitive
 ```
 
-Create an authenticationpolicy.yaml file with the following content on your local machine:
+Create an authorizationpolicy.yaml file with the following content on your local machine:
 
 ```
 apiVersion: security.istio.io/v1beta1
-kind: AuthenticationPolicy
+kind: AuthorizationPolicy
 metadata:
   annotations:
     role: edit
@@ -339,7 +340,7 @@ Run the following command to create the corresponding contributor resources:
 
 ```
 kubectl create -f rolebinding.yaml
-kubectl create -f authenticationpolicy.yaml
+kubectl create -f authorizationpolicy.yaml
 ```
 
 The above command adds a contributor *userid@email.com* to the profile named *profileName*. The contributor


### PR DESCRIPTION
This reverts commit af22175be74938e6290d2fb2abf24c7150e71951.

This is because #2934 renames `AuthorizationPolicy` to `AuthenticationPolicy`, which is obviously not correct, as a `AuthenticationPolicy` resource kind does not exist.