### PR TITLE
updates to GSoC Page after selection into the program

### DIFF
--- a/content/en/events/gsoc-2024.md
+++ b/content/en/events/gsoc-2024.md
@@ -5,25 +5,19 @@ description = "Google Summer of Code 2024"
 
 ---
 
-Kubeflow Community is excited to announce that we have been [selected](https://summerofcode.withgoogle.com/programs/2024/organizations/kubeflow) as organization to participate in [**Google Summer of Code 2024**](https://buildyourfuture.withgoogle.com/programs/summer-of-code).
-
-Below are the "ideas/features" from different projects in Kubeflow that are seeking proposals from GSoC Students
+Kubeflow Community is excited to announce that we have been [selected](https://summerofcode.withgoogle.com/programs/2024/organizations/kubeflow) as organization to participate in [**Google Summer of Code 2024**](https://buildyourfuture.withgoogle.com/programs/summer-of-code). This page aims to help you participate in the Kubeflow organization for GSoC 2024.
 
 ## How can I participate in Kubeflow GSoC?
 
 Please go to [Google Summer of Code 2024](https://buildyourfuture.withgoogle.com/programs/summer-of-code) and sign up as a student. Next, look at the [projects below](#project-ideas-for-2024-gsoc) to decide which ones you are interested in. Note, that you must submit your proposals through the GSoC website and your proposal must be selected to participate.
 
-Contributor applications open __March 18th, 2024__ and close on __April 2nd, 2024__.
-
-For more information, see the GSoC website and/or reach out to the GSoC organizers.
-
-Please only contact mentors about projects, not the program itself.
+Contributor applications open __March 18th, 2024__ and close on __April 2nd, 2024__. For more information, see the GSoC website and/or reach out to the GSoC organizers. Please only contact mentors about projects, not the program itself.
 
 ### Slack
 
 Please [__Join the Kubeflow Slack__](https://www.kubeflow.org/docs/about/community/#kubeflow-slack).
 
-Please __do not__ reach out privately to mentors, instead, start a thread in the `#gsoc-participants` channel so others can see the response. Be kind to our mentors, please search to see if your question has already been answered.
+Please __do not__ reach out privately to mentors, instead, start a thread in the [`#gsoc-participants`](https://kubeflow.slack.com/archives/C06LW6Z3RA6) channel so others can see the response. Be kind to our mentors, please search to see if your question has already been answered.
 
 ### Meetings
 
@@ -47,9 +41,7 @@ document.getElementById('calendar-container').innerHTML = html;
 
 Please understand that not everyone can be selected for Google Summer of Code (GSoC), there are many possible candidates for each project.
 
-However, we want to encourage you to participate in the Kubeflow project!
-
-The best way to get started is to attend [working group meetings](/docs/about/community/#kubeflow-community-calendars) for components you want to contribute to.
+However, we still want to encourage you to participate in the Kubeflow project! Get started by attending [working group meetings](/docs/about/community/#kubeflow-community-calendars) for components you want to help with, and reading our [contributing guide](/docs/about/contributing/).
 
 # Project Ideas for 2024 GSoC
 
@@ -214,7 +206,7 @@ Training Operator and Katib SDKs have [a valid docstring](https://github.com/kub
 
 **Mentors:** Andrey Velichkevich, Johnu George, Shivay Lamba, Yuan (Terry) Tang, Yuki Iwai
 
-**Component:** Katib/General
+**Component:** Katib/Training Operator
 
 ---
 

--- a/content/en/events/gsoc-2024.md
+++ b/content/en/events/gsoc-2024.md
@@ -7,20 +7,27 @@ description = "Google Summer of Code 2024"
 
 Kubeflow Community is excited to announce that we have been [selected](https://summerofcode.withgoogle.com/programs/2024/organizations/kubeflow) as organization to participate in [**Google Summer of Code 2024**](https://buildyourfuture.withgoogle.com/programs/summer-of-code).
 
-Students, welcome to an incredible chance to dive into the vibrant Kubeflow community! Join us and become a valued contributor to our rapidly expanding network dedicated to AI/ML technologies on Kubernetes. Kubeflow mentors come with years of valuable experience and a passion for community growth and project enhancement, they're the guiding stars of our program. Immerse yourself in a dynamic environment where you'll not only gain insights from top industry experts but also sharpen your skills in open source collaboration, time management, and presentation prowess alongside making impactful technical contributions to projects of your interest. Our dedicated mentors will be by your side every step of the way, offering invaluable guidance and support throughout the project. Get ready to embark on an exciting journey of growth and learning!
-Below are the "ideas/features" from different projects in the Kubeflow that being submitted for seeking proposals from GSoC Students.
+Below are the "ideas/features" from different projects in Kubeflow that are seeking proposals from GSoC Students
 
-## How can I participate in Kubeflow GSoc?
+## How can I participate in Kubeflow GSoC?
 
-Please go to [Google Summer of Code 2024](https://buildyourfuture.withgoogle.com/programs/summer-of-code) and sign up as student and look up Kubeflow organization and select the projects you want to submit proposals. Note, you can submit more than one proposal. Contributor Applications open **March 18th, 2024** and end on **Apr 2nd 2024**. First read through contributor guidelines, how to participate GSoC google website. Only ask questions about projects with your mentors. General questions about GSoC please reach out to GSoC organizers.
+Please go to [Google Summer of Code 2024](https://buildyourfuture.withgoogle.com/programs/summer-of-code) and sign up as a student. Next, look at the [projects below](#project-ideas-for-2024-gsoc) to decide which ones you are interested in. Note, that you must submit your proposals through the GSoC website and your proposal must be selected to participate.
 
-## Slack
+Contributor applications open __March 18th, 2024__ and close on __April 2nd, 2024__.
 
-If you need to reach out our mentors, join [Kubeflow Slack](https://www.kubeflow.org/docs/about/community/#kubeflow-slack) and join #gsoc-participants channel. Look up your mentor or find project specific channel on Kubeflow slack. Be kind to your mentor, search and see if the question has been already answered in the channel first. Note that for most projects there are more than one mentor you can tag and request help.
+For more information, see the GSoC website and/or reach out to the GSoC organizers.
 
-## Meetings
+Please only contact mentors about projects, not the program itself.
 
-To facilitate the questions from students, we ask you to find the next community meeting for the project you are interested in from below list and attend that meeting and ask questions.
+### Slack
+
+Please [__Join the Kubeflow Slack__](https://www.kubeflow.org/docs/about/community/#kubeflow-slack).
+
+Please __do not__ reach out privately to mentors, instead, start a thread in the `#gsoc-participants` channel so others can see the response. Be kind to our mentors, please search to see if your question has already been answered.
+
+### Meetings
+
+You may wish to attend the next community meeting for the group that is leading your chosen project, please see the calendar below for more information.
 
 <div id="calendar-container"></div>
 <script type="text/javascript">
@@ -36,15 +43,15 @@ const html = `<iframe src="https://calendar.google.com/calendar/embed?ctz=${time
 document.getElementById('calendar-container').innerHTML = html;
 </script>
 
-## Didn't get selected for GSoC? Don't worry, you can still contribute!
+## What if my proposal is not chosen?
 
-We understand that not everyone gets selected for Google Summer of Code (GSoC). However, we're still open to collaboration with enthusiastic students! While we can't offer a stipend like GSoC, we can provide valuable mentorship and experience.
+Please understand that not everyone can be selected for Google Summer of Code (GSoC), there are many possible candidates for each project.
 
-To ensure successful mentoring, we expect a strong commitment and enthusiasm from you for the chosen project. This way, our mentors can dedicate their time and expertise to guide you effectively.
+However, we want to encourage you to participate in the Kubeflow project!
 
-We believe there are many ways to contribute outside of GSoC. If you're interested, please reach out to us!
+The best way to get started is to attend [working group meetings](/docs/about/community/#kubeflow-community-calendars) for components you want to contribute to.
 
-# Project Ideas for the 2024
+# Project Ideas for 2024 GSoC
 
 ### Project 1: Kubeflow Notebooks 2.0
 

--- a/content/en/events/gsoc-2024.md
+++ b/content/en/events/gsoc-2024.md
@@ -5,25 +5,46 @@ description = "Google Summer of Code 2024"
 
 ---
 
-Kubeflow Community is excited to announce that we are applying this year to participate in the [**Google Summer of Code 2024**](https://buildyourfuture.withgoogle.com/programs/summer-of-code)
+Kubeflow Community is excited to announce that we have been [selected](https://summerofcode.withgoogle.com/programs/2024/organizations/kubeflow) as organization to participate in [**Google Summer of Code 2024**](https://buildyourfuture.withgoogle.com/programs/summer-of-code).
 
+Students, welcome to an incredible chance to dive into the vibrant Kubeflow community! Join us and become a valued contributor to our rapidly expanding network dedicated to AI/ML technologies on Kubernetes. Kubeflow mentors come with years of valuable experience and a passion for community growth and project enhancement, they're the guiding stars of our program. Immerse yourself in a dynamic environment where you'll not only gain insights from top industry experts but also sharpen your skills in open source collaboration, time management, and presentation prowess alongside making impactful technical contributions to projects of your interest. Our dedicated mentors will be by your side every step of the way, offering invaluable guidance and support throughout the project. Get ready to embark on an exciting journey of growth and learning!
 Below are the "ideas/features" from different projects in the Kubeflow that being submitted for seeking proposals from GSoC Students.
 
-## Registration
+## How can I participate in Kubeflow GSoc?
 
-Please go to [Google Summer of Code 2024](https://buildyourfuture.withgoogle.com/programs/summer-of-code) and sign up as student and look up Kubeflow organization and select the projects you want to submit proposals. Note, you can submit more than one proposal. Contributor Applications open **March 20, 2024** and end on **Apr 4th 2024**. So start writing your proposals.
+Please go to [Google Summer of Code 2024](https://buildyourfuture.withgoogle.com/programs/summer-of-code) and sign up as student and look up Kubeflow organization and select the projects you want to submit proposals. Note, you can submit more than one proposal. Contributor Applications open **March 18th, 2024** and end on **Apr 2nd 2024**. First read through contributor guidelines, how to participate GSoC google website. Only ask questions about projects with your mentors. General questions about GSoC please reach out to GSoC organizers.
 
-## Mentors
+## Slack
 
-Kubeflow community is an unparalleled opportunity to make a lasting impact and share your wealth of experience. As a mentor, you'll have the chance to guide and shape the next generation of talent, while also collaborating with like-minded individuals to elevate projects to new heights. With dedicated support mechanisms like community recognition and feedback channels, you'll feel valued and empowered every step of the way. Join us in this exciting journey of mentorship and collaboration! If you want submit an project idea reach out Ramesh Reddy on slack.
+If you need to reach out our mentors, join [Kubeflow Slack](https://www.kubeflow.org/docs/about/community/#kubeflow-slack) and join #gsoc-participants channel. Look up your mentor or find project specific channel on Kubeflow slack. Be kind to your mentor, search and see if the question has been already answered in the channel first. Note that for most projects there are more than one mentor you can tag and request help.
 
-## Students
+## Meetings
 
-Welcome to an incredible chance to dive into the vibrant Kubeflow community! Join us and become a valued contributor to our rapidly expanding network dedicated to AI/ML technologies on Kubernetes. Kubeflow mentors come with years of valuable experience and a passion for community growth and project enhancement, they're the guiding stars of our program. Immerse yourself in a dynamic environment where you'll not only gain insights from top industry experts but also sharpen your skills in open source collaboration, time management, and presentation prowess alongside making impactful technical contributions to projects of your interest. Our dedicated mentors will be by your side every step of the way, offering invaluable guidance and support throughout the project. Get ready to embark on an exciting journey of growth and learning!
+To facilitate the questions from students, we ask you to find the next community meeting for the project you are interested in from below list and attend that meeting and ask questions.
 
-**If you need to reach out our mentors, join [Kubeflow Slack](https://www.kubeflow.org/docs/about/community/#kubeflow-slack) and look up your mentor or find project specific channel on Kubeflow slack**
+<div id="calendar-container"></div>
+<script type="text/javascript">
+const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const calender_src_list = [
+  // Kubeflow Community
+  "kubeflow.org_7l5vnbn8suj2se10sen81d9428%40group.calendar.google.com",
+  // KServe Community
+  "4fqdmu5fp4l0bgdlf4lm1atnsl2j4612%40import.calendar.google.com",
+];
+let calender_src = calender_src_list.map(src => `&src=${src}&color=%23A79B8E`).join('');
+const html = `<iframe src="https://calendar.google.com/calendar/embed?ctz=${timezone}&height=600&wkst=1&bgcolor=%23ffffff&showPrint=0&showDate=1&mode=AGENDA&showTitle=0${calender_src}" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>`;
+document.getElementById('calendar-container').innerHTML = html;
+</script>
 
-## Project Ideas for the 2024
+## Didn't get selected for GSoC? Don't worry, you can still contribute!
+
+We understand that not everyone gets selected for Google Summer of Code (GSoC). However, we're still open to collaboration with enthusiastic students! While we can't offer a stipend like GSoC, we can provide valuable mentorship and experience.
+
+To ensure successful mentoring, we expect a strong commitment and enthusiasm from you for the chosen project. This way, our mentors can dedicate their time and expertise to guide you effectively.
+
+We believe there are many ways to contribute outside of GSoC. If you're interested, please reach out to us!
+
+# Project Ideas for the 2024
 
 ### Project 1: Kubeflow Notebooks 2.0
 
@@ -54,6 +75,8 @@ You would be part of the larger effort, and involved in one or more code deliver
 
 **Mentors:** Mathew Wicks, Kimonas Sitorchos, Julius von Kohout
 
+**Component:** Notebooks
+
 ---
 
 ---
@@ -73,6 +96,8 @@ See the proposal for more information: [https://github.com/kubeflow/manifests/bl
 **Length:** 175 hrs
 
 **Mentors:** Kimonas Sitorchos, Julius von Kohout
+
+**Component:** Notebooks
 
 ---
 
@@ -100,6 +125,8 @@ Specifically, your goal would be to:
 
 **Mentors:** Mathew Wicks, Kimonas Sitorchos, Julius von Kohout
 
+**Component:** Notebooks/General
+
 ---
 
 ---
@@ -118,6 +145,8 @@ To continue our roadmap around LLMOps in Kubeflow, we want to give user function
 
 **Mentors:** Andrey Velichkevich, Johnu George, Yuan (Terry) Tang, Yuki Iwai
 
+**Component:** Katib
+
 ---
 
 ---
@@ -135,6 +164,8 @@ We want to integrate Jax in Training Operator to run distributed training and fi
 **Length:** 350 hrs
 
 **Mentors:** Andrey Velichkevich, Johnu George, Yuan (Terry) Tang, Yuki Iwai
+
+**Component:** Training Operator
 
 ---
 
@@ -156,6 +187,8 @@ Sometimes the container sidecar approach might not work for users. For example, 
 
 **Mentors:** Andrey Velichkevich, Johnu George, Yuan (Terry) Tang, Yuki Iwai
 
+**Component:** Katib
+
 ---
 
 ---
@@ -174,6 +207,8 @@ Training Operator and Katib SDKs have [a valid docstring](https://github.com/kub
 
 **Mentors:** Andrey Velichkevich, Johnu George, Shivay Lamba, Yuan (Terry) Tang, Yuki Iwai
 
+**Component:** Katib/General
+
 ---
 
 ---
@@ -191,6 +226,8 @@ We need to enhance Katib Experiment APIs to support various parameter distributi
 **Length:** 350 hrs
 
 **Mentors:** Andrey Velichkevich, Johnu George, Yuan (Terry) Tang, Yuki Iwai
+
+**Component:** Katib
 
 ---
 
@@ -212,6 +249,8 @@ We plan to support PostgreSQL as an alternative to MySQL/MariaDB so users will b
 
 **Mentors:** Ricardo Martinelli, Shivay Lamba
 
+**Component:** Pipelines
+
 ---
 
 ---
@@ -227,6 +266,8 @@ We aim to extend the capabilities of the KF Model Registry Python client by enab
 **Length:** 175 hrs
 
 **Mentors:** Matteo Mortari, Andrea Lamparelli
+
+**Component:** Model Registry
 
 ---
 


### PR DESCRIPTION
This updates page after the selection Kubeflow into GSoc mainly highlighting

- how to participate in kubeflow's gsoc
- how to reach out to mentors
- how to reach out to mentors in community calls
- what to do if student did not get selected in gsoc program