### PR TITLE
Updated contributors table link

### DIFF
--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -44,7 +44,7 @@ There are a number of ways to contribute to Kubeflow:
 - File issues reporting bugs or providing feedback
 - Answer questions on Slack or GitHub issues
 
-You can use this [table](http://devstats.kubeflow.org/d/9/developers-summary) to see how many contributions you've made.
+You can use this [table](https://kubeflow.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1) to see how many contributions you've made.
 
 - **Note**: This only counts GitHub related ways of contributing
 


### PR DESCRIPTION
This PR updates the contributors table link.
Fixes https://github.com/kubeflow/website/issues/3732.