### PR TITLE
Katib: Add KATIB_POSTGRESQL_SSL_MODE variable of Katib DB Manager

### DIFF
--- a/content/en/docs/components/katib/env-variables.md
+++ b/content/en/docs/components/katib/env-variables.md
@@ -195,6 +195,12 @@ deployment:
         <td>No</td>
       </tr>
       <tr>
+        <td><code>KATIB_POSTGRESQL_SSL_MODE</code></td>
+        <td>Katib Postgres SSL mode</td>
+        <td>disable</td>
+        <td>No</td>
+      </tr>
+      <tr>
         <td><code>SKIP_DB_INITIALIZATION</code></td>
         <td>Option to skip DB table initialization</td>
         <td>false</td>


### PR DESCRIPTION
This follow-up PR reflects a change from https://github.com/kubeflow/katib/pull/2266, which introduced a new environment variable option to allow users to specify the value of Postgres sslmode.

It updates Katib DB Manager part of [Environment Variables for Katib Components](https://www.kubeflow.org/docs/components/katib/env-variables/#katib-db-manager).
