### PR TITLE
Katib: fix the source code reference about mxnet

### DIFF
--- a/content/en/docs/components/katib/early-stopping.md
+++ b/content/en/docs/components/katib/early-stopping.md
@@ -28,7 +28,7 @@ stopped. Currently, early stopping works only with
 **Note**: Your training container must print training logs with the timestamp,
 because early stopping algorithms need to know the sequence of reported metrics.
 Check the
-[`MXNet` example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-images/mxnet-mnist/mnist.py#L36)
+[`PyTorch` example](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/trial-images/pytorch-mnist/mnist.py#L141)
 to learn how to add a date format to your logs.
 
 ## Configure the experiment with early stopping

--- a/content/en/docs/components/katib/hyperparameter.md
+++ b/content/en/docs/components/katib/hyperparameter.md
@@ -240,7 +240,7 @@ random search example](https://github.com/kubeflow/katib/blob/master/examples/v1
 
 The random search algorithm example uses an MXNet neural network to train an image
 classification model using the MNIST dataset. You can check training container source code
-[here](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/trial-images/mxnet-mnist).
+[here](https://github.com/kubeflow/katib/tree/master/examples/v1beta1/trial-images/pytorch-mnist).
 The experiment runs twelve training jobs with various hyperparameters and saves the results.
 
 If you installed Katib as part of Kubeflow, you can't run experiments in the


### PR DESCRIPTION
 fix the source code reference about mxnet.
The mxnet example has been removed in https://github.com/kubeflow/katib/pull/2267 and no longer available, we use pytorch example instead.