### PR TITLE
Migrate GKE docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,18 @@ defaultContentLanguageInSubdir = false
 enableMissingTranslationPlaceholders = true
 # disable taxonomies
 disableKinds = ["taxonomy", "taxonomyTerm"]
-
+# deprecated directories
+ignoreFiles = [
+  "content/en/docs/distributions/gke/deploy/*", 
+  "content/en/docs/distributions/gke/pipelines/*", 
+  "content/en/docs/distributions/gke/anthos.md", 
+  "content/en/docs/distributions/gke/authentication.md",
+  "content/en/docs/distributions/gke/authentication.md", 
+  "content/en/docs/distributions/gke/custom-domain.md", 
+  "content/en/docs/distributions/gke/customizing-gke.md", 
+  "content/en/docs/distributions/gke/private-clusters.md", 
+  "content/en/docs/distributions/gke/troubleshooting-gke.md"
+  ]
 ###############################################################################
 # Hugo - Top-level navigation (horizontal)
 ###############################################################################

--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -202,3 +202,4 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/components/istio/*            /docs/external-add-ons/istio/:splat
 /docs/components/feature-store/*    /docs/external-add-ons/feature-store/:splat
 /docs/components/serving/*          /docs/external-add-ons/serving/:splat
+/docs/distributions/gke/*           https://googlecloudplatform.github.io/kubeflow-gke-docs/docs/:splat

--- a/content/en/docs/distributions/gke/_index.md
+++ b/content/en/docs/distributions/gke/_index.md
@@ -3,3 +3,7 @@ title = "Kubeflow on Google Cloud"
 description = "Running Kubeflow on Kubernetes Engine and Google Cloud Platform"
 weight = 20
 +++
+
+[Kubeflow on Google Cloud](https://googlecloudplatform.github.io/kubeflow-gke-docs) is an open-source toolkit for building machine learning (ML) systems. Seamlessly integrated with GCP services Kubeflow allows you to build secure, scalable, and reliable ML workflows of any complexity, while reducing operational costs and development time.
+
+Start using [Kubeflow on Google Cloud](https://googlecloudplatform.github.io/kubeflow-gke-docs) today.

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -57,7 +57,7 @@ Packaged distributions are developed and supported by their respective maintaine
         <td>Google Kubernetes Engine (GKE)</td>
         <td>{{% gke/latest-version %}}</td>
         <td><a href="/docs/distributions/gke/">Docs</a></td>
-        <td></td>
+        <td><a href="https://googlecloudplatform.github.io/kubeflow-gke-docs">External Website</a></td>
       </tr>
       <tr>
         <td>Kubeflow on IBM Cloud</td>


### PR DESCRIPTION
- Added a link to the external website
- Added ignoreFiles with the list of migrated docs 
- Updated description for the landing page of Kubeflow of Google Cloud