### PR TITLE
add deployKF to list of distributions

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -167,7 +167,7 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
       </tr>
       <tr>
         <td>deployKF</td>
-        <td>deployKF</td>
+        <td>Aranui Solutions</td>
         <td>All Conformant Kubernetes</td>
         <td>
           <a href="https://www.deploykf.org/">Website</a>

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -166,6 +166,17 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
         </td>
       </tr>
       <tr>
+        <td>deployKF</td>
+        <td>deployKF</td>
+        <td>All Conformant Kubernetes</td>
+        <td>
+          <a href="https://www.deploykf.org/">Website</a>
+        </td>
+        <td>
+          1.7.0 <sup>[<a href="https://www.deploykf.org/releases/version-matrix/#kubeflow-tools">Version Matrix</a>]</sup>
+        </td>
+      </tr>
+      <tr>
         <td>Kubeflow on Oracle Container Engine for Kubernetes</td>
         <td>Oracle</td>
         <td>


### PR DESCRIPTION
This PR adds deployKF, to the list of distributions:

- https://www.deploykf.org/
- https://github.com/deployKF/deployKF

I have positioned it alphabetically in this list (after the top section of major cloud providers).