### PR TITLE
Update link to Next Step in Pipeline Metrics page

### DIFF
--- a/content/en/docs/components/pipelines/sdk/pipelines-metrics.md
+++ b/content/en/docs/components/pipelines/sdk/pipelines-metrics.md
@@ -140,4 +140,4 @@ The following example shows the **accuracy-score** and
 ## Next step
 
 Visualize the output of your component by [writing out metadata for an output 
-viewer](/docs/components/pipelines/metrics/output-viewer/).
+viewer](/docs/components/pipelines/sdk/output-viewer/).


### PR DESCRIPTION
I noticed that the next steps link in https://www.kubeflow.org/docs/components/pipelines/sdk/pipelines-metrics/ was broken , this PR fixes it.

Also,  closes: #3225