### PR TITLE
update release docs (dependency table + headings)

### DIFF
--- a/content/en/docs/releases/kubeflow-0.6.md
+++ b/content/en/docs/releases/kubeflow-0.6.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 0.6 release"
 weight = 106
 +++
 
-## 0.6.1
+## Kubeflow 0.6.1
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -48,7 +48,7 @@ weight = 106
 </table>
 </div>
 
-## 0.6.0
+## Kubeflow 0.6.0
 
 <div class="table-responsive">
 <table class="table table-bordered">

--- a/content/en/docs/releases/kubeflow-0.7.md
+++ b/content/en/docs/releases/kubeflow-0.7.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 0.7 release"
 weight = 105
 +++
 
-## 0.7.0
+## Kubeflow 0.7.0
 
 <div class="table-responsive">
 <table class="table table-bordered">

--- a/content/en/docs/releases/kubeflow-1.0.md
+++ b/content/en/docs/releases/kubeflow-1.0.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 1.0 release"
 weight = 104
 +++
 
-## 1.0.2
+## Kubeflow 1.0.2
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -48,7 +48,7 @@ weight = 104
 </table>
 </div>
 
-## 1.0.1
+## Kubeflow 1.0.1
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -92,7 +92,7 @@ weight = 104
 </table>
 </div>
 
-## 1.0.0
+## Kubeflow 1.0.0
 
 <div class="table-responsive">
 <table class="table table-bordered">

--- a/content/en/docs/releases/kubeflow-1.1.md
+++ b/content/en/docs/releases/kubeflow-1.1.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 1.1 release"
 weight = 103
 +++
 
-## 1.1.0
+## Kubeflow 1.1.0
 
 <div class="table-responsive">
 <table class="table table-bordered">

--- a/content/en/docs/releases/kubeflow-1.2.md
+++ b/content/en/docs/releases/kubeflow-1.2.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 1.2 release"
 weight = 102
 +++
 
-## 1.2.0
+## Kubeflow 1.2.0
 
 <div class="table-responsive">
 <table class="table table-bordered">

--- a/content/en/docs/releases/kubeflow-1.3.md
+++ b/content/en/docs/releases/kubeflow-1.3.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 1.3 release"
 weight = 101
 +++
 
-## 1.3.1
+## Kubeflow 1.3.1
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -48,8 +48,7 @@ weight = 101
 </table>
 </div>
 
-<br>
-<b>Versions of components in 1.3.1:</b>
+### Component Versions
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -193,7 +192,7 @@ weight = 101
 </table>
 </div>
 
-## 1.3.0
+## Kubeflow 1.3.0
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -237,8 +236,7 @@ weight = 101
 </table>
 </div>
 
-<br>
-<b>Versions of components in 1.3.0:</b>
+### Component Versions
 
 <div class="table-responsive">
 <table class="table table-bordered">

--- a/content/en/docs/releases/kubeflow-1.4.md
+++ b/content/en/docs/releases/kubeflow-1.4.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 1.4 release"
 weight = 100
 +++
 
-## 1.4.1
+## Kubeflow 1.4.1
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -54,8 +54,7 @@ weight = 100
 </table>
 </div>
 
-<br>
-<b>Versions of components in 1.4.1:</b>
+### Component Versions
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -181,7 +180,7 @@ weight = 100
 </table>
 </div>
 
-## 1.4.0
+## Kubeflow 1.4.0
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -231,8 +230,7 @@ weight = 100
 </table>
 </div>
 
-<br>
-<b>Versions of components in 1.4.0:</b>
+### Component Versions
 
 <div class="table-responsive">
 <table class="table table-bordered">

--- a/content/en/docs/releases/kubeflow-1.5.md
+++ b/content/en/docs/releases/kubeflow-1.5.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 1.5 release"
 weight = 99
 +++
 
-## 1.5.1
+## Kubeflow 1.5.1
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -66,8 +66,7 @@ weight = 99
 </table>
 </div>
 
-<br>
-<b>Versions of components in 1.5.1:</b>
+### Component Versions
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -187,7 +186,102 @@ weight = 99
 </table>
 </div>
 
