### PR TITLE
Kubeflow on AWS - Generalized documentation (Master)

### DIFF
--- a/content/en/docs/components/pipelines/sdk/connect-api.md
+++ b/content/en/docs/components/pipelines/sdk/connect-api.md
@@ -23,7 +23,7 @@ Kubeflow distributions secure the Kubeflow Pipelines public endpoint with authen
 Since Kubeflow distributions can have different authentication and authorization requirements, the steps needed to connect to your Kubeflow Pipelines instance might be different depending on the Kubeflow distribution you installed. Refer to documentation for [your Kubeflow distribution](/docs/started/installing-kubeflow/):
 
 * [Connecting to Kubeflow Pipelines on Google Cloud using the SDK](/docs/distributions/gke/pipelines/authentication-sdk/)
-* [Kubeflow Pipelines on AWS](https://www.kubeflow.org/docs/distributions/aws/component-guides/pipeline/)
+* [Kubeflow Pipelines on AWS](https://awslabs.github.io/kubeflow-manifests/docs/component-guides/pipelines/)
 * [Authentication using OIDC in Azure](/docs/distributions/azure/authentication-oidc/)
 * [Pipelines on IBM Cloud Kubernetes Service (IKS)](/docs/distributions/ibm/pipelines/)
 

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -39,9 +39,9 @@ Packaged distributions are developed and supported by their respective maintaine
         <td>Kubeflow on AWS</td>
         <td>Amazon Web Services (AWS)</td>
         <td>Amazon Elastic Kubernetes Service (EKS)</td>
-        <td>1.3</td>
+        <td>1.4</td>
         <td><a href="/docs/distributions/aws/">Docs</a></td>
-        <td></td>
+        <td><a href="https://awslabs.github.io/kubeflow-manifests/">External Website</a></td>
       </tr>
       <tr>
         <td>Kubeflow on Azure</td>


### PR DESCRIPTION
Removed AWS distribution-owned docs from Kubeflow website (master branch). Issue  #3074. 