### PR TITLE
updated path to component-sdk-v2.yaml

### DIFF
--- a/content/en/docs/components/pipelines/sdk-v2/build-pipeline.ipynb
+++ b/content/en/docs/components/pipelines/sdk-v2/build-pipeline.ipynb
@@ -466,7 +466,7 @@
    "outputs": [],
    "source": [
     "web_downloader_op = kfp.components.load_component_from_url(\n",
-    "    'https://raw.githubusercontent.com/kubeflow/pipelines/master/components/web/Download/component-sdk-v2.yaml')"
+    "    'https://raw.githubusercontent.com/kubeflow/pipelines/master/components/contrib/web/Download/component-sdk-v2.yaml')"
    ]
   },
   {


### PR DESCRIPTION
in the line 
web_downloader_op = kfp.components.load_component_from_url(
    'https://raw.githubusercontent.com/kubeflow/pipelines/master/components/contrib/web/Download/component-sdk-v2.yaml')

the yaml link has changed from "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/web/Download/component-sdk-v2.yaml" to  the correct link "https://raw.githubusercontent.com/kubeflow/pipelines/master/components/contrib/web/Download/component-sdk-v2.yaml"