### PR TITLE
Updated CRs documentation to include comment about istio annotation

### DIFF
--- a/content/en/docs/components/training/mpi.md
+++ b/content/en/docs/components/training/mpi.md
@@ -10,7 +10,9 @@ weight = 35
 
 This guide walks you through using MPI for training.
 
-The MPI Operator makes it easy to run allreduce-style distributed training on Kubernetes. Please check out [this blog post](https://medium.com/kubeflow/introduction-to-kubeflow-mpi-operator-and-industry-adoption-296d5f2e6edc) for an introduction to MPI Operator and its industry adoption.
+The MPI Operator, `MPIJob`, makes it easy to run allreduce-style distributed training on Kubernetes. Please check out [this blog post](https://medium.com/kubeflow/introduction-to-kubeflow-mpi-operator-and-industry-adoption-296d5f2e6edc) for an introduction to MPI Operator and its industry adoption.
+
+**Note**: `MPIJob` doesn’t work in a user namespace by default because of Istio [automatic sidecar injection](https://istio.io/v1.3/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection). In order to get it running, it needs annotation `sidecar.istio.io/inject: "false"` to disable it for either `MPIJob` pods or namespace. To view an example of how to add this annotation to your `yaml` file, see the [`TFJob` documentation](https://www.kubeflow.org/docs/components/training/tftraining/).
 
 ## Installation
 

--- a/content/en/docs/components/training/mxnet.md
+++ b/content/en/docs/components/training/mxnet.md
@@ -14,6 +14,8 @@ and manage Apache MXNet jobs just like built-in K8S resources.
 
 The Kubeflow implementation of `MXJob` is in [`training-operator`](https://github.com/kubeflow/training-operator).
 
+**Note**: `MXJob` doesn’t work in a user namespace by default because of Istio [automatic sidecar injection](https://istio.io/v1.3/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection). In order to get it running, it needs annotation `sidecar.istio.io/inject: "false"` to disable it for either `MXJob` pods or namespace. To view an example of how to add this annotation to your `yaml` file, see the [`TFJob` documentation](https://www.kubeflow.org/docs/components/training/tftraining/).
+
 ## Installing MXNet Operator
 
 If you haven't already done so please follow the [Getting Started Guide](/docs/started/getting-started/) to deploy Kubeflow.

--- a/content/en/docs/components/training/paddlepaddle.md
+++ b/content/en/docs/components/training/paddlepaddle.md
@@ -14,6 +14,9 @@ This page describes `PaddleJob` for training a machine learning model with [Padd
 to run PaddlePaddle training jobs on Kubernetes. The Kubeflow implementation of
 `PaddleJob` is in [`training-operator`](https://github.com/kubeflow/training-operator).
 
+
+**Note**: `PaddleJob` doesn’t work in a user namespace by default because of Istio [automatic sidecar injection](https://istio.io/v1.3/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection). In order to get it running, it needs annotation `sidecar.istio.io/inject: "false"` to disable it for either `PaddleJob` pods or namespace. To view an example of how to add this annotation to your `yaml` file, see the [`TFJob` documentation](https://www.kubeflow.org/docs/components/training/tftraining/).
+
 ## Installing Paddle Operator
 
 If you haven't already done so please follow the [Getting Started Guide](/docs/started/getting-started/) to deploy Kubeflow.

--- a/content/en/docs/components/training/pytorch.md
+++ b/content/en/docs/components/training/pytorch.md
@@ -14,6 +14,8 @@ This page describes `PyTorchJob` for training a machine learning model with [PyT
 to run PyTorch training jobs on Kubernetes. The Kubeflow implementation of
 `PyTorchJob` is in [`training-operator`](https://github.com/kubeflow/training-operator).
 
+**Note**: `PyTorchJob` doesn’t work in a user namespace by default because of Istio [automatic sidecar injection](https://istio.io/v1.3/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection). In order to get it running, it needs annotation `sidecar.istio.io/inject: "false"` to disable it for either `PyTorchJob` pods or namespace. To view an example of how to add this annotation to your `yaml` file, see the [`TFJob` documentation](https://www.kubeflow.org/docs/components/training/tftraining/).
+
 ## Installing PyTorch Operator
 
 If you haven't already done so please follow the [Getting Started Guide](/docs/started/getting-started/) to deploy Kubeflow.
@@ -84,7 +86,7 @@ kubectl get -o yaml pytorchjobs pytorch-simple -n kubeflow
 
 See the status section to monitor the job status. Here is sample output when the job is successfully completed.
 
-```
+```yaml
 apiVersion: kubeflow.org/v1
 kind: PyTorchJob
 metadata:

--- a/content/en/docs/components/training/xgboost.md
+++ b/content/en/docs/components/training/xgboost.md
@@ -14,6 +14,8 @@ This page describes `XGBoostJob` for training a machine learning model with [XGB
 to run XGBoost training jobs on Kubernetes. The Kubeflow implementation of
 `XGBoostJob` is in [`training-operator`](https://github.com/kubeflow/training-operator).
 
+**Note**: `XGBoostJob` doesn’t work in a user namespace by default because of Istio [automatic sidecar injection](https://istio.io/v1.3/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection). In order to get it running, it needs annotation `sidecar.istio.io/inject: "false"` to disable it for either `XGBoostJob` pods or namespace. To view an example of how to add this annotation to your `yaml` file, see the [`TFJob` documentation](https://www.kubeflow.org/docs/components/training/tftraining/).
+
 ## Installing XGBoost Operator
 
 If you haven't already done so please follow the [Getting Started Guide](/docs/started/getting-started/) to deploy Kubeflow.


### PR DESCRIPTION
Based on the discussion on the PR https://github.com/kubeflow/training-operator/pull/2004 , I updated the documentation website pages for the different `*Job` CRs to include a comment about having to disable automatic sidecar injection in some cases, and how to do that.