### PR TITLE
remove arrikto kubeflow as a service (dead link)

### DIFF
--- a/content/en/docs/distributions/kfaas/_index.md
+++ b/content/en/docs/distributions/kfaas/_index.md
@@ -1,7 +1,0 @@
-+++
-title = "Arrikto Kubeflow as a Service"
-description = "Kubeflow as a Service makes it easy for everyone to develop and serve models with the click of a button."
-weight = 50
-+++
-
-To get started go to https://kubeflow.arrikto.com/

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -109,20 +109,8 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
         </td>
       </tr>
       <tr>
-        <td>Arrikto Kubeflow as a Service</td>
-        <td rowspan="2">Arrikto</td>
-        <td>
-          N/A <sup>(fully managed)</sup>
-        </td>
-        <td>
-          <a href="https://www.arrikto.com/kubeflow-as-a-service/">Website</a>
-        </td>
-        <td>
-          1.5.0
-        </td>
-      </tr>
-      <tr>
         <td>Arrikto Enterprise Kubeflow</td>
+        <td>Arrikto</td>
         <td>
           ◦ Amazon Elastic Kubernetes Service (EKS)
           <br>


### PR DESCRIPTION
As raised in https://github.com/kubeflow/website/issues/3519, it seems like `"Arrikto Kubeflow as a Service"` no longer exists.

The following links which were provided in the docs are dead:
- https://kubeflow.arrikto.com/
- https://www.arrikto.com/kubeflow-as-a-service/

Therefore, I vote we should remove them from the website.

__NOTE:__ I have left `"Arrikto Enterprise Kubeflow"` up, but I suspect it no longer meets the definition of "active" given its [last release was Kubeflow 1.5, and happened in March 2023](https://docs.arrikto.com/NEWS.html#version-2-0-2-aurora)