### PR TITLE
[Katib] Limit verbs when use a new CRD in Trials

### DIFF
--- a/content/en/docs/components/katib/trial-template.md
+++ b/content/en/docs/components/katib/trial-template.md
@@ -276,7 +276,11 @@ Follow these two simple steps to integrate your custom CRD in Katib:
        - pipelineruns
        - taskruns
      verbs:
-       - "*"
+       - "get"
+       - "list"
+       - "watch"
+       - "create"
+       - "delete"
    ```
 
 1. Modify Katib controller


### PR DESCRIPTION
After this PR: https://github.com/kubeflow/katib/pull/2091, we use scoped verbs while adding a new CRD to the Katib Controller RBAC.


/assign @johnugeorge @tenzen-y 