### PR TITLE
update root OWNERS (remove inactive, add @thesuperzapper)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,18 +1,10 @@
 approvers:
-  - animeshsingh
   - chensun
   - james-jwu
-  - knkski
-  - shannonbradshaw
+  - thesuperzapper
   - zijianjoy
 reviewers:
-  - 8bitmp3
-  - aronchick
-  - berndverst
-  - dansanche
-  - dsdinter
-  - Jeffwan
-  - jinchihe
-  - nickchase
-  - pdmack
-  - terrytangyuan
+  - chensun
+  - james-jwu
+  - thesuperzapper
+  - zijianjoy


### PR DESCRIPTION
This PR updates the root OWNERS to reflect the currently active and highly trusted maintainers of the website.

#### Regarding the `approvers`, the following actions are taken:

- Remove anyone who has not approved a PR in many years (or who has publicly left the project)
- Adds @thesuperzapper:
    -  _(NOTE: if adding me is too controversial with the remaining approvers, I am happy to make a separate PR for further discussion)_
- This leaves the following members:
    - @chensun
    - @james-jwu
    - @thesuperzapper
    - @zijianjoy

#### Regarding the `reviewers`, the following actions are taken:

- Aligns them exactly with the `approvers`:
    - This is NOT a reflection on anyone who was removed, it's just that there is no practical reason to have root `reviewers` who are separate from the `approvers`.
    - This ensures PRs that make changes to something that ONLY a root approver can approve are automatically assigned to the root approvers for review. 
    - _(NOTE: root `reviewers` are only assigned by the bot when a file does not have a more specific OWNER reviewer)_