### PR TITLE
add docs for "kubeflow arena" component

### DIFF
--- a/content/en/docs/components/arena/OWNERS
+++ b/content/en/docs/components/arena/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - cheyang
+  - wsxiaozhang
+  - denverdino
+  - happy2048

--- a/content/en/docs/components/arena/_index.md
+++ b/content/en/docs/components/arena/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Kubeflow Arena"
+description = "Documentation for Kubeflow Arena"
+weight = 70
++++
+
+Kubeflow Arena is a command-line interface for data scientists to run and monitor machine learning training jobs and check their results in an easy way. 
+
+For more information, see the [Kubeflow Arena documentation](https://arena-docs.readthedocs.io/en/latest/), or the [Kubeflow Arena GitHub repository](https://github.com/kubeflow/arena).


### PR DESCRIPTION
To be honest, I was not aware of Arena until recently, but as it is developed in the Kubeflow GitHub org, it deserves a place on the website.

I have used the [same OWNERS as the `kubeflow/arena` repository](https://github.com/kubeflow/arena/blob/master/OWNERS).
