### PR TITLE
add docs for ignore_upstream_failure

### DIFF
--- a/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
+++ b/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
@@ -116,11 +116,11 @@ def my_pipeline():
         fail_op()
 ```
 #### Ignore upstream failure
-Another similiar method to achieve the same process as the exithandler while at the same time allowing tasks to collect output from upstream tasks is the [`ignore_upstream_failure()`][ignore-upstream-failure] configuration from [`pipeline_task`][tasks-configurations]
+The [ignore_upstream_failure()][ignore-upstream-failure] configuration from [pipeline_task] is useful if the calle task has upstream dependencies. This method converts the caller task into an exit handler task if the pipeline task fails and continues to collect outputs from the upstream tasks.
 
-If called, the pipeline task will run when any specified upstream tasks complete, even if unsuccessful. This method effectively turns the caller task into an exit task if the caller task has upstream dependencies. If the task has no upstream tasks, either via data exchange or an explicit dependency via `.after()`, this method has no effect.
+If the task has no upstream tasks, either through data exchange or an explicit dependency by using .after(), this method has no effect.
 
-In the following pipeline, `clean_up_task` will execute after `fail_op` regardless of if the task fails or not
+In the following pipeline, `clean_up_task` is executed after `fail_op`, regardless of whether the task fails or not
 
 ```python
 from kfp import dsl
@@ -132,7 +132,7 @@ def my_pipeline(text: str = 'message'):
         message=task.output).ignore_upstream_failure()
 ```
 
-An important thing to note is that the component used for the caller task is required to have a default value for all inputs read from the upstream tasks, this is to make sure the caller tasks never fails regardless of the status of the upstream tasks, since if an upstream tasks fails to produce the inputs it would use the default value. 
+Note that the component used for the caller task requires a default value for each input read from an upstream task. The default value is applied if an upstream task fails to produce inputs. Specifying default values ensures that the caller task always succeeds, regardless of the status of the upstream task. 
 
 
 [component-io]: /docs/components/pipelines/v2/author-a-pipeline/component-io#passing-data-between-tasks

--- a/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
+++ b/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
@@ -116,9 +116,9 @@ def my_pipeline():
         fail_op()
 ```
 #### Ignore upstream failure
-The [ignore_upstream_failure()][ignore-upstream-failure] configuration from [pipeline_task] is useful if the caller task has upstream dependencies. If the pipeline task fails, this method converts the caller task into an exit handler and continues to collect outputs from the upstream tasks.
+The [`.ignore_upstream_failure()`][ignore-upstream-failure] configuration from [`pipeline_task`][tasks-configurations] is useful if the caller task wants to ignore the failures of upstream tasks. If the pipeline task fails, this method converts the caller task into an exit handler and continues to collect outputs from the upstream tasks.
 
-If the task has no upstream tasks, either through data exchange or an explicit dependency by using .after(), this method has no effect.
+If the task has no upstream tasks, either through data exchange or an explicit dependency by using `.after()`, this method has no effect.
 
 In the following pipeline definition, `clean_up_task` is executed after `fail_op`, regardless of whether the task fails or not:
 
@@ -132,7 +132,7 @@ def my_pipeline(text: str = 'message'):
         message=task.output).ignore_upstream_failure()
 ```
 
-Note that the component used for the caller task requires a default value for each input read from an upstream task. The default value is applied if an upstream task fails to produce inputs. Specifying default values ensures that the caller task always succeeds, regardless of the status of the upstream task. 
+Note that the component used for the caller task requires a default value for each input read from an upstream task. The default value is applied if the upstream task fails to produce the outputs that are passed as inputs to the caller task. Specifying default values ensures that the caller task always succeeds, regardless of the status of the upstream task. 
 
 
 [component-io]: /docs/components/pipelines/v2/author-a-pipeline/component-io#passing-data-between-tasks

--- a/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
+++ b/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
@@ -116,11 +116,11 @@ def my_pipeline():
         fail_op()
 ```
 #### Ignore upstream failure
-The [ignore_upstream_failure()][ignore-upstream-failure] configuration from [pipeline_task] is useful if the calle task has upstream dependencies. This method converts the caller task into an exit handler task if the pipeline task fails and continues to collect outputs from the upstream tasks.
+The [ignore_upstream_failure()][ignore-upstream-failure] configuration from [pipeline_task] is useful if the caller task has upstream dependencies. If the pipeline task fails, this method converts the caller task into an exit handler and continues to collect outputs from the upstream tasks.
 
 If the task has no upstream tasks, either through data exchange or an explicit dependency by using .after(), this method has no effect.
 
