### PR TITLE
Update Kubeflow version for Arrikto distributions

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -95,7 +95,7 @@ Packaged distributions are developed and supported by their respective maintaine
         <td>Arrikto Kubeflow as a Service</td>
         <td>Arrikto</td>
         <td>Fully Managed</td>
-        <td>1.4</td>
+        <td>1.5</td>
         <td>N/A</td>
         <td><a href="http://kubeflow.arrikto.com/">External Website</a></td>
       </tr>
@@ -106,7 +106,7 @@ Packaged distributions are developed and supported by their respective maintaine
             AKS,
             GKE
         </td>
-        <td>1.4</td>
+        <td>1.5</td>
         <td>
           <a href="/docs/distributions/ekf/">Docs</a>
         </td>


### PR DESCRIPTION
Update the Kubeflow version for Arrikto distributions, since Arrikto Enterprise Kubeflow and Arrikto Kubeflow as a Service come with Kubeflow 1.5.

Signed-off-by: Nickie Gkolia <nickie@arrikto.com>