### PR TITLE
update release info

### DIFF
--- a/content/en/docs/releases/kubeflow-0.6.md
+++ b/content/en/docs/releases/kubeflow-0.6.md
@@ -16,9 +16,16 @@ weight = 106
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        N/A
+        <b>Blog:</b> 
+          <a href="https://medium.com/kubeflow/kubeflow-v0-6-a-robust-foundation-for-artifact-tracking-data-versioning-multi-user-support-9896d329412c">Kubeflow 0.6 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=fiFk5FB7il8">Kubeflow 0.6 Release Feature Review</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-06">Kubeflow 0.6 Features</a>
       </td>
     </tr>
     <tr>
@@ -49,15 +56,20 @@ weight = 106
     <tr>
       <th class="table-light">Release Date</th>
       <td>
-        2019-07-19 (<a href="https://medium.com/kubeflow/kubeflow-v0-6-a-robust-foundation-for-artifact-tracking-data-versioning-multi-user-support-9896d329412c">Blog</a>)
+        2019-07-19
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-06">
-          ROADMAP.md#kubeflow-06
-        </a>
+        <b>Blog:</b> 
+          <a href="https://medium.com/kubeflow/kubeflow-v0-6-a-robust-foundation-for-artifact-tracking-data-versioning-multi-user-support-9896d329412c">Kubeflow 0.6 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=fiFk5FB7il8">Kubeflow 0.6 Release Feature Review</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-06">Kubeflow 0.6 Features</a>
       </td>
     </tr>
     <tr>

--- a/content/en/docs/releases/kubeflow-0.7.md
+++ b/content/en/docs/releases/kubeflow-0.7.md
@@ -16,11 +16,13 @@ weight = 105
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-07">
-          ROADMAP.md#kubeflow-07
-        </a>
+        <b>Blog:</b> 
+          <a href="https://medium.com/kubeflow/kubeflow-v0-7-delivers-beta-functionality-in-the-leadup-to-v1-0-1e63036c07b8">Kubeflow 0.7 Release Announcement</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-07">Kubeflow 0.7 Features</a>
       </td>
     </tr>
     <tr>

--- a/content/en/docs/releases/kubeflow-1.0.md
+++ b/content/en/docs/releases/kubeflow-1.0.md
@@ -16,9 +16,16 @@ weight = 104
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        N/A
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/releases/2020/03/02/kubeflow-1-0-cloud-native-ml-for-everyone.html">Kubeflow 1.0 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=L6wG_mpRWe8">Kubeflow 1.0 Release Community Webinar</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-10">Kubeflow 1.0 Features</a>
       </td>
     </tr>
     <tr>
@@ -53,9 +60,16 @@ weight = 104
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        N/A
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/releases/2020/03/02/kubeflow-1-0-cloud-native-ml-for-everyone.html">Kubeflow 1.0 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=L6wG_mpRWe8">Kubeflow 1.0 Release Community Webinar</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-10">Kubeflow 1.0 Features</a>
       </td>
     </tr>
     <tr>
@@ -86,15 +100,20 @@ weight = 104
     <tr>
       <th class="table-light">Release Date</th>
       <td>
-        2020-02-20 (<a href="https://blog.kubeflow.org/releases/2020/03/02/kubeflow-1-0-cloud-native-ml-for-everyone.html">Blog</a>)
+        2020-02-20
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-10">
-          ROADMAP.md#kubeflow-10
-        </a>
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/releases/2020/03/02/kubeflow-1-0-cloud-native-ml-for-everyone.html">Kubeflow 1.0 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=L6wG_mpRWe8">Kubeflow 1.0 Release Community Webinar</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-10">Kubeflow 1.0 Features</a>
       </td>
     </tr>
     <tr>

--- a/content/en/docs/releases/kubeflow-1.1.md
+++ b/content/en/docs/releases/kubeflow-1.1.md
@@ -12,15 +12,20 @@ weight = 103
     <tr>
       <th class="table-light">Release Date</th>
       <td>
-        2020-07-31 (<a href="https://blog.kubeflow.org/release/official/2020/07/31/kubeflow-1.1-blog-post.html">Blog</a>)
+        2020-07-31
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-11-features-release-date-late-june-2020">
-          ROADMAP.md#kubeflow-11-features-release-date-late-june-2020
-        </a>
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/release/official/2020/07/31/kubeflow-1.1-blog-post.html">Kubeflow 1.1 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=kd-mWl1cq48">Kubeflow 1.1 Community Release Update</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-11-features-release-date-late-june-2020">Kubeflow 1.1 Features</a>
       </td>
     </tr>
     <tr>

--- a/content/en/docs/releases/kubeflow-1.2.md
+++ b/content/en/docs/releases/kubeflow-1.2.md
@@ -12,15 +12,17 @@ weight = 102
     <tr>
       <th class="table-light">Release Date</th>
       <td>
