### PR TITLE
Updated link to Kubeflow 1.8 Release Overview video

### DIFF
--- a/content/en/docs/releases/kubeflow-1.8.md
+++ b/content/en/docs/releases/kubeflow-1.8.md
@@ -22,7 +22,7 @@ weight = 96
           <a href="https://blog.kubeflow.org/kubeflow-1.8-release/">Kubeflow 1.8 Release Announcement</a>
         <br>
         <b>Video:</b> 
-          <a>Kubeflow 1.8 Release Overview (TBA)</a>
+          <a href="https://www.youtube.com/watch?v=eUX9edNwYao">Kubeflow 1.8 Release Overview</a>
         <br>
         <b>Roadmap:</b>
           <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-18-release-planned-for-release-oct-2023">Kubeflow 1.8 Features</a>


### PR DESCRIPTION
This just updates the release page to the video,

I would like to ask if they can rebase the tag v1.8-release branch to this commit, and recreate the tag release, so we can have a new page.