-In the following pipeline, `clean_up_task` is executed after `fail_op`, regardless of whether the task fails or not
+In the following pipeline definition, `clean_up_task` is executed after `fail_op`, regardless of whether the task fails or not:
 
 ```python
 from kfp import dsl

--- a/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
+++ b/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
@@ -115,6 +115,24 @@ def my_pipeline():
     with dsl.ExitHandler(exit_task=print_status_task):
         fail_op()
 ```
+#### ignore upstream failure
+Another similiar method to achieve the same process as the exithandler while at the same time allowing tasks to collect output from upstream tasks is the [`ignore_upstream_failure()`][ignore-upstream-failure] configuration from [`pipeline_task`][tasks-configurations]
+
+If called, the pipeline task will run when any specified upstream tasks complete, even if unsuccessful. This method effectively turns the caller task into an exit task if the caller task has upstream dependencies. If the task has no upstream tasks, either via data exchange or an explicit dependency via .after(), this method has no effect.
+
+In the following pipeline, `clean_up_task` will execute after `print_op` regardless of if the task fails or not
+
+```python
+from kfp import dsl
+
+@dsl.pipeline()
+def my_pipeline(text: str = 'message'):
+    task = fail_op(message=text)
+    clean_up_task = print_op(
+        message=task.output).ignore_upstream_failure()
+```
+
+An important thing to note is that the component used for the caller task is required to have a default value for all inputs read from the upstream tasks, this is to make sure the caller tasks never fails regardless of the status of the upstream tasks, since if an upstream tasks fails to produce the inputs it would use the default value. 
 
 
 [component-io]: /docs/components/pipelines/v2/author-a-pipeline/component-io#passing-data-between-tasks
@@ -123,3 +141,5 @@ def my_pipeline():
 [component-io-pipeline-io]: /docs/components/pipelines/v2/author-a-pipeline/component-io/#pipeline-io
 <!-- TODO: make this reference more precise throughout -->
 [dsl-reference-docs]: https://kubeflow-pipelines.readthedocs.io/en/master/source/dsl.html
+[ignore-upstream-failure]: https://kubeflow-pipelines.readthedocs.io/en/master/source/dsl.html#kfp.dsl.PipelineTask.ignore_upstream_failure
+[tasks-configurations]:  https://www.kubeflow.org/docs/components/pipelines/v2/author-a-pipeline/tasks/#task-level-configurations

--- a/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
+++ b/content/en/docs/components/pipelines/v2/author-a-pipeline/pipelines.md
@@ -115,12 +115,12 @@ def my_pipeline():
     with dsl.ExitHandler(exit_task=print_status_task):
         fail_op()
 ```
-#### ignore upstream failure
+#### Ignore upstream failure
 Another similiar method to achieve the same process as the exithandler while at the same time allowing tasks to collect output from upstream tasks is the [`ignore_upstream_failure()`][ignore-upstream-failure] configuration from [`pipeline_task`][tasks-configurations]
 
-If called, the pipeline task will run when any specified upstream tasks complete, even if unsuccessful. This method effectively turns the caller task into an exit task if the caller task has upstream dependencies. If the task has no upstream tasks, either via data exchange or an explicit dependency via .after(), this method has no effect.
+If called, the pipeline task will run when any specified upstream tasks complete, even if unsuccessful. This method effectively turns the caller task into an exit task if the caller task has upstream dependencies. If the task has no upstream tasks, either via data exchange or an explicit dependency via `.after()`, this method has no effect.
 
-In the following pipeline, `clean_up_task` will execute after `print_op` regardless of if the task fails or not
+In the following pipeline, `clean_up_task` will execute after `fail_op` regardless of if the task fails or not
 
 ```python
 from kfp import dsl

--- a/content/en/docs/components/pipelines/v2/author-a-pipeline/tasks.md
+++ b/content/en/docs/components/pipelines/v2/author-a-pipeline/tasks.md
@@ -88,6 +88,7 @@ The KFP SDK provides the following task methods for setting task-level configura
 * `.set_accelerator_limit`
 * `.set_memory_limit`
 * `.set_retry`
+* `.ignore_upstream_failure`
 
 For detailed information on how to use the above methods, see the [`kfp.dsl.PipelineTask` reference documentation][dsl-reference-docs].
 


### PR DESCRIPTION
Add documentation for the newly implemented `ignore_upstream_failure` method for pipeline tasks. If this feature is called the pipeline task will run when any specified upstream tasks complete, even if unsuccessful. This method effectively turns the caller task into an exit task if the caller task has upstream dependencies.

Sample:

```
@dsl.pipeline()
def my_pipeline(text: str = 'message'):
    task = fail_op(message=text)
    clean_up_task = print_op(
        message=task.output).ignore_upstream_failure()
```