-        2020-11-18 (<a href="https://blog.kubeflow.org/release/official/2020/11/18/kubeflow-1.2-blog-post.html">Blog</a>)
+        2020-11-18
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-12-features-release-date-november-2020">
-          ROADMAP.md#kubeflow-12-features-release-date-november-2020
-        </a>
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/release/official/2020/11/18/kubeflow-1.2-blog-post.html">Kubeflow 1.2 Release Announcement</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-12-features-release-date-november-2020">Kubeflow 1.2 Features</a>
       </td>
     </tr>
     <tr>

--- a/content/en/docs/releases/kubeflow-1.3.md
+++ b/content/en/docs/releases/kubeflow-1.3.md
@@ -16,9 +16,16 @@ weight = 101
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        N/A
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/kubeflow-1.3-release/">Kubeflow 1.3 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=RjN55bQ4kh4">Kubeflow 1.3 Release Overview</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-13-features-released-april-2021">Kubeflow 1.3 Features</a>
       </td>
     </tr>
     <tr>
@@ -194,15 +201,20 @@ weight = 101
     <tr>
       <th class="table-light">Release Date</th>
       <td>
-        2021-04-23 (<a href="https://blog.kubeflow.org/kubeflow-1.3-release/">Blog</a>)
+        2021-04-23
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-13-features-released-april-2021">
-          ROADMAP.md#kubeflow-13-features-released-april-2021
-        </a>
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/kubeflow-1.3-release/">Kubeflow 1.3 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=RjN55bQ4kh4">Kubeflow 1.3 Release Overview</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-13-features-released-april-2021">Kubeflow 1.3 Features</a>
       </td>
     </tr>
     <tr>

--- a/content/en/docs/releases/kubeflow-1.4.md
+++ b/content/en/docs/releases/kubeflow-1.4.md
@@ -16,9 +16,16 @@ weight = 100
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        N/A
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/kubeflow-1.4-release/">Kubeflow 1.4 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=gG61gHw4J14">Kubeflow 1.4 Release Overview</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-141-release-delivered-december-2021">Kubeflow 1.4.1 Features</a>
       </td>
     </tr>
     <tr>
@@ -182,15 +189,20 @@ weight = 100
     <tr>
       <th class="table-light">Release Date</th>
       <td>
-        2021-10-12 (<a href="https://blog.kubeflow.org/kubeflow-1.4-release/">Blog</a>)
+        2021-10-12
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-14-release-due-september-2021">
-          ROADMAP.md#kubeflow-14-release-due-september-2021
-        </a>
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/kubeflow-1.4-release/">Kubeflow 1.4 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=gG61gHw4J14">Kubeflow 1.4 Release Overview</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-14-release-delivered-october-2021">Kubeflow 1.4 Features</a>
       </td>
     </tr>
     <tr>

--- a/content/en/docs/releases/kubeflow-1.5.md
+++ b/content/en/docs/releases/kubeflow-1.5.md
@@ -4,6 +4,189 @@ description = "Information about the Kubeflow 1.5 release"
 weight = 99
 +++
 
