### PR TITLE
Update IKS doc for kubeflow v1.5

### DIFF
--- a/content/en/docs/distributions/ibm/deploy/authentication.md
+++ b/content/en/docs/distributions/ibm/deploy/authentication.md
@@ -146,11 +146,11 @@ Kubernetes Service 37 days before it expires. After this secret is updated, you
 must manually copy it to the `istio-ingressgateway-certs` secret by repeating
 commands in step 5 and 6.
 
-## Optional - KFServing configuration
+## Optional - KServe configuration
 
-With this HTTPS setup, you need to make additional changes to get KFServing to work.
+With this HTTPS setup, you need to make additional changes to get KServe to work.
 
-1. First, update the Knative domain that is used for the KFServing routes to the
+1. First, update the Knative domain that is used for the KServe routes to the
 hostname that you used when updating `kubeflow-gateway`.
 
     ```shell
@@ -270,5 +270,5 @@ the content of the cookie is retrieved from the browser, it can be added as a he
 (e.g. `"Cookie: authservice_session=MTYwNz..."`). For example:
 
 ```shell
-curl -v https://sklearn-iris-kfserving-test.kf-dev-442dbba0442be6c8c50f31ed96b00532-0001.sjc03.containers.appdomain.cloud/v1/models/sklearn-iris:predict -d '{"instances": [[6.8,  2.8,  4.8,  1.4],[6.0,  3.4,  4.5,  1.6]]}' -H "Cookie: authservice_session=MTYwODMyODk5M3xOd3dBTkVzeU5VSlJRazlQVnpWT1dGUldWa0ZXVDBRMVFsY3pVVFZHVVVGV01rWkRORmd6VmxCVVNsQkVSa2xaUlZVMFRUVldVMEU9fJBHfRCAvs6nSh_J04VlBEq_yqhkUvc5Z1Mqahe9klOd"
+curl -v https://sklearn-iris-kserve-test.kf-dev-442dbba0442be6c8c50f31ed96b00532-0001.sjc03.containers.appdomain.cloud/v1/models/sklearn-iris:predict -d '{"instances": [[6.8,  2.8,  4.8,  1.4],[6.0,  3.4,  4.5,  1.6]]}' -H "Cookie: authservice_session=MTYwODMyODk5M3xOd3dBTkVzeU5VSlJRazlQVnpWT1dGUldWa0ZXVDBRMVFsY3pVVFZHVVVGV01rWkRORmd6VmxCVVNsQkVSa2xaUlZVMFRUVldVMEU9fJBHfRCAvs6nSh_J04VlBEq_yqhkUvc5Z1Mqahe9klOd"
 ```

--- a/content/en/docs/distributions/ibm/deploy/iks-compatibility.md
+++ b/content/en/docs/distributions/ibm/deploy/iks-compatibility.md
@@ -6,21 +6,17 @@ weight = 6
 
 ## Compatibility
 
-The following table relates compatibility between Kubernetes versions 1.19+ of IBM Cloud Kubernetes service and Kubeflow version 1.4.
+The following table relates compatibility between Kubernetes versions 1.20+ of IBM Cloud Kubernetes service and Kubeflow version 1.5.
 
 <div class="table-responsive">
   <table class="table table-bordered">
     <thead class="thead-light">
       <tr>
         <th>IBM Cloud Kubernetes Versions</th>
-        <th>Kubeflow 1.4.0</th>
+        <th>Kubeflow 1.5.0</th>
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>1.19</td>
-        <td><b>Compatible</b></td>
-      </tr>
       <tr>
         <td>1.20</td>
         <td><b>Compatible</b></td>
@@ -31,7 +27,7 @@ The following table relates compatibility between Kubernetes versions 1.19+ of I
       </tr>
       <tr>
         <td>1.22</td>
-        <td><b>Incompatible</b> see <a href="https://github.com/istio/istio/issues/34665">istio/istio#34665</a></td>
+        <td><b>Incompatible</b></td>
       </tr>
     </tbody>
   </table>

--- a/content/en/docs/distributions/ibm/deploy/install-kubeflow-on-iks.md
+++ b/content/en/docs/distributions/ibm/deploy/install-kubeflow-on-iks.md
@@ -97,13 +97,13 @@ Using kustomize together with kubectl to deploy kubeflow:
 1. Clone the manifest repo as follows:
 
    ```shell
-   git clone https://github.com/IBM/manifests.git -b v1.4.0 ibm-manifests-140
+   git clone https://github.com/IBM/manifests.git -b v1.5-branch ibm-manifests-150
    ```
 
-2. Change directory to `ibm-manifests-140`:
+2. Change directory to `ibm-manifests-150`:
 
    ```shell
-   cd ibm-manifests-140
+   cd ibm-manifests-150
    ```
 
 3. Generate password for default user: `user@example.com`
@@ -181,13 +181,13 @@ You can also learn [how to use App ID](https://cloud.ibm.com/docs/appid?topic=ap
 1. Clone the manifest repo as follows:
 
    ```shell
-   git clone https://github.com/IBM/manifests.git -b v1.4.0 ibm-manifests-140
+   git clone https://github.com/IBM/manifests.git -b v1.5-branch ibm-manifests-150
    ```
 
-2. Change directory to `ibm-manifests-140`:
+2. Change directory to `ibm-manifests-150`:
 
    ```shell
-   cd ibm-manifests-140
+   cd ibm-manifests-150
    ```
 
 3. Update the `dist/stacks/ibm/application/oidc-authservice-appid/params.env`
@@ -226,13 +226,13 @@ You can also learn [how to use App ID](https://cloud.ibm.com/docs/appid?topic=ap
 6. If at any point the values change and you have to change them, you can either patch the
    [configmap](#patch-configmap) and [secret](#patch-secret) or change the content in the
    files and apply the kustomize again. You will need to restart authservice with
-   `kubectl delete pod -l app-authservice -n istio-system` .
+   `kubectl delete pod -l app=authservice -n istio-system` .
 
    To apply just the `oidc-authservice-appid` you can use this command:
 
    ```bash
    kustomize build dist/stacks/ibm/application/oidc-authservice-appid | kubectl apply -f -
-   kubectl delete pod -l app-authservice -n istio-system
+   kubectl delete pod -l app=authservice -n istio-system
    ```
 
 ### Verify mutli-user installation

--- a/content/en/docs/distributions/ibm/deploy/uninstall-kubeflow.md
+++ b/content/en/docs/distributions/ibm/deploy/uninstall-kubeflow.md
@@ -10,7 +10,7 @@ Uninstall Kubeflow on your IBM Cloud IKS cluster.
 1. Go to your Kubeflow deployment directory where you download the
    IBM manifests repository: https://github.com/IBM/manifests.git
    ```shell
-   cd ibm-manifests-140
+   cd ibm-manifests-150
    ```
 
 2. Run the following command to get Kubeflow Profiles:


### PR DESCRIPTION
Update the instructions to point to the manifests repo
which is used to deploy kubeflow v1.5 on IBM IKS cluster

Signed-off-by: Yihong Wang <yh.wang@ibm.com>