### PR TITLE
Fixed typos in server-config.md

### DIFF
--- a/content/en/docs/components/pipelines/v2/administration/server-config.md
+++ b/content/en/docs/components/pipelines/v2/administration/server-config.md
@@ -1,12 +1,12 @@
 +++
 title = "Server Configuration"
-description = "Guidance on managin your Kubeflow Pipelines instances"
+description = "Guidance on managing your Kubeflow Pipelines instances"
 weight = 1
 +++
 
 
 By default, you can use Kubeflow Pipelines deployment manifests as provided,
-which aim to offer the a standard configuration for most use cases. At the meantime,
+which aim to offer a standard configuration for most use cases. At the meantime,
 customizations are available for more advanced usage.
 
 When deploying Kubeflow Pipelines servers, you can pass various environment variables
@@ -35,7 +35,7 @@ this value for your users, for example: `^.*.yourdomain$` in the
 
 #### Full fledged Kubeflow deployment
 
-For full fledged Kubeflow, each namespace is corrsponded to a project with the same name.
+For full fledged Kubeflow, each namespace corresponds to a project with the same name.
 To configure the `ALLOWED_ARTIFACT_DOMAIN_REGEX` value for user namespace, add an entry in `ml-pipeline-ui-artifact`
 just like this example in [sync.py](https://github.com/kubeflow/pipelines/blob/b630d5c8ae7559be0011e67f01e3aec1946ef765/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py#L304-L310) for `ALLOWED_ARTIFACT_DOMAIN_REGEX` environment variable,
 the entry is identical to the environment variable instruction in Standalone Kubeflow Pipelines


### PR DESCRIPTION
This PR fixes `typos in content/en/docs/components/pipelines/v2/administration/server-config.md`.