### PR TITLE
Fix broken localcluster-deployment page hyperlink

### DIFF
--- a/content/en/docs/components/pipelines/installation/localcluster-deployment.md
+++ b/content/en/docs/components/pipelines/installation/localcluster-deployment.md
@@ -307,7 +307,7 @@ curl -sfL https://get.k3ai.in | bash -s -- --gpu --plugin_kfpipelines
 ```
 
 For more information about K3ai, refer to the
-[official documentation](https://docs.k3ai.in).
+[official documentation](https://k3ai.github.io/docs/intro).
 
 ## Deploying Kubeflow Pipelines
 


### PR DESCRIPTION
This PR fixes hyperlinks that is broken as a result of [this](https://github.com/kubeflow/website/issues/3180) deprecation commit in kubeflow/pipelines. #3180 