### PR TITLE
Updated legal info due to migration from CLA to DCO

### DIFF
--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -15,16 +15,7 @@ There are just a few small guidelines you need to follow.
 
 Kubeflow uses Developer Certificate of Origin ([DCO](https://github.com/apps/dco/)).
 
-Please sign off your contributions by doing ONE of the following:
-* Use `git commit -s ...` with each commit to add the sign-off or
-* Manually add a `Signed-off-by: Your Name <your.email@example.com>` to each commit message.
-
-The email address must match your primary GitHub email. You do NOT need cryptographic (e.g. gpg) signing.
-* Use `git commit -s --amend ...` to add a sign-off to the latest commit, if you forgot.
-
-To automatically sign off on every commit, copy the https://github.com/kubeflow/community/tree/master/dco-signoff-hook/prepare-commit-msg file to the `.git/hooks` directory in your repo or if you already have such a hook, merge the contents into your existing hook.
-
-*Note*: Some projects will provide specific configuration to ensure all commits are signed-off. Please check the project's documentation for more details.
+Check https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits to learn how to sign off your contributions.
 
 ### Follow the code of conduct
 

--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -11,15 +11,20 @@ There are just a few small guidelines you need to follow.
 
 ## Getting Started
 
-### Sign the CLA
+### Sign off your commits
 
-Contributions to this project must be accompanied by a Contributor License Agreement (CLA).
-You (or your employer) retain the copyright to your contribution.
-This gives us permission to use and redistribute your contributions as part of the project.
-Head over to <https://cla.developers.google.com/> to see your current agreements on file or to sign a new one.
+Kubeflow uses Developer Certificate of Origin ([DCO](https://github.com/apps/dco/)).
 
-You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project),
-you probably don't need to do it again.
+Please sign off your contributions by doing ONE of the following:
+* Use `git commit -s ...` with each commit to add the sign-off or
+* Manually add a `Signed-off-by: Your Name <your.email@example.com>` to each commit message.
+
+The email address must match your primary GitHub email. You do NOT need cryptographic (e.g. gpg) signing.
+* Use `git commit -s --amend ...` to add a sign-off to the latest commit, if you forgot.
+
+To automatically sign off on every commit, copy the https://github.com/kubeflow/community/tree/master/dco-signoff-hook/prepare-commit-msg file to the `.git/hooks` directory in your repo or if you already have such a hook, merge the contents into your existing hook.
+
+*Note*: Some projects will provide specific configuration to ensure all commits are signed-off. Please check the project's documentation for more details.
 
 ### Follow the code of conduct
 


### PR DESCRIPTION
This PR depends on https://github.com/kubeflow/community/pull/703.

The Legal text is based on [Argo Project](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal).