### PR TITLE
Switched the case of the heading

### DIFF
--- a/content/en/docs/components/pipelines/v2/compile-a-pipeline.md
+++ b/content/en/docs/components/pipelines/v2/compile-a-pipeline.md
@@ -1,5 +1,5 @@
 +++
-title = "Compile a pipeline"
+title = "Compile a Pipeline"
 description = "Compile a pipeline definition to YAML"
 weight = 5
 +++


### PR DESCRIPTION
Switched the case of the heading to make it consistent with the rest of the documentation.