### PR TITLE
Fix: fix broken images by using consistent path. Fixes #3250

### DIFF
--- a/content/en/docs/external-add-ons/elyra/_index.md
+++ b/content/en/docs/external-add-ons/elyra/_index.md
@@ -12,7 +12,7 @@ that can be executed in a Kubeflow environment.
 Below is an example of a Piepline created with Elyra, you can identify the components/tasks
 and related properties that are all managed in the visual editor.
 
-<img src="./elyra-pipeline-covid-scenario.png" alt="A pipeline example created using Elyra Pipeline Visual Editor" class="mt-3 mb-3 p-3 border border-info rounded" />
+<img src="/docs/external-add-ons/elyra/elyra-pipeline-covid-scenario.png" alt="A pipeline example created using Elyra Pipeline Visual Editor" class="mt-3 mb-3 p-3 border border-info rounded" />
 
 To learn more about Elyra, visit <a href="https://github.com/elyra-ai/elyra" target="_blank">Elyra GitHub project</a>
 

--- a/content/en/docs/external-add-ons/kserve/kserve.md
+++ b/content/en/docs/external-add-ons/kserve/kserve.md
@@ -7,7 +7,7 @@ weight = 2
 
 
 
-<img src="../pics/kserve.png" alt="KServe" width="640px">
+<img src="/docs/external-add-ons/kserve/pics/kserve.png" alt="KServe" width="640px">
 
  
 KServe enables serverless inferencing on Kubernetes and provides performant, high abstraction interfaces for common machine learning (ML) frameworks like TensorFlow, XGBoost, scikit-learn, PyTorch, and ONNX to solve production model serving use cases.

--- a/content/en/docs/external-add-ons/kserve/webapp.md
+++ b/content/en/docs/external-add-ons/kserve/webapp.md
@@ -119,7 +119,7 @@ The main page of the app provides a list of all the InferenceServices that are
 deployed in the selected Namespace. The frontend periodically polls the backend
 for the latest state of InferenceServices.
 
-<img src="./pics/webapp-list.png" alt="Models web app main page">
+<img src="/docs/external-add-ons/kserve/pics/webapp-list.png" alt="Models web app main page">
 
 ### Creating
 
@@ -130,7 +130,7 @@ Note that the backend will override the provided `.metadata.namespace` field of
 the submitted object, to prevent users from trying to create InferenceServices
 in other namespaces.
 
-<img src="./pics/webapp-new.png" alt="Models web app create page">
+<img src="/docs/external-add-ons/kserve/pics/webapp-new.png" alt="Models web app create page">
 
 ### Deleting
 
@@ -157,7 +157,7 @@ view a more detailed summary of the CR's state. In this page users can inspect:
 4. Logs from the created Pods (LOGS)
 4. The YAML file as is in the K8s API Server (YAML)
 
-<img src="./pics/webapp-overview.png" alt="Models web app overview page">
+<img src="/docs/external-add-ons/kserve/pics/webapp-overview.png" alt="Models web app overview page">
 
 {{% alert title="Note" color="info" %}}
 To gather the logs the backend will:
@@ -256,7 +256,7 @@ After applying these YAMLs, based on your installation mode, and ensuring the
 Grafana instance is exposed under `/grafana` the web app will show the
 `METRICS` tab.
 
-<img src="./pics/webapp-metrics.png" alt="Models web app metrics page">
+<img src="/docs/external-add-ons/kserve/pics/webapp-metrics.png" alt="Models web app metrics page">
 
 ## Configurations
 


### PR DESCRIPTION
Fix broken image link on webpage due to a relative path used.