-## 1.5.0
+### Dependency Versions (Manifests)
+
+{{% alert title="Note" color="warning" %}}
+This information is only for the manifests found in the <a href="https://github.com/kubeflow/manifests">kubeflow/manifests</a> repository, packaged distributions may have different requirements or supported versions.
+{{% /alert %}}
+
+<div class="table-responsive">
+<table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Dependency</th>
+        <th>Validated or Included Version(s)</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+  <tbody>
+      <!-- ======================= -->
+      <!-- Kubernetes -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://kubernetes.io/">Kubernetes</a>
+        </td>
+        <td>1.21</td>
+        <td rowspan="1" class="align-middle">
+          <i>Kubernetes 1.22 is NOT supported by Kubeflow 1.5, see <a href="https://github.com/kubeflow/kubeflow/issues/6353">kubeflow/kubeflow#6353</a> for more information.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Istio -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://istio.io/">Istio</a>
+        </td>
+        <td>1.11.0</td>
+        <td rowspan="3" class="align-middle">
+          <i>Other versions may work, but have not been validated by the <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Kubeflow Manifests Working Group</a>.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- cert-manager  -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://cert-manager.io/">cert-manager</a>
+        </td>
+        <td>1.5.0</td>
+      </tr>
+      <!-- ======================= -->
+      <!-- dex  -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://dexidp.io/">dex</a>
+        </td>
+        <td>2.22.0</td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Kustomize  -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://kustomize.io/">Kustomize</a>
+        </td>
+        <td>3.2.0</td>
+        <td>
+          <i>Newer versions of Kustomize are not currently supported, follow <a href="https://github.com/kubeflow/manifests/issues/1797">kubeflow/manifests#1797</a> for progress on this issue.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Knative Serving -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://knative.dev/docs/serving/">Knative Serving</a>
+        </td>
+        <td>0.22.1</td>
+        <td rowspan="2" class="align-middle">
+          <i>Knative is only needed when using the optional <a href="https://kserve.github.io/website/">KServe Component</a>.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Knative Eventing -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://knative.dev/docs/eventing/">Knative Eventing</a>
+        </td>
+        <td>0.22.1</td>
+      </tr>
+  </tbody>
+</table>
+</div>
+
+## Kubeflow 1.5.0
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -249,8 +343,7 @@ weight = 99
 </table>
 </div>
 
-<br>
-<b>Versions of components in 1.5.0:</b>
+### Component Versions
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -365,6 +458,101 @@ weight = 99
         <td>
           <a href="https://github.com/kubeflow/training-operator/releases/tag/v1.4.0">v1.4.0</a>
         </td>
+      </tr>
+  </tbody>
+</table>
+</div>
+
+### Dependency Versions (Manifests)
+
+{{% alert title="Note" color="warning" %}}
+This information is only for the manifests found in the <a href="https://github.com/kubeflow/manifests">kubeflow/manifests</a> repository, packaged distributions may have different requirements or supported versions.
+{{% /alert %}}
+
+<div class="table-responsive">
+<table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Dependency</th>
+        <th>Validated or Included Version(s)</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+  <tbody>
+      <!-- ======================= -->
+      <!-- Kubernetes -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://kubernetes.io/">Kubernetes</a>
+        </td>
+        <td>1.21</td>
+        <td rowspan="1" class="align-middle">
+          <i>Kubernetes 1.22 is NOT supported by Kubeflow 1.5, see <a href="https://github.com/kubeflow/kubeflow/issues/6353">kubeflow/kubeflow#6353</a> for more information.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Istio -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://istio.io/">Istio</a>
+        </td>
+        <td>1.11.0</td>
+        <td rowspan="3" class="align-middle">
+          <i>Other versions may work, but have not been validated by the <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Kubeflow Manifests Working Group</a>.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- cert-manager  -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://cert-manager.io/">cert-manager</a>
+        </td>
+        <td>1.5.0</td>
+      </tr>
+      <!-- ======================= -->
+      <!-- dex  -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://dexidp.io/">dex</a>
+        </td>
+        <td>2.22.0</td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Kustomize  -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://kustomize.io/">Kustomize</a>
+        </td>
+        <td>3.2.0</td>
+        <td>
+          <i>Newer versions of Kustomize are not currently supported, follow <a href="https://github.com/kubeflow/manifests/issues/1797">kubeflow/manifests#1797</a> for progress on this issue.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Knative Serving -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://knative.dev/docs/serving/">Knative Serving</a>
+        </td>
+        <td>0.22.1</td>
+        <td rowspan="2" class="align-middle">
+          <i>Knative is only needed when using the optional <a href="https://kserve.github.io/website/">KServe Component</a>.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Knative Eventing -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://knative.dev/docs/eventing/">Knative Eventing</a>
+        </td>
+        <td>0.22.1</td>
       </tr>
   </tbody>
 </table>

