### PR TITLE
fix slack invite link

### DIFF
--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -7,10 +7,10 @@ aliases = ["/docs/community/"]
 
 ## Slack
 
-Join the official Kubeflow Slack with [this invite link](https://join.slack.com/t/kubeflow/shared_invite/zt-17rs5ttas-bhCYiDwi1e25yGok_HZN2A).
+[Join the official Kubeflow Slack!](https://invite.playplay.io/invite?team_id=T7QLHSH6U)
 
 {{% alert title="Tip" color="info" %}}
-If the above invite has expired, please [raise an issue on the `kubeflow/website` repo](https://github.com/kubeflow/website/issues/new).
+If the above link is not working, please [raise an issue on the `kubeflow/website` repo](https://github.com/kubeflow/website/issues/new).
 {{% /alert %}}
 
 The Kubeflow Slack workspace has many channels, here are a few examples:


### PR DESCRIPTION
Resolves https://github.com/kubeflow/website/issues/3252

This PR updates the slack invite link to use the https://invite.playplay.io/ invite bot.
This should remove the need to update the link in the future, as the following link will not expire:
- https://invite.playplay.io/invite?team_id=T7QLHSH6U