### PR TITLE
Katib: Add SKIP_DB_INITIALIZATION variable of Katib DB Manager

### DIFF
--- a/content/en/docs/components/katib/env-variables.md
+++ b/content/en/docs/components/katib/env-variables.md
@@ -194,6 +194,12 @@ deployment:
         <td>katib</td>
         <td>No</td>
       </tr>
+      <tr>
+        <td><code>SKIP_DB_INITIALIZATION</code></td>
+        <td>Option to skip DB table initialization</td>
+        <td>false</td>
+        <td>No</td>
+      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
This follow-up PR reflects a change from https://github.com/kubeflow/katib/pull/2245, which introduced a new environment variable option to skip DB initialization when Katib DB manager is run.

It updates **Katib DB Manager** part of [Environment Variables for Katib Components](https://www.kubeflow.org/docs/components/katib/env-variables/#katib-db-manager).

Closes #3656 