### PR TITLE
Update GCP deployment version to v1.8 in Installing Kubeflow page 

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -79,7 +79,7 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
           <a href="https://googlecloudplatform.github.io/kubeflow-gke-docs">Website</a>
         </td>
         <td>
-          1.7.0 <sup>[<a href="https://googlecloudplatform.github.io/kubeflow-gke-docs/docs/changelog/#170">Release Notes</a>]</sup>
+          1.8.0 <sup>[<a href="https://googlecloudplatform.github.io/kubeflow-gke-docs/docs/changelog/#180">Release Notes</a>]</sup>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Follow up on https://github.com/kubeflow/website/pull/3619#issuecomment-1804605803