### PR TITLE
Mark MPI-operator as beta

### DIFF
--- a/content/en/docs/components/training/mpi.md
+++ b/content/en/docs/components/training/mpi.md
@@ -5,7 +5,7 @@ weight = 35
                     
 +++
 
-{{% alpha-status
+{{% beta-status
   feedbacklink="https://github.com/kubeflow/mpi-operator/issues" %}}
 
 This guide walks you through using MPI for training.


### PR DESCRIPTION
The APIs are beta.

Not sure if this was an oversight.