+## 1.5.1
+
+<div class="table-responsive">
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <th class="table-light">Release Date</th>
+      <td>
+        2022-06-15
+      </td>
+    </tr>
+    <tr>
+      <th class="table-light">Media</th>
+      <td>
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/kubeflow-1.5-release/">Kubeflow 1.5 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=QNNCM9Kq3Q0">Kubeflow 1.5 Release Overview</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-15-release-delivered-march-2022">Kubeflow 1.5 Features</a>
+      </td>
+    </tr>
+    <tr>
+      <th class="table-light">Manifests</th>
+      <td>
+        <b>Release:</b> 
+          <a href="https://github.com/kubeflow/manifests/releases/tag/v1.5.1">v1.5.1</a>
+        <br>
+        <b>Branch:</b>
+          <a href="https://github.com/kubeflow/manifests/tree/v1.5-branch">v1.5-branch</a>
+      </td>
+    </tr>
+    <tr>
+      <th class="table-light">Release Team</th>
+      <td>
+        <b>Lead:</b> Kimonas Sotirchos (<a href="https://github.com/kimwnasptd">@kimwnasptd</a>)
+        <br>
+        <b>Member:</b> Anna Jung (<a href="https://github.com/annajung">@annajung</a>)
+        <br>
+        <b>Member:</b> Daniela Plascencia (<a href="https://github.com/DnPlas">@DnPlas</a>)
+        <br>
+        <b>Member:</b> Dominik Fleischmann (<a href="https://github.com/DomFleischmann">@DomFleischmann</a>)
+        <br>
+        <b>Member:</b> Kylie Travis (<a href="https://github.com/Bhakti087">@Bhakti087</a>)
+        <br>
+        <b>Member:</b> Mathew Wicks (<a href="https://github.com/thesuperzapper">@thesuperzapper</a>)
+        <br>
+        <b>Member:</b> Suraj Kota (<a href="https://github.com/surajkota">@surajkota</a>)
+        <br>
+        <b>Member:</b> Vedant Padwal (<a href="https://github.com/js-ts">@js-ts</a>)
+        <br>
+        <b>Product Manager:</b> Josh Bottum (<a href="https://github.com/jbottum">@jbottum</a>)
+        <br>
+        <b>Docs Lead:</b> Shannon Bradshaw (<a href="https://github.com/shannonbradshaw">@shannonbradshaw</a>)
+      </td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+<br>
+<b>Versions of components in 1.5.1:</b>
+
+<div class="table-responsive">
+<table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Maintainers</th>
+        <th>Component Name</th>
+        <th>Version</th>
+      </tr>
+    </thead>
+  <tbody>
+      <!-- ======================= -->
+      <!-- AutoML Working Group -->
+      <!-- ======================= -->
+      <tr>
+        <td rowspan="1" class="align-middle">AutoML Working Group</td>
+        <td>Katib</td>
+        <td>
+          <a href="https://github.com/kubeflow/katib/releases/tag/v0.13.0">v0.13.0</a>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Notebooks Working Group -->
+      <!-- ======================= -->
+      <tr>
+        <td rowspan="9" class="align-middle">Notebooks Working Group</td>
+        <td>Admission Webhook (PodDefaults)</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/admission-webhook">v1.5.0</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Central Dashboard</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/centraldashboard">v1.5.0</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Jupyter Web App</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/jupyter">v1.5.0</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Kubeflow Access Management API</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/access-management">v1.5.0</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Notebook Controller</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/notebook-controller">v1.5.0</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Profile Controller</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/profile-controller">v1.5.0</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Tensorboard Controller</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/notebook-controller">v1.5.0</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Tensorboard Web App</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/volumes">v1.5.0</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Volumes Web App</td>
+        <td>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/tensorboards">v1.5.0</a>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Pipelines Working Group -->
+      <!-- ======================= -->
+      <tr>
+        <td rowspan="2" class="align-middle">Pipelines Working Group</td>
+        <td>Kubeflow Pipelines</td>
+        <td>
+          <a href="https://github.com/kubeflow/pipelines/releases/tag/1.8.2">v1.8.2</a>
+        </td>
+      </tr>
+      <tr>
+        <td>Kubeflow Pipelines Tekton</td>
+        <td>
+          <a href="https://github.com/kubeflow/kfp-tekton/releases/tag/v1.1.1">v1.1.1</a>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Serving Working Group -->
+      <!-- ======================= -->
+      <tr>
+        <td rowspan="1" class="align-middle">Serving Working Group</td>
+        <td>KServe</td>
+        <td>
+          <a href="https://github.com/kserve/kserve/releases/tag/v0.7.0">v0.7.0</a>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Training Working Group -->
+      <!-- ======================= -->
+      <tr>
+        <td rowspan="1" class="align-middle">Training Working Group</td>
+        <td>Training Operator</td>
+        <td>
+          <a href="https://github.com/kubeflow/training-operator/releases/tag/v1.4.0">v1.4.0</a>
+        </td>
+      </tr>
+  </tbody>
+</table>
+</div>
+
 ## 1.5.0
 
 <div class="table-responsive">
@@ -16,9 +199,16 @@ weight = 99
       </td>
     </tr>
     <tr>
-      <th class="table-light">Roadmap</th>
+      <th class="table-light">Media</th>
       <td>
-        N/A
+        <b>Blog:</b> 
+          <a href="https://blog.kubeflow.org/kubeflow-1.5-release/">Kubeflow 1.5 Release Announcement</a>
+        <br>
+        <b>Video:</b> 
+          <a href="https://www.youtube.com/watch?v=QNNCM9Kq3Q0">Kubeflow 1.5 Release Overview</a>
+        <br>
+        <b>Roadmap:</b>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-15-release-delivered-march-2022">Kubeflow 1.5 Features</a>
       </td>
     </tr>
     <tr>
@@ -170,13 +360,7 @@ weight = 99
       <!-- Training Working Group -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="2" class="align-middle">Training Working Group</td>
-        <td>MPI Operator</td>
-        <td>
-          <a href="https://github.com/kubeflow/mpi-operator/releases/tag/v1.4.0">v1.4.0</a>
-        </td>
-      </tr>
-      <tr>
+        <td rowspan="1" class="align-middle">Training Working Group</td>
         <td>Training Operator</td>
         <td>
           <a href="https://github.com/kubeflow/training-operator/releases/tag/v1.4.0">v1.4.0</a>
@@ -185,4 +369,3 @@ weight = 99
   </tbody>
 </table>
 </div>
-


### PR DESCRIPTION
### This PR does the following:

- Adds release info for Kubeflow 1.5.1 (replaces PR https://github.com/kubeflow/website/pull/3298)
- Adds a "media" section to the table which contains links to media about the release, for example:
    - Our official release blogs
    - Our official video overview
    - Our official roadmap _(I also fixed the roadmap links, which were not pointing to the correct headers, because the names had changed)_
- Fixes the 1.5.0 table to not include "mpi-operator" (as this is not part of Kubeflow 1.5)

### Screenshot of new "media" row:

![Screen Shot 2022-08-04 at 10 56 09](https://user-images.githubusercontent.com/5735406/182740288-a0a7be82-9f89-4e68-b169-19b7cc706c28.png)

