### PR TITLE
add history on KF logo

### DIFF
--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -78,6 +78,8 @@ configure based on the cluster it deploys into.
 Kubeflow started as an open sourcing of the way Google ran [TensorFlow](https://www.tensorflow.org/) internally, based on a pipeline called [TensorFlow Extended](https://www.tensorflow.org/tfx/).
 It began as just a simpler way to run TensorFlow jobs on Kubernetes, but has since expanded to be a multi-architecture, multi-cloud framework for running end-to-end machine learning workflows.
 
+The [Kubeflow logo represents](https://github.com/kubeflow/kubeflow/issues/187#issuecomment-375194419) the letters `K` and `F` inside the heptagon of the Kubernetes logo, which represent two communities: `Kubernetes` (cloud-native) and `flow` (Machine Learning). In this context, `flow` is not only indicating `TensorFlow`, but also all ML frameworks which make use of Dataflow Graph as the normal form for model/algorithm implementation.
+
 ## Roadmaps
 
 To see what's coming up in future versions of Kubeflow, refer to the [Kubeflow roadmap](https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md).


### PR DESCRIPTION
As a newcomer interested in this community, I never noticed in the Kubeflow logo had "K" and "F" 😅 
To me, it looked like a https://en.wikipedia.org/wiki/Diamond_cut

Until today, another variation made me notice those letters.
You know, like those https://en.wikipedia.org/wiki/Rabbit%E2%80%93duck_illusion effect

With this PR, I propose adding it to the History section in the introduction.

As I searched Kubeflow git org history, I found an expanded explanation, which is hyperlinked in the markdown for the extra-curious and proper attribution.