### PR TITLE
add "distribution name" notice on "installing kubeflow" + style improvements

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -286,6 +286,18 @@ footer {
 }
 
 // --------------------------------------------------
+// Installing Kubeflow page
+// --------------------------------------------------
+.distributions-table-active thead {
+  background-color: $primary;
+  color: $secondary;
+}
+
+.distributions-table-legacy thead {
+  background-color: $info;
+}
+
+// --------------------------------------------------
 // 404 page
 // --------------------------------------------------
 .error-page {

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,20 +5,26 @@ weight = 20
 
 +++
 
+### What is Kubeflow?
+
 Kubeflow is an end-to-end Machine Learning (ML) platform for Kubernetes, it provides components for each stage in the ML lifecycle, from exploration through to training and deployment.
 Operators can choose what is best for their users, there is no requirement to deploy every component.
-To read more about the components and architecture of Kubeflow, please see the <a href="/docs/started/architecture/">Kubeflow Architecture</a> page.
+
+Learn more about Kubeflow on the [Introduction](/docs/started/introduction/) and [Architecture](/docs/started/architecture/) pages.
 
 ### How to install Kubeflow?
 
-There are two pathways to get up and running with Kubeflow, you may either:
+Anywhere you are running Kubernetes, you should be able to run Kubeflow.
+There are two primary ways to install Kubeflow:
 
-1. [Use a packaged distribution](#packaged-distributions-of-kubeflow)
-2. [Use the raw manifests](#raw-kubeflow-manifests) <sup>(for advanced users)</sup>
+1. [__Packaged Distributions__](#packaged-distributions-of-kubeflow) <sup>(recommended)</sup>
+2. [__Raw Manifests__](#raw-kubeflow-manifests) <sup>(advanced users)</sup>
 
 <a id="packaged-distributions"></a>
 <a id="install-a-packaged-kubeflow-distribution"></a>
 ## Packaged Distributions of Kubeflow 
+
+Packaged distributions are maintained by various organizations and typically aim to provide a simplified installation and management experience for Kubeflow.
 
 {{% alert title="Conformance and Certification" color="warning" %}}
 Packaged distributions are developed and supported by their respective maintainers.
@@ -28,7 +34,7 @@ In the near future, there are plans to introduce <a href="https://github.com/kub
 {{% /alert %}}
 
 {{% alert title="Distribution Names" color="info" %}}
-Some distributions have names like `Kubeflow on <PLATFORM>`.
+Some packaged distributions have names like `Kubeflow on <PLATFORM>`.
 Please note, they are __not__ the only way to use Kubeflow on that platform, it is simply the name of a distribution.
 
 There are discussions about renaming these distributions to avoid confusion with others that may be available on the same platform.
@@ -36,7 +42,7 @@ There are discussions about renaming these distributions to avoid confusion with
 
 ### Active Distributions
 
-The following table lists <strong>active distributions</strong> that are <em>currently maintained</em> by their respective maintainers.
+The following table lists <strong>active distributions</strong> which are <em>currently maintained</em> by their respective maintainers.
 
 <div class="table-responsive distributions-table-active">
   <table class="table table-bordered">
@@ -236,15 +242,24 @@ The following table lists <strong>legacy distributions</strong> which have <em>n
 <a id="install-the-kubeflow-manifests-manually"></a>
 ## Raw Kubeflow Manifests
 
+The raw Kubeflow Manifests are aggregated by the [Manifests Working Group](https://github.com/kubeflow/community/tree/master/wg-manifests)
+and are intended to be used as the __base of packaged distributions__.
+
+Very advanced users may choose to install the manifests for a specific Kubeflow version by following the instructions in the `README` in the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.
+
+- [__Kubeflow 1.8:__](/docs/releases/kubeflow-1.8/)
+   - [`v1.8-branch`](https://github.com/kubeflow/manifests/tree/v1.8-branch#installation) <sup>(development branch)</sup>
+   - [`v1.8.0`](https://github.com/kubeflow/manifests/tree/v1.8.0#installation)
+- [__Kubeflow 1.7:__](/docs/releases/kubeflow-1.7/)
+   - [`v1.7-branch`](https://github.com/kubeflow/manifests/tree/v1.7-branch#installation) <sup>(development branch)</sup>
+   - [`v1.7.0`](https://github.com/kubeflow/manifests/tree/v1.7.0#installation)
+
 {{% alert title="Warning" color="warning" %}}
-This method is for advanced users.
-The Kubeflow community is not able to provide support for environment-specific issues when using the raw manifests.
+Kubeflow is a complex system with many components and dependencies, using the raw manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
+
+When using the raw manifests, the Kubeflow community is not able to provide support for environment-specific issues or custom configurations.
 If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
 {{% /alert %}}
-
-The raw <a href="https://github.com/kubeflow/manifests"><code>kubeflow/manifests</code></a> are aggregated by the <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Manifests Working Group</a> 
-and are intended to be used as the <strong>base of packaged distributions</strong>.
-However, advanced users that are willing to make manual patches may choose to install the manifests directly by following <a href="https://github.com/kubeflow/manifests#installation">these instructions</a>.
 
 <a id="next-steps"></a>
 ## Next steps

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -29,7 +29,7 @@ In the near future, there are plans to introduce <a href="https://github.com/kub
 
 {{% alert title="Distribution Names" color="info" %}}
 Some distributions have names like `Kubeflow on <PLATFORM>`.
-Please note, they are not the "official installation method" for Kubeflow on that platform, it is simply the name of a distribution.
+Please note, they are __not__ the only way to use Kubeflow on that platform, it is simply the name of a distribution.
 
 There are discussions about renaming these distributions to avoid confusion with others that may be available on the same platform.
 {{% /alert %}}

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -20,19 +20,27 @@ There are two pathways to get up and running with Kubeflow, you may either:
 <a id="install-a-packaged-kubeflow-distribution"></a>
 ## Packaged Distributions of Kubeflow 
 
-{{% alert title="Note" color="warning" %}}
-Packaged distributions are developed and supported by their respective maintainers, <b>the Kubeflow community does not endorse or certify any specific distribution</b>.
+{{% alert title="Conformance and Certification" color="warning" %}}
+Packaged distributions are developed and supported by their respective maintainers.
+The Kubeflow community <strong>does not endorse or certify</strong> any specific distribution.
 
 In the near future, there are plans to introduce <a href="https://github.com/kubeflow/community/blob/master/proposals/kubeflow-conformance-program-proposal.md">conformance testing for distributions</a>, you may track progress on this initiative by following <a href="https://github.com/kubeflow/kubeflow/issues/6485">kubeflow/kubeflow#6485</a>.
 {{% /alert %}}
 
+{{% alert title="Distribution Names" color="info" %}}
+Some distributions have names like `Kubeflow on <PLATFORM>`.
+Please note, they are not the "official installation method" for Kubeflow on that platform, it is simply the name of a distribution.
+
+There are discussions about renaming these distributions to avoid confusion with others that may be available on the same platform.
+{{% /alert %}}
+
 ### Active Distributions
 
-The following table lists <b>active distributions</b> that have <b>had a recent release</b> (within the last 6 months).
+The following table lists <strong>active distributions</strong> that are <em>currently maintained</em> by their respective maintainers.
 
-<div class="table-responsive">
+<div class="table-responsive distributions-table-active">
   <table class="table table-bordered">
-    <thead class="thead-light">
+    <thead>
       <tr>
         <th>Name</th>
         <th>Maintainer</th>
@@ -68,7 +76,6 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
           1.7.0 <sup>[<a href="https://github.com/Azure/kubeflow-aks/releases/tag/v1.7.0">Release Notes</a>]</sup>
         </td>
       </tr>
-      <tr>
       <tr>
         <td>Kubeflow on Google Cloud</td>
         <td>Google Cloud</td>
@@ -164,11 +171,11 @@ The following table lists <b>active distributions</b> that have <b>had a recent 
 
 ### Legacy Distributions
 
-The following table lists <b>legacy distributions</b> which have <b>not had a recent release</b> (within the last 6 months).
+The following table lists <strong>legacy distributions</strong> which have <em>not had a recent release</em> (within the last 6 months), or whose maintainers have indicated that they are <em>no longer actively maintaining the distribution</em>.
 
-<div class="table-responsive">
+<div class="table-responsive distributions-table-legacy">
   <table class="table table-bordered">
-    <thead class="thead-light">
+    <thead>
       <tr>
         <th>Name</th>
         <th>Maintainer</th>
@@ -231,14 +238,13 @@ The following table lists <b>legacy distributions</b> which have <b>not had a re
 
 {{% alert title="Warning" color="warning" %}}
 This method is for advanced users.
-
 The Kubeflow community is not able to provide support for environment-specific issues when using the raw manifests.
 If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
 {{% /alert %}}
 
-The raw <a href="https://github.com/kubeflow/manifests">Kubeflow manifests</a> are aggregated by the <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Manifests Working Group</a> 
-and are intended to be used as the base of packaged distributions,
-<b>advanced users may choose to install the manifests directly</b> by following <a href="https://github.com/kubeflow/manifests#installation">these instructions</a>.
+The raw <a href="https://github.com/kubeflow/manifests"><code>kubeflow/manifests</code></a> are aggregated by the <a href="https://github.com/kubeflow/community/tree/master/wg-manifests">Manifests Working Group</a> 
+and are intended to be used as the <strong>base of packaged distributions</strong>.
+However, advanced users that are willing to make manual patches may choose to install the manifests directly by following <a href="https://github.com/kubeflow/manifests#installation">these instructions</a>.
 
 <a id="next-steps"></a>
 ## Next steps

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -245,7 +245,7 @@ The following table lists <strong>legacy distributions</strong> which have <em>n
 The raw Kubeflow Manifests are aggregated by the [Manifests Working Group](https://github.com/kubeflow/community/tree/master/wg-manifests)
 and are intended to be used as the __base of packaged distributions__.
 
-Very advanced users may choose to install the manifests for a specific Kubeflow version by following the instructions in the `README` in the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.
+Very advanced users may choose to install the manifests for a specific Kubeflow version by following the instructions in the `README` of the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.
 
 - [__Kubeflow 1.8:__](/docs/releases/kubeflow-1.8/)
    - [`v1.8-branch`](https://github.com/kubeflow/manifests/tree/v1.8-branch#installation) <sup>(development branch)</sup>

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -17,7 +17,7 @@ Learn more about Kubeflow on the [Introduction](/docs/started/introduction/) and
 Anywhere you are running Kubernetes, you should be able to run Kubeflow.
 There are two primary ways to install Kubeflow:
 
-1. [__Packaged Distributions__](#packaged-distributions-of-kubeflow) <sup>(recommended)</sup>
+1. [__Packaged Distributions__](#packaged-distributions-of-kubeflow)
 2. [__Raw Manifests__](#raw-kubeflow-manifests) <sup>(advanced users)</sup>
 
 <a id="packaged-distributions"></a>
@@ -255,7 +255,8 @@ Very advanced users may choose to install the manifests for a specific Kubeflow 
    - [`v1.7.0`](https://github.com/kubeflow/manifests/tree/v1.7.0#installation)
 
 {{% alert title="Warning" color="warning" %}}
-Kubeflow is a complex system with many components and dependencies, using the raw manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
+Kubeflow is a complex system with many components and dependencies.
+Using the raw manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
 
 When using the raw manifests, the Kubeflow community is not able to provide support for environment-specific issues or custom configurations.
 If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).


### PR DESCRIPTION
The changes in this PR:
- The main purpose of this PR is to add a warning that says `Kubeflow on <PLATFORM>` is just name, and not the only way to install Kubeflow on that platform.
- We also update the "header colors" of the tables, to look nicer.
- We also update the text above each table to be more correct.
- We also updated the text for the "raw manifests", to better explain that using them requires "manual patches of YAML".


After we merge this, we need to move the `Kubeflow on AWS` distribution to the legacy distribution table, there is an existing PR to do this: 
- https://github.com/kubeflow/website/pull/3641


## Screenshot

![Installing-Kubeflow-Kubeflow](https://github.com/kubeflow/website/assets/5735406/90b5ec83-adf8-48f8-8917-a194fd9f8757)


