### PR TITLE
Update definition of maxFailedTrialCount

### DIFF
--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -115,10 +115,10 @@ These are the fields in the experiment configuration spec:
   experiment will be running until the objective goal is reached or the experiment
   reaches a maximum number of failed trials.
 
-- **maxFailedTrialCount**: The maximum number of failed trials before Katib
-  should stop the experiment. This is equivalent to the number of failed
-  hyperparameter sets that Katib should test.
-  If the number of failed trials exceeds `maxFailedTrialCount`, Katib stops the
+- **maxFailedTrialCount**: The maximum number of trials allowed to fail.
+  This is equivalent to the number of failed hyperparameter sets that Katib should test.
+  Katib recognizes trials with a status of `Failed` or `MetricsUnavailable` as `Failed` trials,
+  and if the number of failed trials reaches `maxFailedTrialCount`, Katib stops the
   experiment with a status of `Failed`.
 
 - **algorithm**: The search algorithm that you want Katib to use to find the


### PR DESCRIPTION
I updated the definition of `maxTrialCount` and added explain about the `Failed` status in the Experiment.

Ref: https://github.com/kubeflow/katib/pull/1877

/cc @johnugeorge @andreyvelich @gaocegege 
