### PR TITLE
move "Arrikto Enterprise Kubeflow" to legacy distributions

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -109,23 +109,6 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
         </td>
       </tr>
       <tr>
-        <td>Arrikto Enterprise Kubeflow</td>
-        <td>Arrikto</td>
-        <td>
-          ◦ Amazon Elastic Kubernetes Service (EKS)
-          <br>
-          ◦ Azure Kubernetes Service (AKS)
-          <br>
-          ◦ Google Kubernetes Engine (GKE)
-        </td>
-        <td>
-          <a href="https://www.arrikto.com/enterprise-kubeflow/">Website</a>
-        </td>
-        <td>
-          1.5.0 <sup>[<a href="https://docs.arrikto.com/Changelog.html">Release Notes</a>]</sup>
-        </td>
-      </tr>
-      <tr>
         <td>Charmed Kubeflow</td>
         <td>Canonical</td>
         <td>
@@ -217,6 +200,23 @@ The following table lists <b>legacy distributions</b> which have <b>not had a re
         </td>
         <td>
           1.6.0
+        </td>
+      </tr>
+      <tr>
+        <td>Arrikto Enterprise Kubeflow</td>
+        <td>Arrikto</td>
+        <td>
+          ◦ Amazon Elastic Kubernetes Service (EKS)
+          <br>
+          ◦ Azure Kubernetes Service (AKS)
+          <br>
+          ◦ Google Kubernetes Engine (GKE)
+        </td>
+        <td>
+          <a href="https://www.arrikto.com/enterprise-kubeflow/">Website</a>
+        </td>
+        <td>
+          1.5.0 <sup>[<a href="https://docs.arrikto.com/Changelog.html">Release Notes</a>]</sup>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
This PR moves "Arrikto Enterprise Kubeflow" to the legacy distributions section.

While it has not technically been 6 months of inactivity (only about 4, since the [last release on `2023-03-31`](https://docs.arrikto.com/Changelog.html#version-2-0-2-aurora)), as the most recent version only included Kubeflow 1.5.0 (which was released on `2022-06-15`), I think its fair to say this distribution is no longer active.

I am sad to have to do this.