### PR TITLE
Use AuthorizationPolicy in instructions

### DIFF
--- a/content/en/docs/components/multi-tenancy/getting-started.md
+++ b/content/en/docs/components/multi-tenancy/getting-started.md
@@ -315,11 +315,11 @@ subjects:
   name: userid@email.com   # replace with the email of the user from your Active Directory case sensitive
 ```
 
-Create an authenticationpolicy.yaml file with the following content on your local machine:
+Create an authorizationpolicy.yaml file with the following content on your local machine:
 
 ```
 apiVersion: security.istio.io/v1beta1
-kind: AuthenticationPolicy
+kind: AuthorizationPolicy
 metadata:
   annotations:
     role: edit
@@ -339,7 +339,7 @@ Run the following command to create the corresponding contributor resources:
 
 ```
 kubectl create -f rolebinding.yaml
-kubectl create -f authenticationpolicy.yaml
+kubectl create -f authorizationpolicy.yaml
 ```
 
 The above command adds a contributor *userid@email.com* to the profile named *profileName*. The contributor


### PR DESCRIPTION
The instructions reference `AuthenticationPolicy` which I couldn't find anywhere. However, there's AuthorizationPolicy`. I've tested this on my cluster and it's working.