--- a/content/en/docs/releases/kubeflow-1.6.md
+++ b/content/en/docs/releases/kubeflow-1.6.md
@@ -4,7 +4,7 @@ description = "Information about the Kubeflow 1.6 release"
 weight = 98
 +++
 
-## 1.6.1
+## Kubeflow 1.6.1
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -64,8 +64,7 @@ weight = 98
 </table>
 </div>
 
-<br>
-<b>Versions of components in 1.6.1:</b>
+### Component Versions
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -185,15 +184,19 @@ weight = 98
 </table>
 </div>
 
-<br>
-<b>Versions of dependencies in 1.6.1:</b>
+### Dependency Versions (Manifests)
+
+{{% alert title="Note" color="warning" %}}
+This information is only for the manifests found in the <a href="https://github.com/kubeflow/manifests">kubeflow/manifests</a> repository, packaged distributions may have different requirements or supported versions.
+{{% /alert %}}
 
 <div class="table-responsive">
 <table class="table table-bordered">
     <thead class="thead-light">
       <tr>
-        <th>Dependent Component Name</th>
-        <th>Version</th>
+        <th>Dependency</th>
+        <th>Validated or Included Version(s)</th>
+        <th>Notes</th>
       </tr>
     </thead>
   <tbody>
@@ -201,61 +204,79 @@ weight = 98
       <!-- Kubernetes -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Kubernetes</td>
         <td>
-          1.22
+          <a href="https://kubernetes.io/">Kubernetes</a>
+        </td>
+        <td>1.22</td>
+        <td rowspan="4" class="align-middle">
+          <i>Other versions may work, but have not been validated by the <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Kubeflow Manifests Working Group</a>.</i>
         </td>
       </tr>
       <!-- ======================= -->
       <!-- Istio -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Istio</td>
         <td>
-          1.14.1
+          <a href="https://istio.io/">Istio</a>
         </td>
+        <td>1.14.1</td>
       </tr>
       <!-- ======================= -->
-      <!-- Knative  -->
+      <!-- cert-manager  -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Knative</td>
         <td>
-          1.2
+          <a href="https://cert-manager.io/">cert-manager</a>
         </td>
+        <td>1.5.0</td>
       </tr>
       <!-- ======================= -->
-      <!-- Cert Manager  -->
+      <!-- dex  -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Cert Manager</td>
         <td>
-          1.5.0
+          <a href="https://dexidp.io/">dex</a>
         </td>
-      </tr>
-      <!-- ======================= -->
-      <!-- Dex  -->
-      <!-- ======================= -->
-      <tr>
-        <td rowspan="1" class="align-middle">Dex</td>
-        <td>
-          2.31.2
-        </td>
+        <td>2.31.2</td>
       </tr>
       <!-- ======================= -->
       <!-- Kustomize  -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Kustomize</td>
         <td>
-          3.2.0
+          <a href="https://kustomize.io/">Kustomize</a>
         </td>
+        <td>3.2.0</td>
+        <td>
+          <i>Newer versions of Kustomize are not currently supported, follow <a href="https://github.com/kubeflow/manifests/issues/1797">kubeflow/manifests#1797</a> for progress on this issue.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Knative Serving -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://knative.dev/docs/serving/">Knative Serving</a>
+        </td>
+        <td>1.2.5</td>
+        <td rowspan="2" class="align-middle">
+          <i>Knative is only needed when using the optional <a href="https://kserve.github.io/website/">KServe Component</a>.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Knative Eventing -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://knative.dev/docs/eventing/">Knative Eventing</a>
+        </td>
+        <td>1.2.4</td>
       </tr>
   </tbody>
 </table>
 </div>
 
-## 1.6.0
+## Kubeflow 1.6.0
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -315,8 +336,7 @@ weight = 98
 </table>
 </div>
 
-<br>
-<b>Versions of components in 1.6.0:</b>
+### Component Versions
 
 <div class="table-responsive">
 <table class="table table-bordered">
