### PR TITLE
Add link to release video

### DIFF
--- a/content/en/docs/releases/kubeflow-1.6.md
+++ b/content/en/docs/releases/kubeflow-1.6.md
@@ -22,7 +22,7 @@ weight = 98
           <a href="https://blog.kubeflow.org/kubeflow-1.6-release/">Kubeflow 1.6 Release Announcement</a>
         <br>
         <b>Video:</b> 
-          TBA
+          <a href="https://youtu.be/RR1xSfnFGGI">Kubeflow 1.6 Release Overview</a>
         <br>
         <b>Roadmap:</b>
           <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-16-release-due-september-2022">Kubeflow 1.6 Features</a>

--- a/content/en/docs/releases/kubeflow-1.6.md
+++ b/content/en/docs/releases/kubeflow-1.6.md
@@ -22,10 +22,10 @@ weight = 98
           <a href="https://blog.kubeflow.org/kubeflow-1.6-release/">Kubeflow 1.6 Release Announcement</a>
         <br>
         <b>Video:</b> 
-          <a href="https://youtu.be/RR1xSfnFGGI">Kubeflow 1.6 Release Overview</a>
+          <a href="https://www.youtube.com/watch?v=RR1xSfnFGGI">Kubeflow 1.6 Release Overview</a>
         <br>
         <b>Roadmap:</b>
-          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-16-release-due-september-2022">Kubeflow 1.6 Features</a>
+          <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-16-release-delivered-september-2022">Kubeflow 1.6 Features</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

- Add a link to the 1.6 release video

cc @kubeflow/release-team 

This will need to be cherry-picked to the v1.6-branch as well