### PR TITLE
docs: bump Charmed Kubeflow supported version 1.6.1->1.7.0

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -164,7 +164,7 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
           <a href="https://charmed-kubeflow.io/">Website</a>
         </td>
         <td>
-          1.6.1
+          1.7.0
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Update Canonical's Charmed Kubeflow supported version.

cc: @DomFleischmann 