### PR TITLE
Add create kubeflow-user-example-com ns

### DIFF
--- a/content/en/docs/distributions/openshift/install-kubeflow.md
+++ b/content/en/docs/distributions/openshift/install-kubeflow.md
@@ -46,10 +46,11 @@ Use the following steps to install Kubeflow 1.6 on OpenShift 4.9.
 git clone https://github.com/opendatahub-io/manifests.git --branch v1.6-branch-openshift
 ```
 
-2. Create `kubeflow` namespace
+2. Create `kubeflow` namespaces
 
 ```commandline
 oc create ns kubeflow
+oc create ns kubeflow-user-example-com
 ```
 
 4. Deploy all Kubeflow components under `openshift` stack using the following command:


### PR DESCRIPTION
When following the current instructions the install throws the following error message:

```
Error from server (NotFound): error when creating "STDIN": namespaces "kubeflow-user-example-com" not found
```

The kubeflow-user-example-com ns should be created before the install to prevent this error.