### PR TITLE
[Katib] Change the Default Resume Policy

### DIFF
--- a/content/en/docs/components/katib/experiment.md
+++ b/content/en/docs/components/katib/experiment.md
@@ -52,7 +52,7 @@ These are the fields in the experiment configuration spec:
   Katib generates hyperparameter combinations in the range based on the
   hyperparameter tuning algorithm that you specify.
   Refer to the
-  [`ParameterSpec` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L185-L206).
+  [`ParameterSpec` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L193-L214).
 
 - **objective**: The metric that you want to optimize.
   The objective metric is also called the _target variable_.
@@ -157,7 +157,7 @@ These are the fields in the experiment configuration spec:
   - [Argo `Workflows`](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/argo)
 
   Refer to the
-  [`TrialTemplate` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L208-L270).
+  [`TrialTemplate` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L216-L278).
   Follow the [trial template guide](/docs/components/katib/trial-template/)
   to understand how to specify `trialTemplate` parameters, save templates in
   `ConfigMaps` and support custom Kubernetes resources in Katib.
@@ -173,36 +173,36 @@ These are the fields in the experiment configuration spec:
   to optimize, including the number of layers in the network, the types of
   operations, and more.
   Refer to the
-  [`NasConfig` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L296).
+  [`NasConfig` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L303-L320).
 
   - **graphConfig**: The graph config that defines structure for a
     directed acyclic graph of the neural network. You can specify the number of layers,
     `input_sizes` for the input layer and `output_sizes` for the output layer.
     Refer to the
-    [`GraphConfig` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L301-L306).
+    [`GraphConfig` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L309-L314).
 
   - **operations**: The range of operations that you want to tune for your ML model.
     For each neural network layer the NAS algorithm selects one of the operations
     to build a neural network. Each operation contains sets of **parameters** which
     are described above.
     Refer to the
-    [`Operation` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L308-L312).
+    [`Operation` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L316-L320).
 
     You can find all NAS examples [here](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/nas).
 
 - **resumePolicy**: The experiment resume policy. Can be one of
-  `LongRunning`, `Never` or `FromVolume`. The default value is `LongRunning`.
+  `LongRunning`, `Never` or `FromVolume`. The default value is `Never`.
   Refer to the
-  [`ResumePolicy` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L58).
+  [`ResumePolicy` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L60).
   To find out how to modify a running experiment and use various
   restart policies follow the
   [resume an experiment guide](/docs/components/katib/resume-experiment/).
 
 _Background information about Katib's `Experiment`, `Suggestion` and `Trial`
 type:_ In Kubernetes terminology, Katib's
-[`Experiment` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L278),
-[`Suggestion` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/suggestions/v1beta1/suggestion_types.go#L128) and
-[`Trial` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/trials/v1beta1/trial_types.go#L129)
+[`Experiment` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L286),
+[`Suggestion` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/suggestions/v1beta1/suggestion_types.go#L131) and
+[`Trial` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/trials/v1beta1/trial_types.go#L134)
 is a [custom resource (CR)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 The YAML file that you create for your experiment is the CR specification.
 

--- a/content/en/docs/components/katib/hyperparameter.md
+++ b/content/en/docs/components/katib/hyperparameter.md
@@ -304,7 +304,7 @@ spec:
           - ftrl
       name: optimizer
       parameterType: categorical
-  resumePolicy: LongRunning
+  resumePolicy: Never
   trialTemplate:
     failureCondition: status.conditions.#(type=="Failed")#|#(status=="True")#
     primaryContainerName: training-container

--- a/content/en/docs/components/katib/resume-experiment.md
+++ b/content/en/docs/components/katib/resume-experiment.md
@@ -62,7 +62,7 @@ as described [above](#modify-experiment)
 To control various resume policies, you can specify `.spec.resumePolicy`
 for the experiment.
 Refer to the
-[`ResumePolicy` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L58).
+[`ResumePolicy` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L60).
 
 ### Resume policy: Never
 
@@ -74,9 +74,8 @@ are deleted and you can't restart the experiment.
 Learn more about Katib concepts
 in the [overview guide](/docs/components/katib/overview/#katib-concepts).
 
-Check the
-[`never-resume.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/resume-experiment/never-resume.yaml#L18)
-example for more details.
+This is the default policy for all Katib experiments.
+You can omit `.spec.resumePolicy` parameter for that functionality.
 
 ### Resume policy: LongRunning
 
@@ -87,8 +86,10 @@ running. Modify experiment's trial count parameters to restart the experiment.
 When you delete the experiment, the suggestion's Deployment and
 Service are deleted.
 
-This is the default policy for all Katib experiments.
-You can omit `.spec.resumePolicy` parameter for that functionality.
+
+Check the
+[`long-running-resume.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/resume-experiment/long-running-resume.yaml#L19)
+example for more details.
 
 ### Resume policy: FromVolume
 
@@ -123,7 +124,7 @@ When you delete the experiment, the suggestion's Deployment, Service,
 PVC and PV are deleted automatically.
 
 Check the
-[`from-volume-resume.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/resume-experiment/from-volume-resume.yaml#L18)
+[`from-volume-resume.yaml`](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/resume-experiment/from-volume-resume.yaml#L19)
 example for more details.
 
 ## Next steps

--- a/content/en/docs/components/katib/trial-template.md
+++ b/content/en/docs/components/katib/trial-template.md
@@ -45,7 +45,7 @@ in the [overview guide](/docs/components/katib/overview/#trial).
 
 Trial template specification is located under `.spec.trialTemplate` of your experiment.
 For the API overview refer to the
-[`TrialTemplate` type](https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L208-L270).
+[`TrialTemplate` type](https://github.com/kubeflow/katib/blob/318f66890ebee00eba9893f7145d366795caa1d0/pkg/apis/controller/experiments/v1beta1/experiment_types.go#L216-L278).
 
 To define experiment's trial, you should specify these parameters in `.spec.trialTemplate`:
 


### PR DESCRIPTION
Related: https://github.com/kubeflow/katib/pull/2102.
We changed the default resume policy to `Never` for Katib Experiments.
Also, I used commit for APIs links so we always have correct reference.

/assign @johnugeorge @tenzen-y 