@@ -436,15 +456,19 @@ weight = 98
 </table>
 </div>
 
-<br>
-<b>Versions of dependencies in 1.6.0:</b>
+### Dependency Versions (Manifests)
+
+{{% alert title="Note" color="warning" %}}
+This information is only for the manifests found in the <a href="https://github.com/kubeflow/manifests">kubeflow/manifests</a> repository, packaged distributions may have different requirements or supported versions.
+{{% /alert %}}
 
 <div class="table-responsive">
 <table class="table table-bordered">
     <thead class="thead-light">
       <tr>
-        <th>Dependent Component Name</th>
-        <th>Version</th>
+        <th>Dependency</th>
+        <th>Validated or Included Version(s)</th>
+        <th>Notes</th>
       </tr>
     </thead>
   <tbody>
@@ -452,55 +476,73 @@ weight = 98
       <!-- Kubernetes -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Kubernetes</td>
         <td>
-          1.22
+          <a href="https://kubernetes.io/">Kubernetes</a>
+        </td>
+        <td>1.22</td>
+        <td rowspan="4" class="align-middle">
+          <i>Other versions may work, but have not been validated by the <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Kubeflow Manifests Working Group</a>.</i>
         </td>
       </tr>
       <!-- ======================= -->
       <!-- Istio -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Istio</td>
         <td>
-          1.14.1
+          <a href="https://istio.io/">Istio</a>
         </td>
+        <td>1.14.1</td>
       </tr>
       <!-- ======================= -->
-      <!-- Knative  -->
+      <!-- cert-manager  -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Knative</td>
         <td>
-          1.2
+          <a href="https://cert-manager.io/">cert-manager</a>
         </td>
+        <td>1.5.0</td>
       </tr>
       <!-- ======================= -->
-      <!-- Cert Manager  -->
+      <!-- dex  -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Cert Manager</td>
         <td>
-          1.5.0
+          <a href="https://dexidp.io/">dex</a>
         </td>
-      </tr>
-      <!-- ======================= -->
-      <!-- Dex  -->
-      <!-- ======================= -->
-      <tr>
-        <td rowspan="1" class="align-middle">Dex</td>
-        <td>
-          2.31.2
-        </td>
+        <td>2.31.2</td>
       </tr>
       <!-- ======================= -->
       <!-- Kustomize  -->
       <!-- ======================= -->
       <tr>
-        <td rowspan="1" class="align-middle">Kustomize</td>
         <td>
-          3.2.0
+          <a href="https://kustomize.io/">Kustomize</a>
         </td>
+        <td>3.2.0</td>
+        <td>
+          <i>Newer versions of Kustomize are not currently supported, follow <a href="https://github.com/kubeflow/manifests/issues/1797">kubeflow/manifests#1797</a> for progress on this issue.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Knative Serving -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://knative.dev/docs/serving/">Knative Serving</a>
+        </td>
+        <td>1.2.5</td>
+        <td rowspan="2" class="align-middle">
+          <i>Knative is only needed when using the optional <a href="https://kserve.github.io/website/">KServe Component</a>.</i>
+        </td>
+      </tr>
+      <!-- ======================= -->
+      <!-- Knative Eventing -->
+      <!-- ======================= -->
+      <tr>
+        <td>
+          <a href="https://knative.dev/docs/eventing/">Knative Eventing</a>
+        </td>
+        <td>1.2.4</td>
       </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This PR resolves the following issues:

- Previously it was not clear what the dependencies on the release pages actually referred to. They are now explicitly stated as being ONLY related to the `kubeflow/manifests`.
- Previously it was not clear that the dependencies on the release pages were not necessarily "hard" requirements (see [this `kubeflow-discuss` thread with a confused user](https://groups.google.com/g/kubeflow-discuss/c/NaFNdy3UixE/m/YsBav1K2BwAJ)). There is now a disclaimer that other versions might work, but are not validated by the Manifests WG. 
- Previously, the headers for each release version were slightly confusing.
- Dependencies were not listed for Kubeflow 1.5

## Screenshot of the updated "Kubeflow 1.6.1" dependency table:

![Screenshot 2022-11-08 at 14 49 09](https://user-images.githubusercontent.com/5735406/200470891-02058782-0c4a-4ec1-98dc-4263368cdcc0.png)

