### PR TITLE
fix broken link for kfp-tekton

### DIFF
--- a/content/en/docs/components/pipelines/v1/sdk/pipelines-with-tekton.md
+++ b/content/en/docs/components/pipelines/v1/sdk/pipelines-with-tekton.md
@@ -6,8 +6,8 @@ weight = 140
 +++
 
 You can use the [KFP-Tekton SDK](https://github.com/kubeflow/kfp-tekton/tree/master/sdk)
-to compile, upload and run your Kubeflow Pipeline DSL Python scripts on a
-[Kubeflow Pipelines with Tekton backend](https://github.com/kubeflow/kfp-tekton/tree/master/tekton_kfp_guide.md).
+to compile, upload and run your Kubeflow Pipeline DSL Python scripts on a 
+[Kubeflow Pipelines with Tekton backend](https://github.com/kubeflow/kfp-tekton/tree/master/guides/kfp-user-guide).
 
 ## SDK packages
 


### PR DESCRIPTION
update the broken link to current kfp-tekton user guide.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>