### PR TITLE
Katib: Fix the default format for Metrics Collector

### DIFF
--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -830,7 +830,7 @@ To define the metrics collector for your experiment:
 
 1. Write code in your training container to print or save to the file metrics in the format
    specified in the `.source.filter.metricsFormat`
-   field. The default format is `([\w|-]+)\s*=\s*([+-]?\d(\.\d+)?([Ee][+-]?\d+)?)`.
+   field. The default format is `([\w|-]+)\s*=\s*([+-]?\d*(\.\d+)?([Ee][+-]?\d+)?)`.
    Each element is a regular expression with two subexpressions. The first
    matched expression is taken as the metric name. The second matched
    expression is taken as the metric value.

--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -843,12 +843,12 @@ To define the metrics collector for your experiment:
    epoch 1:
    loss=3.0e-02
    recall=0.5
-   precision=0.4
+   precision=.4
 
    epoch 2:
    loss=1.3e-02
    recall=0.55
-   precision=0.5
+   precision=.5
    ```
 
 ## Running the experiment


### PR DESCRIPTION
Related: https://github.com/kubeflow/katib/pull/1755.
This fixes Metrics Collector regex.

/assign @kubeflow/wg-automl-leads @anencore94