### PR TITLE
remove kale docs (project is abandoned)

### DIFF
--- a/content/en/docs/external-add-ons/kale/_index.md
+++ b/content/en/docs/external-add-ons/kale/_index.md
@@ -1,9 +1,0 @@
-+++
-title = "Kale"
-description = "Kale enables data scientists to orchestrate end-to-end machine learning (ML) workflows."
-weight = 30
-+++
-
-Kale simplifies the use of Kubeflow, giving data scientists the tool they need to orchestrate end-to-end ML workflows. Kale provides a UI in the form of a JupyterLab extension. You can annotate cells in Jupyter Notebooks to define: pipeline steps, hyperparameter tuning, GPU usage, and metrics tracking. Click a button to create pipeline components and KFP DSL, resolve dependencies, inject data objects into each step, deploy the data science pipeline, and serve the best model.
-
-See <a href="https://codelabs.arrikto.com/codelabs/minikf-kale-katib-kfserving/#0" target="_blank">From Notebook to Kubeflow Pipelines to KFServing</a> for a tutorial overview of Kale.


### PR DESCRIPTION
The kale project has not been updated since [`Oct 20, 2021`](https://github.com/kubeflow-kale/kale/commits/master), therefore I think we can treat it as abandoned and remove it from the Kubeflow website.

Also, there are many issues on the `kubeflow-kale/kale` repo discussing that the project is no longer maintained:

- https://github.com/kubeflow-kale/kale/issues/436
- https://github.com/kubeflow-kale/kale/issues/395