### PR TITLE
slack: Update slack invite link. Fix #3226

### DIFF
--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -7,7 +7,7 @@ aliases = ["/docs/community/"]
 
 ## Slack
 
-Join the official Kubeflow Slack with [this invite link](https://join.slack.com/t/kubeflow/shared_invite/zt-15p4qkx7a-gy2kDrQS52Y44HoSssxpcw).
+Join the official Kubeflow Slack with [this invite link](https://join.slack.com/t/kubeflow/shared_invite/zt-17rs5ttas-bhCYiDwi1e25yGok_HZN2A).
 
 {{% alert title="Tip" color="info" %}}
 If the above invite has expired, please [raise an issue on the `kubeflow/website` repo](https://github.com/kubeflow/website/issues/new).


### PR DESCRIPTION
Last invite was expired after 30 days.

cc @james-jwu 