### PR TITLE
Update config to v1.6

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -98,12 +98,12 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
   gcs_engine_id = "007239566369470735695:624rglujm-w"
 
   # Text label for the version menu in the top bar of the website.
-  version_menu = "Kubeflow Version"
+  version_menu = "v1.6"
 
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "master"
+  version = "v1.6"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.
@@ -115,7 +115,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 
   # A variable used in various docs to determine URLs for config files etc.
   # To find occurrences, search the repo for 'params "githubbranch"'.
-  githubbranch = "master"
+  githubbranch = "v1.6-branch"
 
   # These entries appear in the drop-down menu at the top of the website.
   [[params.versions]]


### PR DESCRIPTION
As noted in step 3 of the "[Creating and publishing a website branch](https://github.com/kubeflow/kubeflow/blob/master/docs_dev/releasing.md#creating-and-publishing-a-website-branch-for-vxy)", update the `config.toml` to point to v1.6 for the kubeflow/website v1.6-branch

Once this PR is merged, @zijianjoy will need to deploy the new branch to netlify to make it available

cc @kubeflow/release-team @zijianjoy 