### PR TITLE
fix netlify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "git submodule update --init --recursive && hugo --gc --minify"
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo --gc --minify"
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.89.4"


### PR DESCRIPTION
As raised in https://github.com/kubeflow/website/issues/3109, the Netlify pre-submit tests are failing because they can't see `../vendor/bootstrap/scss/bootstrap`.

Docsy itself has bootstrap as a submodule, and for some reason `git submodule update --init --recursive` is not actually recursively downloading the submodules from the `./themes/docsy` folder.

The command [recomended by the docsy docs](https://www.docsy.dev/docs/deployment/#deployment-with-netlify) is `cd themes/docsy && git submodule update -f --init && cd ../.. && hugo`, so I have used that, but have also kept the production flags `--gc --minify` to improve site performance.