### PR TITLE
Fix broken page-meta links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -130,7 +130,7 @@ enable = true
 
   # A variable used in various docs to determine URLs for config files etc.
   # To find occurrences, search the repo for 'params "githubbranch"'.
-  githubbranch = "master"
+  github_branch = "master"
 
   # These entries appear in the drop-down menu at the top of the website.
   [[params.versions]]


### PR DESCRIPTION
- Fixes broken doc page meta (GitHub) links
- Fixes https://github.com/google/docsy/issues/138, which reported the issue originally

---

### Before

- On desktop, visit https://www.kubeflow.org/docs/
- Click on **View page source**
- You'll be sent to https://github.com/kubeflow/website/tree/main/content/en/docs/_index.md, which is a 404 because the default branch isn't `main`

### After

- On desktop, visit https://deploy-preview-3625--competent-brattain-de2d6d.netlify.app/docs/
- Click on **View page source**
- You'll be sent to https://github.com/kubeflow/website/tree/master/content/en/docs/_index.md, which is a valid page

/cc @sarahmaddox @LisaFC