### PR TITLE
Fixes: #3717

### DIFF
--- a/content/en/docs/components/katib/env-variables.md
+++ b/content/en/docs/components/katib/env-variables.md
@@ -189,7 +189,7 @@ deployment:
         <td>No</td>
       </tr>
       <tr>
-        <td><code>KATIB_POSTGRESQL_DATABASE</code></td>
+        <td><code>KATIB_POSTGRESQL_DB_DATABASE</code></td>
         <td>Katib Postgres Database name</td>
         <td>katib</td>
         <td>No</td>


### PR DESCRIPTION
https://github.com/kubeflow/katib/blob/2d308b72c3b4ed6f1365d7c6002a307386a8d252/pkg/db/v1beta1/common/const.go#L43

On this line parse another env. KATIB_POSTGRESQL_DATABASE - not implemented. I'll check releases branches -> current main. All time was KATIB_POSTGRESQL_DB_DATABASE

Fixes: https://github.com/kubeflow/website/issues/3717