### PR TITLE
move istio docs from `external-addons` to `multi-tenancy` component

### DIFF
--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -186,7 +186,6 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/started/kubeflow-overview  /docs/started/architecture
 
 # move istio from external-add-ons to multi-tenancy component
-/docs/external-add-ons/istio/     /docs/components/multi-tenancy/istio
 /docs/external-add-ons/istio/*    /docs/components/multi-tenancy/istio
 
 # ===============

--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -185,6 +185,9 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/about/kubeflow             /docs/started/introduction
 /docs/started/kubeflow-overview  /docs/started/architecture
 
+# move istio from external-add-ons to multi-tenancy component
+/docs/external-add-ons/istio/*    /docs/components/multi-tenancy/istio
+
 # ===============
 # IMPORTANT NOTE:
 # Catch-all redirects should be added at the end of this file as redirects happen from top to bottom

--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -186,6 +186,7 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/started/kubeflow-overview  /docs/started/architecture
 
 # move istio from external-add-ons to multi-tenancy component
+/docs/external-add-ons/istio/     /docs/components/multi-tenancy/istio
 /docs/external-add-ons/istio/*    /docs/components/multi-tenancy/istio
 
 # ===============

--- a/content/en/docs/components/multi-tenancy/istio.md
+++ b/content/en/docs/components/multi-tenancy/istio.md
@@ -4,10 +4,6 @@ description = "Managing access to Kubeflow applications and resources via Istio"
 weight = 50
                     
 +++
-{{% alert title="Out of date" color="warning" %}}
-This guide contains outdated information pertaining to Kubeflow 1.0. This guide
-needs to be updated for Kubeflow 1.1.
-{{% /alert %}}
 
 Kubeflow v0.6 onwards deploys Istio along with configuration to enable
 end-to-end authentication and access control. This setup is the foundation

--- a/content/en/docs/external-add-ons/istio/OWNERS
+++ b/content/en/docs/external-add-ons/istio/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-    - PatrickXYS
-reviewers:
-    - yanniszark

--- a/content/en/docs/external-add-ons/istio/_index.md
+++ b/content/en/docs/external-add-ons/istio/_index.md
@@ -1,5 +1,0 @@
-+++
-title = "Istio"
-description = "Documentation on Istio component in Kubeflow"
-weight = 30
-+++


### PR DESCRIPTION
This PR moves the `istio` docs from `external-addons` to the `multi-tenancy` component section.

This is a better location for these docs as istio is clearly not an external addon for Kubeflow, but is part of the multi-user feature.