### PR TITLE
update slack inviter link

### DIFF
--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -9,7 +9,7 @@ aliases = ["/docs/community/"]
 
 The Official Kubeflow Slack is used for informal discussions among users and contributors.
 
-<a href="https://invite.playplay.io/invite?team_id=T7QLHSH6U">
+<a href="https://communityinviter.com/apps/kubeflow/slack">
   <button class="btn btn-primary py-2 px-5 mb-3">Click to join:<br>Kubeflow Slack</button>
 </a>
 


### PR DESCRIPTION
This PR updates our Kubeflow Slack inviter link to use the same system as CNCF Slack, the current bot is struggling under the large number of people joining for GSoC.

__See these related user issues:__

- https://github.com/kubeflow/community/issues/706
- https://groups.google.com/g/kubeflow-discuss/c/ncc_piQY2O8

__The link is changing from:__

- __OLD:__ https://invite.playplay.io/invite?team_id=T7QLHSH6U
- __NEW:__ https://communityinviter.com/apps/kubeflow/slack

---

__NOTE:__ The new link still invites users to the `Kubeflow` slack, not the `CNCF` one. We are still planning on how to migrate to CNCF slack so we can minimize disruption.

