### PR TITLE
Update Release Video in 1.7 Release Page

### DIFF
--- a/content/en/docs/releases/kubeflow-1.7.md
+++ b/content/en/docs/releases/kubeflow-1.7.md
@@ -22,7 +22,7 @@ weight = 97
           <a href="https://blog.kubeflow.org/kubeflow-1.7-release/">Kubeflow 1.7 Release Announcement</a>
         <br>
         <b>Video:</b> 
-          <a href="TBD">Kubeflow 1.7 Release Overview</a>
+          <a href="https://www.youtube.com/watch?v=CUQT-YccpR8">Kubeflow 1.7 Release Overview</a>
         <br>
         <b>Roadmap:</b>
           <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-17-release-planned-march-2023">Kubeflow 1.7 Features</a>


### PR DESCRIPTION
Given that the release happened before the Presentation Video was finished we had a placeholder URL in the Release Page. This is now updated with the correct link.