### PR TITLE
fix 1.5.1 blog link

### DIFF
--- a/content/en/docs/releases/kubeflow-1.5.md
+++ b/content/en/docs/releases/kubeflow-1.5.md
@@ -19,7 +19,7 @@ weight = 99
       <th class="table-light">Media</th>
       <td>
         <b>Blog:</b> 
-          <a href="https://blog.kubeflow.org/kubeflow-1.5-release/">Kubeflow 1.5 Release Announcement</a>
+          <a href="https://blog.kubeflow.org/kubeflow-1.5.1-release/">Kubeflow 1.5.1 Release Announcement</a>
         <br>
         <b>Video:</b> 
           <a href="https://www.youtube.com/watch?v=QNNCM9Kq3Q0">Kubeflow 1.5 Release Overview</a>


### PR DESCRIPTION
There was a link conflict for the Kubeflow 1.5.1 blog post, after PR https://github.com/kubeflow/blog/pull/122, we now have separate links for the 1.5 and 1.5.1 blog posts.

This PR updates the link to the 1.5.1 blog post in the releases page.