### PR TITLE
move `Kubeflow on AWS` to legacy distributions

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -43,19 +43,6 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
     </thead>
     <tbody>
       <tr>
-        <td>Kubeflow on AWS</td>
-        <td>Amazon Web Services</td>
-        <td>
-          Amazon Elastic Kubernetes Service (EKS)
-        </td>
-        <td>
-          <a href="https://awslabs.github.io/kubeflow-manifests">Website</a>
-        </td>
-        <td>
-          {{% aws/latest-version %}} <sup>[<a href="https://github.com/awslabs/kubeflow-manifests/releases">Release Notes</a>]</sup>
-        </td>
-      </tr>
-      <tr>
         <td>Kubeflow on Azure</td>
         <td>Microsoft Azure</td> 
         <td>
@@ -219,6 +206,19 @@ The following table lists <b>legacy distributions</b> which have <b>not had a re
         </td>
         <td>
           1.5.0 <sup>[<a href="https://docs.arrikto.com/Changelog.html">Release Notes</a>]</sup>
+        </td>
+      </tr>
+      <tr>
+        <td>Kubeflow on AWS</td>
+        <td>Amazon Web Services</td>
+        <td>
+          Amazon Elastic Kubernetes Service (EKS)
+        </td>
+        <td>
+          <a href="https://awslabs.github.io/kubeflow-manifests">Website</a>
+        </td>
+        <td>
+          {{% aws/latest-version %}} <sup>[<a href="https://github.com/awslabs/kubeflow-manifests/releases">Release Notes</a>]</sup>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
As indicated by AWS in this thread https://github.com/awslabs/kubeflow-manifests/issues/794, the `Kubeflow on AWS` distribution is no longer actively maintained.

This PR updates the "installing kubeflow" table to reflect this fact.