### PR TITLE
gke: Documentation for Config Controller

### DIFF
--- a/content/en/docs/distributions/gke/deploy/delete-cli.md
+++ b/content/en/docs/distributions/gke/deploy/delete-cli.md
@@ -84,6 +84,8 @@ make delete-cluster
 
 Note, after deleting the management cluster, all the managed Google Cloud
 resources will be kept. You will be responsible for managing them by yourself.
+If you want to delete the managed Google Cloud resources, make sure to delete resources in the `${KF_PROJECT}` namespace in the management cluster first.
+You can learn more about the `${KF_PROJECT}` namespace in `gcp-blueprints/kubeflow/kcc` folder.
 
 You can create a management cluster to manage them again if you apply the same
 Config Connector resources. Refer to [Managing and deleting resources - Acquiring an existing resource](https://cloud.google.com/config-connector/docs/how-to/managing-deleting-resources#acquiring_an_existing_resource).

--- a/content/en/docs/distributions/gke/deploy/project-setup.md
+++ b/content/en/docs/distributions/gke/deploy/project-setup.md
@@ -38,6 +38,7 @@ Follow these steps to set up your Google Cloud project:
     * [Cloud Identity-Aware Proxy API](https://console.cloud.google.com/apis/library/iap.googleapis.com)
     * [Cloud Build API](https://console.cloud.google.com/apis/library/cloudbuild.googleapis.com) (It's required if you plan to use [Fairing](https://www.kubeflow.org/docs/external-add-ons/fairing/) in your Kubeflow cluster)
     * [Cloud SQL Admin API](https://console.cloud.google.com/apis/library/sqladmin.googleapis.com)
+    * [Config Controller (KRM API Hosting API)](https://console.cloud.google.com/apis/library/krmapihosting.googleapis.com)
 
     You can also enable these APIs by running the following command in Cloud Shell:
     ```bash
@@ -50,7 +51,8 @@ Follow these steps to set up your Google Cloud project:
       ml.googleapis.com \
       iap.googleapis.com \
       sqladmin.googleapis.com \
-      meshconfig.googleapis.com 
+      meshconfig.googleapis.com \
+      krmapihosting.googleapis.com
 
     # Cloud Build API is optional, you need it if using Fairing.
     # gcloud services enable cloudbuild.googleapis.com

--- a/content/en/docs/distributions/gke/deploy/upgrade.md
+++ b/content/en/docs/distributions/gke/deploy/upgrade.md
@@ -24,6 +24,8 @@ This guide assumes the following settings:
 
 ## General upgrade instructions
 
+Starting from Kubeflow v1.5, we have integrated with [Config Controller](https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview). You don't need to manually upgrade Management cluster any more, since it managed by [Upgrade Config Controller](https://cloud.google.com/anthos-config-management/docs/how-to/config-controller-setup#upgrade).
+
 Starting from Kubeflow v1.3, we have reworked on the structure of `kubeflow/gcp-blueprints` repository. All resources are located in `gcp-blueprints/management` directory. Upgrade to Management cluster v1.3 is not supported.
 
 Before Kubeflow v1.3, both management cluster and Kubeflow cluster follow the same `instance` and `upstream` folder convention. To upgrade, you'll typically need to update packages in `upstream` to the new version and repeat the `make apply-<subcommand>` commands in their respective deployment process.
@@ -32,7 +34,7 @@ However, specific upgrades might need manual actions below.
 
 ## Upgrading management cluster
 
-### General instruction for upgrading management cluster
+### Upgrading management cluster before 1.5
 
 It is strongly recommended to use source control to keep a copy of your working repository for recording changes at each step.
 


### PR DESCRIPTION
Corresponding Config Controller change: https://github.com/kubeflow/gcp-blueprints/pull/347.
Partial: https://github.com/kubeflow/gcp-blueprints/issues/341

With the migration to Config Controller, user doesn't need to manually manage or upgrade their Management cluster. This is one-time cost for setting up Management cluster. The integration with Kubeflow project is also simplified.