### PR TITLE
docs: Add missing --user option

### DIFF
--- a/content/en/docs/components/pipelines/v1/sdk/install-sdk.md
+++ b/content/en/docs/components/pipelines/v1/sdk/install-sdk.md
@@ -91,7 +91,7 @@ Consider using the `--user` option or check the permissions.
 If you get this error, install `kfp` with the `--user` option:
 
 ```bash
-pip install kfp==1.8
+pip install --user kfp==1.8
 ```
 
 This command installs the `dsl-compile` and `kfp` binaries under `~/.local/bin`, which is not part of the PATH in some Linux distributions, such as Ubuntu. You can add `~/.local/bin` to your PATH by appending the following to a new line at the end of your `.bashrc` file:


### PR DESCRIPTION
This is a pull request about the "Install the Kubeflow Pipelines SDK" section of the document "Install the Kubeflow Pipelines SDK".
https://www.kubeflow.org/docs/components/pipelines/v1/sdk/install-sdk/#install-the-kubeflow-pipelines-sdk

It states to "install kfp with the --user option," but I noticed that the `--user` option is missing.

<img width="792" alt="image" src="https://github.com/kubeflow/website/assets/21273221/ff5065cd-6e7b-47c2-aed4-e258acef9886">

I will send a pull request to add this.
