### PR TITLE
404 page not found - link fix

### DIFF
--- a/content/en/docs/distributions/gke/deploy/overview.md
+++ b/content/en/docs/distributions/gke/deploy/overview.md
@@ -49,4 +49,4 @@ Once you finish deployment, you will be able to:
 ## Next steps
 
 - Repeat [Deploy Kubeflow Cluster](/docs/distributions/gke/deploy/deploy-cli/) if you want to deploy multiple clusters.
-- Run a full ML workflow on Kubeflow, using the [end-to-end MNIST tutorial](/docs/distributions/ibm/iks-e2e/#run-the-mnist-tutorial-on-iks).
+- Run a full ML workflow on Kubeflow, using the [end-to-end MNIST tutorial](https://github.com/kubeflow/pipelines/blob/e42d9d2609369b96973c821dca11fe5b2565e705/samples/contrib/kubeflow-e2e-mnist/kubeflow-e2e-mnist.ipynb).

--- a/content/en/docs/distributions/gke/deploy/overview.md
+++ b/content/en/docs/distributions/gke/deploy/overview.md
@@ -4,7 +4,7 @@ description = "Full fledged Kubeflow deployment on Google Cloud"
 weight = 1
 +++
 
-This guide describes how to deploy Kubeflow and a series of Kubeflow components on GKE (Google Kubernetes Engine). 
+This guide describes how to deploy Kubeflow and a series of Kubeflow components on GKE (Google Kubernetes Engine).
 If you want to use Kubeflow Pipelines only, refer to [Installation Options for Kubeflow Pipelines](/docs/components/pipelines/installation/overview/)
 for choosing an installation option.
 
@@ -12,10 +12,9 @@ for choosing an installation option.
 
 As a high level overview, you need to create one Management cluster which allows you to manage Google Cloud resources via [Config Connector](https://cloud.google.com/config-connector/docs/overview). Management cluster can create, manage and delete multiple Kubeflow clusters, while being independent from Kubeflow clusters' activities. Below is a simplified view of deployment structure. Note that Management cluster can live in a different Google Cloud project from Kubeflow clusters, admin should assign owner permission to Management cluster's service account. It will be explained in detail during Deployment steps.
 
-  <img src="/docs/images/gke/full-deployment-structure.png" 
+<img src="/docs/images/gke/full-deployment-structure.png" 
     alt="Full Kubeflow deployment structure"
     class="mt-3 mb-3 border border-info rounded">
-
 
 ## Deployment steps
 
@@ -27,7 +26,7 @@ Follow the steps below to set up Kubeflow environment on Google Cloud. Some of t
 1.  [Deploy Kubeflow Cluster](/docs/distributions/gke/deploy/deploy-cli/).
 
 If you encounter any issue during the deployment steps, refer to [Troubleshooting deployments on GKE](/docs/distributions/gke/troubleshooting-gke/) to find common issues
-and debugging approaches. If this issue is new, file a bug to [kubeflow/gcp-blueprints](https://github.com/kubeflow/gcp-blueprints) for GKE related issue, or file a bug to the corresponding component in [Kubeflow on GitHub](https://github.com/kubeflow/) if the issue is component specific. 
+and debugging approaches. If this issue is new, file a bug to [kubeflow/gcp-blueprints](https://github.com/kubeflow/gcp-blueprints) for GKE related issue, or file a bug to the corresponding component in [Kubeflow on GitHub](https://github.com/kubeflow/) if the issue is component specific.
 
 ## Features
 
@@ -37,17 +36,17 @@ Once you finish deployment, you will be able to:
 1. get a [Cloud Endpoint](https://cloud.google.com/endpoints/docs) which is accessible via [IAP (Identity-aware Proxy)](https://cloud.google.com/iap).
 1. enable [Multi-user feature](/docs/components/multi-tenancy/) for resource and access isolation.
 1. take advantage of GKE's
-  [Cluster Autoscaler](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler) 
-  to automatically resize the number of nodes in a node pool.
+   [Cluster Autoscaler](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler)
+   to automatically resize the number of nodes in a node pool.
 1. choose GPUs and [Cloud TPU](https://cloud.google.com/tpu/) to accelerate your workload.
 1. use [Cloud Logging](https://cloud.google.com/logging/docs/) to help debugging and troubleshooting.
 1. access to many managed services offered by Google Cloud.
 
-  <img src="/docs/images/gke/full-kf-home.png" 
+<img src="/docs/images/gke/full-kf-home.png" 
     alt="Full Kubeflow Central Dashboard"
     class="mt-3 mb-3 border border-info rounded">
 
 ## Next steps
 
-* Repeat [Deploy Kubeflow Cluster](/docs/distributions/gke/deploy/deploy-cli/) if you want to deploy multiple clusters.
-* Run a full ML workflow on Kubeflow, using the [end-to-end MNIST tutorial](/docs/distributions/gke/gcp-e2e/).
+- Repeat [Deploy Kubeflow Cluster](/docs/distributions/gke/deploy/deploy-cli/) if you want to deploy multiple clusters.
+- Run a full ML workflow on Kubeflow, using the [end-to-end MNIST tutorial](/docs/distributions/ibm/iks-e2e/#run-the-mnist-tutorial-on-iks).


### PR DESCRIPTION
link took users to a 404 page
At the bottom of the [KubeFlow Overview](https://www.kubeflow.org/docs/distributions/gke/deploy/overview/) page, under "Next Steps," there is a hyperlink titled: [end-to-end-MNIST tutorial](https://www.kubeflow.org/docs/distributions/ibm/iks-e2e/#run-the-mnist-tutorial-on-iks). Updated with the correct link
![Screen Shot 2022-07-01 at 11 16 27 PM](https://user-images.githubusercontent.com/76856697/176985202-b3c3efcf-7c39-4007-89ae-6741ffd9e0d3.png)
 