### PR TITLE
fix(pipelines): Update .output['output-key'] to plural

### DIFF
--- a/content/en/docs/components/pipelines/v2/data-types/parameters.md
+++ b/content/en/docs/components/pipelines/v2/data-types/parameters.md
@@ -147,7 +147,7 @@ def my_pipeline() -> int:
 See [Container Components: Create component outputs][container-component-outputs] for more information on how to use `dsl.OutputPath`
 
 ### Multiple output parameters
-You can specify multiple named output parameters using a [`typing.NamedTuple`][typing-namedtuple]. You can access a named output using `.output['<output-key>']` on [`PipelineTask`][pipelinetask]:
+You can specify multiple named output parameters using a [`typing.NamedTuple`][typing-namedtuple]. You can access a named output using `.outputs['<output-key>']` on [`PipelineTask`][pipelinetask]:
 
 ```python
 from kfp import dsl

--- a/content/en/docs/components/pipelines/v2/pipelines/pipeline-basics.md
+++ b/content/en/docs/components/pipelines/v2/pipelines/pipeline-basics.md
@@ -81,7 +81,7 @@ When you call a component in a pipeline definition, it constructs a [`PipelineTa
 
 For a task with a single unnamed output indicated by a single return annotation, access the output using `PipelineTask.output`. This the case for the components `square`, `add`, and `square_root`, which each have one unnamed output.
 
-For tasks with multiple outputs or named outputs, access the output using `PipelineTask.output['<output-key>']`. Using named output parameters is described in more detail in [Data Types: Parameters][parameters-namedtuple].
+For tasks with multiple outputs or named outputs, access the output using `PipelineTask.outputs['<output-key>']`. Using named output parameters is described in more detail in [Data Types: Parameters][parameters-namedtuple].
 
 In the absence of data exchange, tasks will run in parallel for efficient pipeline executions. This is the case for `a_sq_task` and `b_sq_task` which do not exchange data.
 


### PR DESCRIPTION
.output['<output-key>'] should be .outputs['<output-key>'] (plural) instead in case of multiple outputs.