### PR TITLE
Link to RStudio

### DIFF
--- a/content/en/docs/components/notebooks/overview.md
+++ b/content/en/docs/components/notebooks/overview.md
@@ -11,7 +11,7 @@ weight = 5
 Kubeflow Notebooks provides a way to run web-based development environments inside your Kubernetes cluster by running them inside Pods.
 
 Some key features include:
-- Native support for [JupyterLab](https://github.com/jupyterlab/jupyterlab), [RStudio](https://github.com/jupyterlab/jupyterlab), and [Visual Studio Code (code-server)](https://github.com/cdr/code-server).
+- Native support for [JupyterLab](https://github.com/jupyterlab/jupyterlab), [RStudio](https://github.com/rstudio/rstudio), and [Visual Studio Code (code-server)](https://github.com/cdr/code-server).
 - Users can create notebook containers directly in the cluster, rather than locally on their workstations.
 - Admins can provide standard notebook images for their organization with required packages pre-installed.
 - Access control is managed by Kubeflow's RBAC, enabling easier notebook sharing across the organization.


### PR DESCRIPTION
Make RStudio link point to https://github.com/rstudio/rstudio (instead of https://github.com/jupyterlab/jupyterlab) for consistency with:
https://github.com/kubeflow/website/blob/f88fcc0ac728873b561fa510c8d80b7d8a87b48d/content/en/docs/components/notebooks/container-images.md?plain=1#L7