### PR TITLE
MPI-Operator: Add docs for the schedulingPolicy

### DIFF
--- a/content/en/docs/components/training/job-scheduling.md
+++ b/content/en/docs/components/training/job-scheduling.md
@@ -25,6 +25,8 @@ Training Operator supports running jobs with gang-scheduling using Volcano Sched
 You have to install the Scheduler Plugins with coscheduling in your cluster first as a default scheduler or a secondary scheduler of Kubernetes and
 configure operator to select the scheduler name for gang-scheduling in the following:
 
+- training-operator
+
 ```diff
 ...
     spec:
@@ -34,6 +36,36 @@ configure operator to select the scheduler name for gang-scheduling in the follo
 +           - --gang-scheduler-name=scheduler-plugins
           image: kubeflow/training-operator
           name: training-operator
+...
+```
+
+- mpi-operator (installed scheduler-plugins as a default scheduler)
+
+```diff
+...
+    spec:
+      containers:
+      - args:
++       - --gang-scheduling=default-scheduler
+        - -alsologtostderr
+        - --lock-namespace=mpi-operator
+        image: mpioperator/mpi-operator:0.4.0
+        name: mpi-operator
+...
+```
+
+- mpi-operator (installed scheduler-plugins as a secondary scheduler)
+
+```diff
+...
+    spec:
+      containers:
+      - args:
++       - --gang-scheduling=scheduler-plugins-scheduler
+        - -alsologtostderr
+        - --lock-namespace=mpi-operator
+        image: mpioperator/mpi-operator:0.4.0
+        name: mpi-operator
 ...
 ```
 
@@ -75,6 +107,8 @@ In installing Scheduler Plugins as a default scheduler, you don't need to specif
 You have to install volcano scheduler in your cluster first as a secondary scheduler of Kubernetes and
 configure operator to select the scheduler name for gang-scheduling in the following:
 
+- training-operator
+
 ```diff
 ...
     spec:
@@ -84,6 +118,21 @@ configure operator to select the scheduler name for gang-scheduling in the follo
 +           - --gang-scheduler-name=volcano
           image: kubeflow/training-operator
           name: training-operator
+...
+```
+
+- mpi-operator
+
+```diff
+...
+    spec:
+      containers:
+      - args:
++       - --gang-scheduling=volcano
+        - -alsologtostderr
+        - --lock-namespace=mpi-operator
+        image: mpioperator/mpi-operator:0.4.0
+        name: mpi-operator
 ...
 ```
 

--- a/content/en/docs/components/training/mpi.md
+++ b/content/en/docs/components/training/mpi.md
@@ -66,13 +66,13 @@ kubectl kustomize base | kubectl apply -f -
 You can create an MPI job by defining an `MPIJob` config file. See [TensorFlow benchmark example](https://github.com/kubeflow/mpi-operator/blob/master/examples/v2beta1/tensorflow-benchmarks.yaml) config file for launching a multi-node TensorFlow benchmark training job. You may change the config file based on your requirements.
 
 ```
-cat examples/v2beta1/tensorflow-benchmarks.yaml
+cat examples/v2beta1/tensorflow-benchmarks/tensorflow-benchmarks.yaml
 ```
 
 Deploy the `MPIJob` resource to start training:
 
 ```
-kubectl apply -f examples/v2beta1/tensorflow-benchmarks.yaml
+kubectl apply -f examples/v2beta1/tensorflow-benchmarks/tensorflow-benchmarks.yaml
 ```
 
 ## Monitoring an MPI Job

--- a/content/en/docs/components/training/mpi.md
+++ b/content/en/docs/components/training/mpi.md
@@ -75,6 +75,38 @@ Deploy the `MPIJob` resource to start training:
 kubectl apply -f examples/v2beta1/tensorflow-benchmarks/tensorflow-benchmarks.yaml
 ```
 
+## Scheduling Policy
+The MPI Operator supports the [gang-scheduling](/docs/components/training/job-scheduling#running-jobs-with-gang-scheduling).
+If you want to modify the PodGroup parameters, you can configure in the following:  
+
+```diff
+apiVersion: kubeflow.org/v2beta1
+kind: MPIJob
+metadata:
+  name: tensorflow-benchmarks
+spec:
+  slotsPerWorker: 1
+  runPolicy:
+    cleanPodPolicy: Running
++   schedulingPolicy:
++     minAvailable: 10
++     queue: test-queue
++     minResources:
++       requests:
++         cpu: 3000m
++     priorityClass: high
+  mpiReplicaSpecs:
+...
+```
+
+In addition, those fields are passed to the PodGroup for the volcano according to the following: 
+
+- `.spec.runPolicy.schedulingPolicy.minAvailable` defines the minimal number of members to run the PodGroup and is passed to `.spec.mimMember`.
+When using this field, you must ensure the application supports resizing (e.g., Elastic Horovod). If not set, it defaults to the number of workers.
+- `.spec.runPolicy.schedulingPolicy.queue` defines the queue name to allocate resource for the PodGroup and is passed to `.spec.queue`.
+- `.spec.runPolicy.schedulingPolicy.minResources` defines the minimal resources of members to run the PodGroup and is passed to `.spec.mimResources`.
+- `.spec.runPolicy.schedulingPolicy.priorityClass` defines the PodGroup's PriorityClass and is passed to `.spec.priorityClassName`.
+
 ## Monitoring an MPI Job
 
 Once the `MPIJob` resource is created, you should now be able to see the created pods matching the specified number of GPUs. You can also monitor the job status from the status section. Here is sample output when the job is successfully completed.


### PR DESCRIPTION
Since https://github.com/kubeflow/mpi-operator/pull/520, we introduce the schedulingPolicy to mpi-operator.
So I added docs for that.

/assign @alculquicondor 
/hold for https://github.com/kubeflow/mpi-operator/pull/520.
