### PR TITLE
add kfp v2 community and support

### DIFF
--- a/content/en/docs/components/pipelines/community-and-support.md
+++ b/content/en/docs/components/pipelines/community-and-support.md
@@ -1,6 +1,34 @@
 +++
 title = "Community and Support"
 description = "Where to get help, contribute, and learn more"
-weight = 11
-                    
+weight = 11                 
 +++
+
+## Help
+There are several places to get help with KFP:
+
+* [kubeflow-pipelines][kfp-stack-overflow] on Stack Overflow
+* The #kubeflow-pipelines channel in the [Kubeflow Slack Workspace](https://kubeflow.slack.com/)
+* Via a GitHub Issue describing your problem in the [kubeflow/pipelines repository][github-issues]
+* In the [Kubeflow Pipelines Community Meeting](#KFP-Community-Meeting)
+## Kubeflow Pipelines Community Meeting
+There is a Kubeflow Pipelines Community meeting every other Wednesday. This is an opportunity to learn about changes to KFP developments, discuss feature requests, and ask questions. When making a feature request, it is best to include a [GitHub Issue][github-issues] as a written accompaniment to your request.
+
+To participate, join [kubeflow-discuss][kubeflow-discuss-google-group] on Google Groups.
+
+## Bugs and Feature Requests
+Bugs and feature requests should be recorded as GitHub Issues in the [kubeflow/pipelines repository][github-issues].
+
+## Contributing
+KFP is an open source project and welcomes community contribution. KFP has several components, each with its own contributing guidelines:
+
+* [Backend contributing guidelines][backend-contributing-guidelines]
+* [Frontend contributing guidelines][frontend-contributing-guidelines]
+* [SDK contributing guidelines][sdk-contributing-guidelines]
+
+[kfp-stack-overflow]: https://stackoverflow.com/questions/tagged/kubeflow-pipelines
+[github-issues]: https://github.com/kubeflow/pipelines/issues/
+[kubeflow-discuss-google-group]: https://groups.google.com/g/kubeflow-discuss
+[backend-contributing-guidelines]: https://github.com/kubeflow/pipelines/blob/fe66d20b98c84961b96eb8c52f3fdac69e017bce/backend/README.md
+[frontend-contributing-guidelines]: https://github.com/kubeflow/pipelines/blob/fe66d20b98c84961b96eb8c52f3fdac69e017bce/frontend/README.md
+[sdk-contributing-guidelines]: https://github.com/kubeflow/pipelines/blob/fe66d20b98c84961b96eb8c52f3fdac69e017bce/sdk/CONTRIBUTING.md


### PR DESCRIPTION
Some outstanding content, such as cross-section links, to be added once merged into the `pipelines-v2-docs` branch.