### PR TITLE
improve the "installing kubeflow" page

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -9,18 +9,26 @@ Kubeflow is an end-to-end Machine Learning (ML) platform for Kubernetes, it prov
 Operators can choose what is best for their users, there is no requirement to deploy every component.
 To read more about the components and architecture of Kubeflow, please see the <a href="/docs/started/architecture/">Kubeflow Architecture</a> page.
 
+### How to install Kubeflow?
+
 There are two pathways to get up and running with Kubeflow, you may either:
-1. Use a [packaged distribution](#packaged-distributions)
-1. Use the [manifests](#manifests) (advanced)
+
+1. [Use a packaged distribution](#packaged-distributions-of-kubeflow)
+2. [Use the raw manifests](#raw-kubeflow-manifests) <sup>(for advanced users)</sup>
 
 <a id="packaged-distributions"></a>
-## Install a packaged Kubeflow distribution
+<a id="install-a-packaged-kubeflow-distribution"></a>
+## Packaged Distributions of Kubeflow 
 
-{{% alert color="warning" %}}
-Packaged distributions are developed and supported by their respective maintainers, the Kubeflow community does not currently endorse or certify any distribution.
+{{% alert title="Note" color="warning" %}}
+Packaged distributions are developed and supported by their respective maintainers, <b>the Kubeflow community does not endorse or certify any specific distribution</b>.
+
+In the near future, there are plans to introduce <a href="https://github.com/kubeflow/community/blob/master/proposals/kubeflow-conformance-program-proposal.md">conformance testing for distributions</a>, you may track progress on this initiative by following <a href="https://github.com/kubeflow/kubeflow/issues/6485">kubeflow/kubeflow#6485</a>.
 {{% /alert %}}
 
-<b>See the table below for a list of options and links to documentation:</b>
+### Active Distributions
+
+The following table lists <b>active distributions</b> that have <b>had a recent release</b> (within the last 6 months).
 
 <div class="table-responsive">
   <table class="table table-bordered">
@@ -28,129 +36,235 @@ Packaged distributions are developed and supported by their respective maintaine
       <tr>
         <th>Name</th>
         <th>Maintainer</th>
-        <th>Platform</th>
-        <th>Version</th>
-        <th>Docs</th>
-        <th>Website</th>
+        <th>Target Platform</th>
+        <th>Link</th>
+        <th>Latest Release</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>Kubeflow on AWS</td>
-        <td>Amazon Web Services (AWS)</td>
-        <td>Amazon Elastic Kubernetes Service (EKS)</td>
-        <td>{{% aws/latest-version %}}</td>
-        <td><a href="/docs/distributions/aws/">Docs</a></td>
-        <td><a href="https://awslabs.github.io/kubeflow-manifests">External Website</a></td>
-      </tr>
-      <tr>
-        <td>Kubeflow on Azure</td>
-        <td>Microsoft Azure</td>
-        <td>Azure Kubernetes Service (AKS)</td>
-        <td>1.2</td>
-        <td><a href="/docs/distributions/azure/">Docs</a></td>
-        <td></td>
+        <td>Amazon Web Services</td>
+        <td>
+          Amazon Elastic Kubernetes Service (EKS)
+        </td>
+        <td>
+          <u><a href="https://awslabs.github.io/kubeflow-manifests">Website</a></u>
+        </td>
+        <td>
+          2022-10-14
+          <br>
+          <sup>[<a href="https://github.com/awslabs/kubeflow-manifests/releases/tag/v1.6.1-aws-b1.0.0">GitHub Release</a>]</sup>
+        </td>
       </tr>
       <tr>
         <td>Kubeflow on Google Cloud</td>
         <td>Google Cloud</td>
-        <td>Google Kubernetes Engine (GKE)</td>
-        <td>{{% gke/latest-version %}}</td>
-        <td><a href="/docs/distributions/gke/">Docs</a></td>
-        <td></td>
+        <td>
+          Google Kubernetes Engine (GKE)
+        </td>
+        <td>
+          <u><a href="https://github.com/GoogleCloudPlatform/kubeflow-distribution">Website</a></u>
+          <br>
+          <sub><u><a href="/docs/distributions/gke/">Legacy Docs</a></u></sub>
+        </td>
+        <td>
+          2022-10-17
+          <br>
+          <sup>[<a href="https://github.com/GoogleCloudPlatform/kubeflow-distribution/releases/tag/v1.6.1">GitHub Release</a>]</sup>
+        </td>
       </tr>
       <tr>
         <td>Kubeflow on IBM Cloud</td>
         <td>IBM Cloud</td>
-        <td>IBM Cloud Kubernetes Service (IKS) </td>
-        <td>{{% iks/latest-version %}}</td>
-        <td><a href="/docs/distributions/ibm/">Docs</a></td>
-        <td><a href="https://github.com/IBM/manifests/tree/{{% iks/latest-branch %}}">External Website</a></td>
+        <td>
+          IBM Cloud Kubernetes Service (IKS)
+        </td>
+        <td>
+          <u><a href="https://github.com/IBM/manifests/tree/{{% iks/latest-branch %}}">Website</a></u>
+          <br>
+          <sub><u><a href="/docs/distributions/ibm/">Legacy Docs</a></u></sub>
+        </td>
+        <td>
+          2022-10-10
+          <br>
+          <sup>[<a href="https://github.com/IBM/manifests/releases/tag/v1.6.1">GitHub Release</a>]</sup>
+        </td>
       </tr>
       <tr>
         <td>Kubeflow on Nutanix</td>
         <td>Nutanix</td>
-        <td>Nutanix Karbon</td>
-        <td>{{% nutanix/latest-version %}}</td>
-        <td><a href="/docs/distributions/nutanix/">Docs</a></td>
-        <td></td>
+        <td>
+          Nutanix Kubernetes Engine
+        </td>
+        <td>
+          <u><a href="https://github.com/nutanix/karbon-platform-services/tree/master/automation/infrastructure/terraform/kcs/install_kubeflow">Website</a></u>
+          <br>
+          <sub><u><a href="/docs/distributions/nutanix/">Legacy Docs</a></u></sub>
+        </td>
+        <td>
+          2022-08-30
+          <br>
+          <sup>[<a href="https://github.com/nutanix/karbon-platform-services/issues/94#issuecomment-1230618653">GitHub Comment</a>]</sup>
+        </td>
       </tr>
       <tr>
-        <td>Kubeflow on OpenShift</td>
+        <td>Open Data Hub</td>
         <td>Red Hat</td>
-        <td>OpenShift</td>
-        <td>1.6</td>
-        <td><a href="/docs/distributions/openshift/">Docs</a></td>
-        <td><a href="https://opendatahub.io/docs/kubeflow.html">External Website</a></td>
-      </tr>
-      <tr>
-        <td>Argoflow</td>
-        <td>Argoflow Community</td>
-        <td>Conformant Kubernetes</td>
-        <td>1.3</td>
-        <td>N/A</td>
-        <td><a href="https://github.com/argoflow/argoflow">External Website</a></td>
+        <td>
+          OpenShift
+        </td>
+        <td>
+          <u><a href="https://opendatahub.io/docs/kubeflow.html">Website</a></u>
+          <br>
+          <sub><u><a href="/docs/distributions/openshift/">Legacy Docs</a></u></sub>
+        </td>
+        <td>
+          2022-10-26
+          <br>
+          <sup>[<a href="https://github.com/opendatahub-io/odh-manifests/releases/tag/v1.4.0">GitHub Release</a>]</sup>
+        </td>
       </tr>
       <tr>
         <td>Arrikto Kubeflow as a Service</td>
-        <td>Arrikto</td>
-        <td>Fully Managed</td>
-        <td>1.5</td>
-        <td>N/A</td>
-        <td><a href="http://kubeflow.arrikto.com/">External Website</a></td>
+        <td rowspan="2">Arrikto</td>
+        <td>
+          N/A <sup>(fully managed)</sup>
+        </td>
+        <td>
+          <u><a href="https://www.arrikto.com/kubeflow-as-a-service/">Website</a></u>
+        </td>
+        <td>
+          Unknown
+        </td>
       </tr>
       <tr>
         <td>Arrikto Enterprise Kubeflow</td>
-        <td>Arrikto</td>
-        <td>EKS,
-            AKS,
-            GKE
-        </td>
-        <td>1.5</td>
         <td>
-          <a href="/docs/distributions/ekf/">Docs</a>
+          ◦ Amazon Elastic Kubernetes Service (EKS)
+          <br>
+          ◦ Azure Kubernetes Service (AKS)
+          <br>
+          ◦ Google Kubernetes Engine (GKE)
         </td>
         <td>
-          <a href="https://www.arrikto.com/enterprise-kubeflow/">External Website</a>
+          <u><a href="https://www.arrikto.com/enterprise-kubeflow/">Website</a></u>
+        </td>
+        <td>
+          2022-10-24
+          <br>
+          <sup>[<a href="https://docs.arrikto.com/Changelog.html#version-2-0-aurora">Changelog</a>]</sup>
         </td>
       </tr>
       <tr>
         <td>Charmed Kubeflow</td>
         <td>Canonical</td>
-        <td>Conformant Kubernetes</td>
-        <td>1.6</td>
-        <td><a href="/docs/distributions/charmed/">Docs</a></td>
-        <td><a href="https://charmed-kubeflow.io/">External Website</a></td>
+        <td>
+          All Conformant Kubernetes
+        </td>
+        <td>
+          <u><a href="https://charmed-kubeflow.io/">Website</a></u>
+        </td>
+        <td>
+          2022-09-08
+          <br>
+          <sup>[<a href="https://ubuntu.com/blog/charmed-kubeflow-1-6-available">Blog Post</a>]</sup>
+        </td>
       </tr>
       <tr>
-        <td>Kubeflow on Oracle Container Engine for Kubernetes</td>
+        <td>Kubeflow on Oracle Cloud Infrastructure</td>
         <td>Oracle</td>
-        <td>Oracle Cloud Infrastructure (OCI)</td>
-        <td>1.6</td>
-        <td>N/A</td>
-        <td><a href="https://github.com/oracle-devrel/kubeflow-oke">External Website</a></td>
+        <td>
+          Oracle Container Engine for Kubernetes (OKE)
+        </td>
+        <td>
+          <u><a href="https://github.com/oracle-devrel/kubeflow-oke">Website</a></u>
+        </td>
+        <td>
+          Unknown
+        </td>
       </tr>
       <tr>
         <td>Kubeflow on vSphere</td>
         <td>VMware</td>
-        <td>vSphere</td>
-        <td>1.6</td>
-        <td>N/A</td>
-        <td><a href="https://vmware.github.io/ml-ops-platform-for-vsphere/">External Website</a></td>
+        <td>VMware vSphere</td>
+        <td>
+          <u><a href="https://vmware.github.io/ml-ops-platform-for-vsphere/">Website</a></u>
+        </td>
+        <td>
+          Unknown
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Legacy Distributions
+
+The following table lists <b>legacy distributions</b> which have <b>not had a recent release</b> (within the last 6 months).
+
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Name</th>
+        <th>Maintainer</th>
+        <th>Target Platform</th>
+        <th>Link</th>
+        <th>Latest Release</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Argoflow</td>
+        <td>Argoflow Users</td>
+        <td>
+          All Conformant Kubernetes
+        </td>
+        <td>
+          <u><a href="https://github.com/argoflow">Website</a></u>
+        </td>
+        <td>
+          2021-06-02
+          <br>
+          <sup>[<a href="https://github.com/argoflow/argoflow/releases/tag/v0.1.0">GitHub Release</a>]</sup>
+        </td>
+      </tr>
+      <tr>
+        <td>Kubeflow on Azure</td>
+        <td>N/A <sup>(not maintained)</sup></td>
+        <td>
+          Azure Kubernetes Service (AKS)
+        </td>
+        <td>
+          <s>Website</s>
+          <br>
+          <sub><u><a href="/docs/distributions/azure/">Legacy Docs</a></u></sub>
+        </td>
+        <td>
+          2020-11-14
+          <br>
+          <sup>[<a href="https://github.com/kubeflow/manifests/pull/1642">Pull Request</a>]</sup>
+        </td>
       </tr>
     </tbody>
   </table>
 </div>
 
 <a id="manifests"></a>
-## Install the Kubeflow Manifests manually
+<a id="install-the-kubeflow-manifests-manually"></a>
+## Raw Kubeflow Manifests
 
-{{% alert color="warning" %}}
-This method is for advanced users. The Kubeflow community will not support environment-specific issues. If you need support, please consider using a [packaged distribution](#packaged-distributions) of Kubeflow.
+{{% alert title="Warning" color="warning" %}}
+This method is for advanced users.
+
+The Kubeflow community is not able to provide support for environment-specific issues when using the raw manifests.
+If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
 {{% /alert %}}
 
-The <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Manifests Working Group</a> is responsible for aggregating the authoritative manifests of each official Kubeflow component.
-While these manifests are intended to be the base of packaged distributions, advanced users may choose to install them directly by following <a href="https://github.com/kubeflow/manifests#installation">these instructions</a>.
+The raw <a href="https://github.com/kubeflow/manifests">Kubeflow manifests</a> are aggregated by the <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Manifests Working Group</a> 
+and are intended to be used as the base of packaged distributions,
+<b>advanced users may choose to install the manifests directly</b> by following <a href="https://github.com/kubeflow/manifests#installation">these instructions</a>.
 
 <a id="next-steps"></a>
 ## Next steps


### PR DESCRIPTION
This PR improves the `Getting Started / Installing Kubeflow` page in the following ways:

- Splits the distributions tables into two sections:
   - "Active Distributions" - any distribution which has had an update within the last 6 months
   - "Legacy Distributions" - any not active distribution, currently only has:
       -  `Argoflow` (Kubeflow 1.4)
       - `Kubeflow on Azure` (Kubeflow 1.2)
- Improves the readability of the distribution tables:
    - ~~Removed the "version" column as it was quite messy, and often had incorrect information as distributions forgot to update it~~ (replaced with "latest release" column)
    - Combines the distribution "links" into a single column (preparation for once https://github.com/kubeflow/website/issues/3074 is resolved)
- Added a link to the "official website" of each distribution
- Changes the names of the following distributions to be more correct:
    - `Kubeflow on OpenShift` --> `Open Data Hub`
    - `Kubeflow on Oracle Container Engine for Kubernetes` --> `Kubeflow on Oracle Cloud Infrastructure`
- Improves the section header names:
    - `Install a packaged Kubeflow distribution` --> `Packaged Distributions of Kubeflow`
    - `Install the Kubeflow Manifests manually` --> `Raw Kubeflow Manifests`
- Improves the wording of warnings and other text.

## Screenshot of the updated page:

![Installing-Kubeflow-Kubeflow](https://user-images.githubusercontent.com/5735406/205757476-3056658b-2f5b-44fb-8a72-7c4cc8b28774.png)

