### PR TITLE
Corrected link text in metadata.md

### DIFF
--- a/content/en/docs/components/pipelines/concepts/metadata.md
+++ b/content/en/docs/components/pipelines/concepts/metadata.md
@@ -18,4 +18,4 @@ is called a *Lineage Graph*.
 
 ## Next steps
 
-* Learn about [output Aritfact](/docs/components/pipelines/concepts/output-artifact).
+* Learn about [output Artifact](/docs/components/pipelines/concepts/output-artifact).


### PR DESCRIPTION
Corrected link text from "aritfact" to "artifact" in metadata.md.