### PR TITLE
fix buttons for v1 Pipelines SDK

### DIFF
--- a/content/en/docs/components/pipelines/v1/sdk/build-pipeline.md
+++ b/content/en/docs/components/pipelines/v1/sdk/build-pipeline.md
@@ -455,6 +455,6 @@ client.create_run_from_pipeline_func(
 
 
 <div class="notebook-links">
-<a class="colab-link" href="https://colab.research.google.com/github/kubeflow/website/blob/master/content/en/docs/components/pipelines/sdk/build-pipeline.ipynb">Run in Google Colab</a>
-<a class="github-link" href="https://github.com/kubeflow/website/blob/master/content/en/docs/components/pipelines/sdk/build-pipeline.ipynb">View source on GitHub</a>
+<a class="colab-link" href="https://colab.research.google.com/github/kubeflow/website/blob/master/content/en/docs/components/pipelines/v1/sdk/build-pipeline.ipynb">Run in Google Colab</a>
+<a class="github-link" href="https://github.com/kubeflow/website/blob/master/content/en/docs/components/pipelines/v1/sdk/build-pipeline.ipynb">View source on GitHub</a>
 </div>

--- a/content/en/docs/components/pipelines/v1/sdk/python-function-components.md
+++ b/content/en/docs/components/pipelines/v1/sdk/python-function-components.md
@@ -26,8 +26,8 @@ background-position: left center;
 }
 </style>
 <div class="notebook-links">
-<a class="colab-link" href="https://colab.research.google.com/github/kubeflow/website/blob/master/content/en/docs/components/pipelines/sdk/python-function-components.ipynb">Run in Google Colab</a>
-<a class="github-link" href="https://github.com/kubeflow/website/blob/master/content/en/docs/components/pipelines/sdk/python-function-components.ipynb">View source on GitHub</a>
+<a class="colab-link" href="https://colab.research.google.com/github/kubeflow/website/blob/master/content/en/docs/components/pipelines/v1/sdk/python-function-components.ipynb">Run in Google Colab</a>
+<a class="github-link" href="https://github.com/kubeflow/website/blob/master/content/en/docs/components/pipelines/v1/sdk/python-function-components.ipynb">View source on GitHub</a>
 </div>
 
 
@@ -576,6 +576,6 @@ client.create_run_from_pipeline_func(calc_pipeline, arguments=arguments)
 
 
 <div class="notebook-links">
-<a class="colab-link" href="https://colab.research.google.com/github/kubeflow/website/blob/master/content/en/docs/components/pipelines/sdk/python-function-components.ipynb">Run in Google Colab</a>
-<a class="github-link" href="https://github.com/kubeflow/website/blob/master/content/en/docs/components/pipelines/sdk/python-function-components.ipynb">View source on GitHub</a>
+<a class="colab-link" href="https://colab.research.google.com/github/kubeflow/website/blob/master/content/en/docs/components/pipelines/v1/sdk/python-function-components.ipynb">Run in Google Colab</a>
+<a class="github-link" href="https://github.com/kubeflow/website/blob/master/content/en/docs/components/pipelines/v1/sdk/python-function-components.ipynb">View source on GitHub</a>
 </div>


### PR DESCRIPTION
Fix `Run in Google Colab` and `View source on GitHub` buttons for listed v1 Pipelines SDK pages.

Top page buttons only for `build-pipeline.md` page were already working, likely as part of previous doc migration when v2.