### PR TITLE
PaddlePaddle Istio Sidecar Injection Note

### DIFF
--- a/content/en/docs/components/training/paddlepaddle.md
+++ b/content/en/docs/components/training/paddlepaddle.md
@@ -9,10 +9,14 @@ weight = 15
 
 This page describes `PaddleJob` for training a machine learning model with [PaddlePaddle](https://www.paddlepaddle.org.cn/).
 
+## What is PaddleJob?
+
 `PaddleJob` is a Kubernetes
 [custom resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 to run PaddlePaddle training jobs on Kubernetes. The Kubeflow implementation of
 `PaddleJob` is in [`training-operator`](https://github.com/kubeflow/training-operator).
+
+**Note**: `PaddleJob` doesn't work in a user namespace by default because of Istio [automatic sidecar injection](https://istio.io/v1.3/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection). To resolve this,  use the annotation `sidecar.istio.io/inject: "false"` to disable sidecar injection for `PaddleJob` pods.
 
 ## Installing Paddle Operator
 


### PR DESCRIPTION
Added a note to `PaddleJob` about disabling Istio sidecar injection similar to the note in [TFJob](https://www.kubeflow.org/docs/components/training/tftraining/).

More info in Charmed Kubeflow: [Paddle Paddle does not work in user namespace](https://github.com/canonical/bundle-kubeflow/issues/610).