### PR TITLE
charmed kubeflow: updates command for creating controller

### DIFF
--- a/content/en/docs/distributions/charmed/install-kubeflow.md
+++ b/content/en/docs/distributions/charmed/install-kubeflow.md
@@ -43,7 +43,7 @@ For more details, go to the [official Juju documentation](https://juju.is/docs/c
 To operate workloads on your Kubernetes cluster, Juju uses controllers. You can create a controller with the  `bootstrap`  command:
 
 ```bash
-juju bootstrap myk8s my-controller
+juju bootstrap myk8s my-controller --agent-version="2.9.22"
 ```
 
 This command will create a couple of pods under the `my-controller` namespace. You can see your controllers with the `juju controllers` command.


### PR DESCRIPTION
This PR updates the command for creating a controller. It is necessary to specify the agent version as newer ones are not supported. This is an important step that shouldn't be missed as some critical issues could be raised.
