### PR TITLE
pipelines: Announce the Emissary Executor being default starting KFP 1.8

### DIFF
--- a/content/en/docs/components/pipelines/installation/choose-executor.md
+++ b/content/en/docs/components/pipelines/installation/choose-executor.md
@@ -27,7 +27,7 @@ team only recommend choosing between docker executor and emissary executor.
 
 ### Docker Executor
 
-Docker executor is the **default** workflow executor.
+Docker executor is the **default** workflow executor. But Kubeflow Pipelines v1.8 will switch to Emissary Executor as default executor.
 
 {{% alert title="Warning" color="warning" %}}
 Docker executor depends on docker container runtime, which will be deprecated on Kubernetes 1.20+.

--- a/content/en/docs/components/pipelines/installation/standalone-deployment.md
+++ b/content/en/docs/components/pipelines/installation/standalone-deployment.md
@@ -100,10 +100,11 @@ See the Google Kubernetes Engine (GKE) guide to
      **Note**: `kubectl apply -k` accepts local paths and paths that are formatted as [hashicorp/go-getter URLs](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md#url-format). While the paths in the preceding commands look like URLs, the paths are not valid URLs.
 
      {{% alert title="Deprecation Notice" color="warning" %}}
-Kubeflow Pipelines default to the docker executor, but docker executor will be
-deprecated on Kubernetes 1.20+.
-To prepare for the deprecation, refer to [Argo Workflow Executors](/docs/components/pipelines/installation/choose-executor)
-for migration instructions.
+Kubeflow Pipelines will change default executor from Docker to Emissary starting KFP backend v1.8, docker executor has been
+deprecated on Kubernetes 1.20+. 
+
+For Kubeflow Pipelines before v1.8, configure to use Emissary executor by
+referring to [Argo Workflow Executors](/docs/components/pipelines/installation/choose-executor).
      {{% /alert %}}
 
 1. Get the public URL for the Kubeflow Pipelines UI and use it to access the Kubeflow Pipelines UI:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "git submodule update --init --recursive && hugo --gc --minify"
+  command = "hugo"
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.89.4"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "hugo"
+  command = "git submodule update --init --recursive && hugo --gc --minify"
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.89.4"


### PR DESCRIPTION
Considering the Kubeflow 1.5 release timeline: Feb 24. We will be able to announce this change 30 days ahead of time: https://github.com/kubeflow/community/pull/538.

