### PR TITLE
docs(sdk): Adds a note to generate correct cluster link for full KF deployment

### DIFF
--- a/content/en/docs/components/pipelines/sdk/connect-api.md
+++ b/content/en/docs/components/pipelines/sdk/connect-api.md
@@ -52,20 +52,20 @@ print(client.list_experiments())
 Note, for Kubeflow Pipelines in multi-user mode, you cannot access the API using kubectl port-forward
 because it requires authentication. Refer to distribution specific documentation as recommended above.
 
-## Connect to Kubeflow Pipelines from the same cluster
 ### Generate the correct cluster URL
 
 To connect to the cluster on the full Kubeflow deployment, you must add `/_/pipeline` to the domain.
 
 For standalone KFP deployment:
 ```python
-uri = domain
+kfp.Client(host='http://deployment_domain')
 ```
 
 For full KF deployment:
 ```python
-uri = domain/_/pipeline
+kfp.Client(host='http://deployment_domain/_/pipeline')
 ```
+## Connect to Kubeflow Pipelines from the same cluster
 ### Non-multi-user mode
 
 As mentioned above, the Kubeflow Pipelines API Kubernetes service is `ml-pipeline-ui`.

--- a/content/en/docs/components/pipelines/sdk/connect-api.md
+++ b/content/en/docs/components/pipelines/sdk/connect-api.md
@@ -53,7 +53,19 @@ Note, for Kubeflow Pipelines in multi-user mode, you cannot access the API using
 because it requires authentication. Refer to distribution specific documentation as recommended above.
 
 ## Connect to Kubeflow Pipelines from the same cluster
+### Generate the correct cluster URL
 
+To connect to the cluster on the full Kubeflow deployment, you must add `/_/pipeline` to the domain.
+
+For standalone KFP deployment:
+```python
+uri = domain
+```
+
+For full KF deployment:
+```python
+uri = domain/_/pipeline
+```
 ### Non-multi-user mode
 
 As mentioned above, the Kubeflow Pipelines API Kubernetes service is `ml-pipeline-ui`.
@@ -85,7 +97,6 @@ namespace = 'kubeflow' # or the namespace you deployed Kubeflow Pipelines
 client = kfp.Client(host=f'http://ml-pipeline-ui.{namespace}:80')
 print(client.list_experiments())
 ```
-
 ### Multi-User mode
 
 Note, multi-user mode technical details were put in the [How in-cluster authentication works](#how-multi-user-mode-in-cluster-authentication-works) section below.

--- a/content/en/docs/components/pipelines/sdk/connect-api.md
+++ b/content/en/docs/components/pipelines/sdk/connect-api.md
@@ -54,7 +54,7 @@ because it requires authentication. Refer to distribution specific documentation
 
 ### Generate the correct cluster URL
 
-To connect to the cluster on the full Kubeflow deployment, you must add `/_/pipeline` to the domain.
+On the full Kubeflow deployment, to connect to the cluster and generate the correct URL for your experiment details, you must add a `/_/pipeline` suffix to the deployment domain:
 
 For standalone KFP deployment:
 ```python
@@ -65,6 +65,7 @@ For full KF deployment:
 ```python
 kfp.Client(host='http://deployment_domain/_/pipeline')
 ```
+
 ## Connect to Kubeflow Pipelines from the same cluster
 ### Non-multi-user mode
 

--- a/content/en/docs/components/pipelines/sdk/connect-api.md
+++ b/content/en/docs/components/pipelines/sdk/connect-api.md
@@ -97,6 +97,7 @@ namespace = 'kubeflow' # or the namespace you deployed Kubeflow Pipelines
 client = kfp.Client(host=f'http://ml-pipeline-ui.{namespace}:80')
 print(client.list_experiments())
 ```
+
 ### Multi-User mode
 
 Note, multi-user mode technical details were put in the [How in-cluster authentication works](#how-multi-user-mode-in-cluster-authentication-works) section below.


### PR DESCRIPTION
Currently the generated cluster link is generated correctly only for the standalone KFP deployment. 
This doc change lets a user know to add a suffix to the URI to generate the correct cluster link for the full KF deployment. 