### PR TITLE
Update the old Feast installation documentation links

### DIFF
--- a/content/en/docs/external-add-ons/feature-store/getting-started.md
+++ b/content/en/docs/external-add-ons/feature-store/getting-started.md
@@ -21,12 +21,12 @@ For an overview of Feast, please read [Introduction to Feast](/docs/external-add
 **Installation**
 
 To use Feast with Kubeflow, please follow the following steps
-  * [Install Feast](https://docs.feast.dev/how-to-guides/feast-gcp-aws/install-feast) into your development environment, as well as any environment where you want to register feature views or read features from the feature store.
-  * [Create a feature repository](https://docs.feast.dev/how-to-guides/feast-gcp-aws/create-a-feature-repository) to store your feature views and entities. Make sure to configure your feature_store.yaml to point to your online store. Pleas see the online store [configuration reference](https://docs.feast.dev/reference/online-stores) here for more details. 
-  * [Deploy your feature store](https://docs.feast.dev/how-to-guides/feast-gcp-aws/deploy-a-feature-store). This step configures your online store and sets up your feature registry. 
-  * [Build a training dataset](https://docs.feast.dev/how-to-guides/feast-gcp-aws/build-a-training-dataset). This step is typically executed from a Kubeflow Pipeline from which you'd train a model.
-  * [Load features into the online store](https://docs.feast.dev/how-to-guides/feast-gcp-aws/load-data-into-the-online-store). This step can also be executed from a Kubernetes cron job.
-  * [Read features from the online store](https://docs.feast.dev/how-to-guides/feast-gcp-aws/read-features-from-the-online-store). This step is typically executed from your model serving service, right before calling your model for a prediction.
+  * [Install Feast](https://docs.feast.dev/how-to-guides/feast-snowflake-gcp-aws/install-feast) into your development environment, as well as any environment where you want to register feature views or read features from the feature store.
+  * [Create a feature repository](https://docs.feast.dev/how-to-guides/feast-snowflake-gcp-aws/create-a-feature-repository) to store your feature views and entities. Make sure to configure your feature_store.yaml to point to your online store. Pleas see the online store [configuration reference](https://docs.feast.dev/reference/online-stores) here for more details. 
+  * [Deploy your feature store](https://docs.feast.dev/how-to-guides/feast-snowflake-gcp-aws/deploy-a-feature-store). This step configures your online store and sets up your feature registry. 
+  * [Build a training dataset](https://docs.feast.dev/how-to-guides/feast-snowflake-gcp-aws/build-a-training-dataset). This step is typically executed from a Kubeflow Pipeline from which you'd train a model.
+  * [Load features into the online store](https://docs.feast.dev/how-to-guides/feast-snowflake-gcp-aws/load-data-into-the-online-store). This step can also be executed from a Kubernetes cron job.
+  * [Read features from the online store](https://docs.feast.dev/how-to-guides/feast-snowflake-gcp-aws/read-features-from-the-online-store). This step is typically executed from your model serving service, right before calling your model for a prediction.
 
 **Advanced**
 * Please see [this guide](https://docs.feast.dev/how-to-guides/running-feast-in-production) which provides best practices for running Feast in a production context.


### PR DESCRIPTION
This PR is initiated to address the issue of broken links in the Kubeflow documentation, targeting the installation instructions for Feast, by updating them with accurate URLs to ensure users have access to the correct resources.