### PR TITLE
[Katib] Update documentation for suggestion algorithms

### DIFF
--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -246,8 +246,28 @@ continuous) and the number of possibilities is low. A grid search
 performs an exhaustive combinatorial search over all possibilities,
 making the search process extremely long even for medium sized problems.
 
-Katib uses the [Chocolate](https://chocolate.readthedocs.io) optimization
+Katib uses the [Optuna](https://github.com/optuna/optuna) optimization
 framework for its grid search.
+
+<div class="table-responsive">
+  <table class="table table-bordered">
+    <thead class="thead-light">
+      <tr>
+        <th>Setting name</th>
+        <th>Description</th>
+        <th>Example</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>random_state</td>
+        <td>[int]: Set <code>random_state</code> to something other than None
+          for reproducible results.</td>
+        <td>10</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 <a id="random-search"></a>
 

--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -283,8 +283,7 @@ use when combinatorial exploration is not possible. If the number of continuous
 variables is high, you should use quasi random sampling instead.
 
 Katib uses the [Hyperopt](https://hyperopt.github.io/hyperopt/),
-[Goptuna](https://github.com/c-bata/goptuna),
-[Chocolate](https://chocolate.readthedocs.io) or
+[Goptuna](https://github.com/c-bata/goptuna) or
 [Optuna](https://github.com/optuna/optuna) optimization
 framework for its random search.
 
@@ -326,8 +325,7 @@ steps, making it a good choice when the time to
 complete the evaluation of a parameter configuration is long.
 
 Katib uses the
-[Scikit-Optimize](https://github.com/scikit-optimize/scikit-optimize) or
-[Chocolate](https://chocolate.readthedocs.io) optimization framework
+[Scikit-Optimize](https://github.com/scikit-optimize/scikit-optimize) optimization framework
 for its Bayesian search. Scikit-Optimize is also known as `skopt`.
 
 Katib supports the following algorithm settings:

--- a/content/en/docs/components/katib/katib-config.md
+++ b/content/en/docs/components/katib/katib-config.md
@@ -183,11 +183,6 @@ any other settings, a default value is set automatically.
            <td><a href="https://github.com/hyperopt/hyperopt">Hyperopt</a> optimization framework</td>
          </tr>
          <tr>
-           <td><code>suggestion-chocolate</code></td>
-           <td><code>grid</code>, <code>random</code>, <code>quasirandom</code>, <code>bayesianoptimization</code>, <code>mocmaes</code></td>
-           <td><a href="https://github.com/AIworx-Labs/chocolate">Chocolate</a> optimization framework</td>
-         </tr>
-         <tr>
            <td><code>suggestion-skopt</code></td>
            <td><code>bayesianoptimization</code></td>
            <td><a href="https://github.com/scikit-optimize/scikit-optimize">Scikit-optimize</a> optimization framework</td>

--- a/content/en/docs/components/katib/katib-config.md
+++ b/content/en/docs/components/katib/katib-config.md
@@ -199,7 +199,7 @@ any other settings, a default value is set automatically.
          </tr>
          <tr>
            <td><code>suggestion-optuna</code></td>
-           <td><code>multivariate-tpe</code>, <code>tpe</code>, <code>cmaes</code>, <code>random</code></td>
+           <td><code>multivariate-tpe</code>, <code>tpe</code>, <code>cmaes</code>, <code>random</code>, <code>grid</code></td>
            <td><a href="https://github.com/optuna/optuna">Optuna</a> optimization framework</td>
          </tr>
          <tr>


### PR DESCRIPTION
I updated documentation for suggestion algorithms.

1. Add Optuna to the documentation for the grid search algorithm
2. Remove Chocolate from all documentation

Part-of: https://github.com/kubeflow/katib/issues/2058

/hold for https://github.com/kubeflow/katib/pull/2071

/assign @kubeflow/wg-automl-leads 