### PR TITLE
Adding link to events page from top nav

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -36,7 +36,7 @@ ignoreFiles = []
   [[menu.main]]
     name = "Events"
     weight = -102
-    pre = "<i class='fas fa-book pr-2'></i>"
+    pre = "<i class='fas fa-calendar pr-2'></i>"
     url = "/events/"
   [[menu.main]]
     name = "Docs"

--- a/config.toml
+++ b/config.toml
@@ -28,17 +28,18 @@ ignoreFiles = []
 ###############################################################################
 [menu]
   [[menu.main]]
-    name = "Google Summer Of Code 2024 "
+    name = "Kubecon EU 2024 "
     weight = -1000
     pre = "<i class='fas fa-calendar pr-2' style='color: #FFC107'></i>"
-    url = "/events/gsoc-2024/"
+    post = "<br><span class='badge badge-warning'>March 9-12th</span> <span class='badge badge-warning'>PARIS, FRANCE</span> "
+    url = "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/"
   [[menu.main]]
     name = "Events"
-    weight = -101
+    weight = -102
     pre = "<i class='fas fa-book pr-2'></i>"
     url = "/events/"
   [[menu.main]]
-    name = "Documentation"
+    name = "Docs"
     weight = -101
     pre = "<i class='fas fa-book pr-2'></i>"
     url = "/docs/"

--- a/config.toml
+++ b/config.toml
@@ -28,11 +28,15 @@ ignoreFiles = []
 ###############################################################################
 [menu]
   [[menu.main]]
-    name = "Kubeflow Summit 2023 "
+    name = "Google Summer Of Code 2024 "
     weight = -1000
     pre = "<i class='fas fa-calendar pr-2' style='color: #FFC107'></i>"
-    post = "<br><span class='badge badge-warning'>Oct 6th</span> <span class='badge badge-warning'>Irving, Texas</span> <span class='badge badge-warning'>Virtual</span>"
-    url = "/events/kubeflow-summit-2023/"
+    url = "/events/gsoc-2024/"
+  [[menu.main]]
+    name = "Events"
+    weight = -101
+    pre = "<i class='fas fa-book pr-2'></i>"
+    url = "/events/"
   [[menu.main]]
     name = "Documentation"
     weight = -101

--- a/config.toml
+++ b/config.toml
@@ -28,11 +28,11 @@ ignoreFiles = []
 ###############################################################################
 [menu]
   [[menu.main]]
-    name = "Kubecon EU 2024 "
+    name = "Kubeflow Summit EU / KubeCon EU "
     weight = -1000
     pre = "<i class='fas fa-calendar pr-2' style='color: #FFC107'></i>"
-    post = "<br><span class='badge badge-warning'>March 9-12th</span> <span class='badge badge-warning'>PARIS, FRANCE</span> "
-    url = "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/"
+    post = "<br><span class='badge badge-warning'>19 March, 2024</span> <span class='badge badge-warning'>Paris, France</span> "
+    url = "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/kubeflow-summit/"
   [[menu.main]]
     name = "Events"
     weight = -102

--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ ignoreFiles = []
 ###############################################################################
 [menu]
   [[menu.main]]
-    name = "Kubeflow Summit EU / KubeCon EU "
+    name = "Kubeflow Summit / KubeCon Europe "
     weight = -1000
     pre = "<i class='fas fa-calendar pr-2' style='color: #FFC107'></i>"
     post = "<br><span class='badge badge-warning'>19 March, 2024</span> <span class='badge badge-warning'>Paris, France</span> "


### PR DESCRIPTION
Adding "events" page to top nav and also replacing Kubeflow Summit with GSoC reference.