### PR TITLE
removed '\n' between link text and URL

### DIFF
--- a/content/en/docs/distributions/openshift/install-kubeflow.md
+++ b/content/en/docs/distributions/openshift/install-kubeflow.md
@@ -40,8 +40,7 @@ Minimal:
 Use the following steps to install Kubeflow 1.3 on OpenShift 4.x.
 
 
-1. Download the example "kfdef" for Kubeflow 1.3 on Openshift from [kubeflow/manifests/distributions/kfdef]
-(https://raw.githubusercontent.com/opendatahub-io/manifests/v1.3-branch/distributions/kfdef/kfctl_openshift_v1.3.0.yaml).
+1. Download the example "kfdef" for Kubeflow 1.3 on Openshift from [kubeflow/manifests/distributions/kfdef](https://raw.githubusercontent.com/opendatahub-io/manifests/v1.3-branch/distributions/kfdef/kfctl_openshift_v1.3.0.yaml).
 
 
 


### PR DESCRIPTION
Because of the newline character between the link text and the URL, the link appears as follows:
https://raw.githubusercontent.com/opendatahub-io/manifests/v1.3-branch/distributions/kfdef/kfctl_openshift_v1.3.0.yaml)
and does not work due to the close parenthesis.