### PR TITLE
Update Kubeflow Installation with Standalone Mode

### DIFF
--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -24,8 +24,8 @@ Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptu
 deployed as standalone services, without the need to install the full Kubeflow platform. You might
 integrate these services as part of your existing AI/ML platform or use them independently.
 
-This is a quick and easy method to get started with Kubeflow ecosystem since those components usually
-don't require additional management tools used in a Kubeflow Platform.
+These components are a quick and easy method to get started with the Kubeflow ecosystem. They
+provide flexibility to users who may not require the capabilities of a full Kubeflow Platform.
 
 The following table lists Kubeflow components that may be deployed in a standalone mode. It also
 lists their associated GitHub repository and

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -328,8 +328,7 @@ The following table lists distributions which are <em>maintained</em> by their r
 ### Install Kubeflow Platform from Raw Manifests
 
 The raw Kubeflow Manifests are aggregated by the
-[Manifests Working Group](https://github.com/kubeflow/community/tree/master/wg-manifests)
-and are intended to be used as the **base of packaged distributions**.
+Manifests Working Group and are intended to be used as the **base of packaged distributions**.
 
 Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
 applications which makes **Kubeflow Platform**. This installation is helpful when you want to try

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -104,7 +104,7 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
       </tr>
       <tr>
         <td>
-          <a href="docs/components/pipelines/v2/installation/quickstart/">
+          <a href="/docs/components/pipelines/v2/installation/quickstart/">
             Kubeflow Pipelines
           </a>
         </td>

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -11,14 +11,14 @@ distributions or raw manifests.
 Read [the introduction guide](/docs/started/introduction) to learn more about Kubeflow, Kubeflow
 standalone components and Kubeflow Platform.
 
-## Installing Methods
+## Installation Methods
 
 You can install Kubeflow using one of these methods:
 
-- [**Kubeflow Components Standalone**](#kubeflow-components-standalone)
+- [**Standalone Kubeflow Components**](#standalone-kubeflow-components)
 - [**Kubeflow Platform**](#kubeflow-platform)
 
-### Kubeflow Components Standalone
+### Standalone Kubeflow Components
 
 Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptual-overview) may be
 deployed as standalone services, without the need to install the full platform. You might integrate

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,11 +5,11 @@ weight = 20
 
 +++
 
-This page describes how to install Kubeflow standalone components or Kubeflow Platform using package
+This guide describes how to install Kubeflow standalone components or Kubeflow Platform using package
 distributions or raw manifests.
 
-Read [the introduction guide](/docs/started/introduction) to
-understand what are Kubeflow standalone components and what is Kubeflow Platform.
+Read [the introduction guide](/docs/started/introduction) to understand what are Kubeflow
+standalone components and what is Kubeflow Platform.
 
 ## Installing Kubeflow
 
@@ -25,8 +25,8 @@ Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptu
 deployed as standalone services, without the need to install the full platform. You might integrate
 these services as part of your existing AI/ML platform or use them independently.
 
-This is the easiest method to get started with Kubeflow ecosystem since those components usually
-don't require additional management tools used in Kubeflow Platform.
+This is a easier method to get started with Kubeflow ecosystem since those components usually
+don't require additional management tools used in a Kubeflow Platform.
 
 The following table lists Kubeflow components that may be deployed in a standalone mode. It also
 lists their associated GitHub repository and
@@ -157,7 +157,7 @@ WG is working on that as part of [this issue](https://github.com/kubeflow/kubefl
 ### Install Kubeflow Platform from Packaged Distributions
 
 Packaged distributions are maintained by various organizations and typically aim to provide
-a simplified installation and management experience for **Kubeflow Platform**. Some distributions
+a simplified installation and management experience for your **Kubeflow Platform**. Some distributions
 can be deployed on [all certified Kubernetes distributions](https://kubernetes.io/partners/#conformance),
 while others target a specific platform (e.g. EKS or GKE).
 
@@ -360,6 +360,6 @@ Nevertheless, we welcome contributions and bug reports very much.
 
 ## Next steps
 
-- Review our [Introduction to Kubeflow](/docs/started/introduction/).
-- Explore the [Architecture of Kubeflow](/docs/started/architecture).
-- Learn more about the [Components of Kubeflow](/docs/components/).
+- Review our [introduction to Kubeflow](/docs/started/introduction/).
+- Explore the [architecture of Kubeflow](/docs/started/architecture).
+- Learn more about the [components of Kubeflow](/docs/components/).

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,30 +5,65 @@ weight = 20
 
 +++
 
-## What is Kubeflow?
+Kubeflow is the ecosystem of various applications created to address each stage in the AI/ML lifecycle,
+from exploration to training and serving. You can deploy Kubeflow components as standalone applications
+or deploy Kubeflow as an end-to-end AI/ML platform. Anywhere you are running Kubernetes,
+you should be able to run Kubeflow.
 
-Kubeflow is an end-to-end Machine Learning (ML) platform for Kubernetes, it provides components for each stage in the ML lifecycle, from exploration through to training and deployment.
-Operators can choose what is best for their users, there is no requirement to deploy every component.
+There are a few ways to install Kubeflow:
 
-Learn more about Kubeflow in the [Introduction](/docs/started/introduction/) and
-[Architecture](/docs/started/architecture/) pages.
+- [**Install Kubeflow Components Standalone**](#install-kubeflow-components-standalone)
+- [**Install Kubeflow Platform from Raw Manifests**](#install-kubeflow-platform-from-raw-manifests)
+- [**Install Kubeflow Platform from Packaged Distributions**](#install-kubeflow-platform-from-packages-distributions)
 
-## How to install Kubeflow?
+## Install Kubeflow Components Standalone
 
-Anywhere you are running Kubernetes, you should be able to run Kubeflow.
-There are two primary ways to install Kubeflow:
+Kubeflow components can be deployed as standalone applications. You can integrate those components
+to your existing AI/ML platform. For example, for Model Training you can install Training Operator
+or for Model Serving you can install KServe.
 
-1. [**Packaged Distributions**](#packaged-distributions-of-kubeflow)
-1. [**Raw Manifests**](#raw-kubeflow-manifests) <sup>(advanced users)</sup>
+Follow the appropriate guides to install required Kubeflow components in standalone mode:
 
-<a id="packaged-distributions"></a>
-<a id="install-a-packaged-kubeflow-distribution"></a>
+- Install [Kubeflow Pipelines](/docs/components/pipelines/v2/installation/quickstart/)
+- Install [Kubeflow Training Operator](/docs/components/training/installation/#installing-training-operator)
+- Install [Kubeflow MPI Operator](/docs/components/training/user-guides/mpi/#installation)
+- Install [Kubeflow Katib] (TODO: Add link after #3723)
+- Install [KServe](https://kserve.github.io/website/0.10/admin/serverless/serverless/)
+- Install Kubeflow Model Registry (TODO: Add link after #3698)
 
-## Packaged Distributions of Kubeflow
+## Install Kubeflow Platform from Raw Manifests
+
+The raw Kubeflow Manifests are aggregated by the
+[Manifests Working Group](https://github.com/kubeflow/community/tree/master/wg-manifests)
+and are intended to be used as the **base of packaged distributions**.
+
+Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
+applications which makes **Kubeflow Platform**.
+
+Users may choose to install the manifests for a specific Kubeflow version by following the
+instructions in the `README` of the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.
+
+- [**Kubeflow 1.8:**](/docs/releases/kubeflow-1.8/)
+  - [`v1.8-branch`](https://github.com/kubeflow/manifests/tree/v1.8-branch#installation) <sup>(development branch)</sup>
+  - [`v1.8.0`](https://github.com/kubeflow/manifests/tree/v1.8.0#installation)
+- [**Kubeflow 1.7:**](/docs/releases/kubeflow-1.7/)
+  - [`v1.7-branch`](https://github.com/kubeflow/manifests/tree/v1.7-branch#installation) <sup>(development branch)</sup>
+  - [`v1.7.0`](https://github.com/kubeflow/manifests/tree/v1.7.0#installation)
+
+{{% alert title="Warning" color="warning" %}}
+Kubeflow is a complex system with many components and dependencies.
+Using the raw manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
+
+When using the raw manifests, the Kubeflow community is not able to provide support for environment-specific issues or custom configurations.
+If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
+Nevertheless, we welcome contributions and bug reports very much.
+{{% /alert %}}
+
+## Install Kubeflow Platform from Packages Distributions
 
 Packaged distributions are maintained by various organizations and typically aim to provide
-a simplified installation and management experience for Kubeflow. Some distributions can be
-deployed on [all certified Kubernetes distributions](https://kubernetes.io/partners/#conformance),
+a simplified installation and management experience for **Kubeflow Platform**. Some distributions
+can be deployed on [all certified Kubernetes distributions](https://kubernetes.io/partners/#conformance),
 while others target a specific platform (e.g. EKS or GKE).
 
 {{% alert title="Note" color="warning" %}}
@@ -200,33 +235,9 @@ The following table lists distributions which are <em>maintained</em> by their r
   </table>
 </div>
 
-## Raw Kubeflow Manifests
-
-The raw Kubeflow Manifests are aggregated by the [Manifests Working Group](https://github.com/kubeflow/community/tree/master/wg-manifests)
-and are intended to be used as the **base of packaged distributions**.
-
-Advanced users may choose to install the manifests for a specific Kubeflow version by following the
-instructions in the `README` of the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.
-
-- [**Kubeflow 1.8:**](/docs/releases/kubeflow-1.8/)
-  - [`v1.8-branch`](https://github.com/kubeflow/manifests/tree/v1.8-branch#installation) <sup>(development branch)</sup>
-  - [`v1.8.0`](https://github.com/kubeflow/manifests/tree/v1.8.0#installation)
-- [**Kubeflow 1.7:**](/docs/releases/kubeflow-1.7/)
-  - [`v1.7-branch`](https://github.com/kubeflow/manifests/tree/v1.7-branch#installation) <sup>(development branch)</sup>
-  - [`v1.7.0`](https://github.com/kubeflow/manifests/tree/v1.7.0#installation)
-
-{{% alert title="Warning" color="warning" %}}
-Kubeflow is a complex system with many components and dependencies.
-Using the raw manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
-
-When using the raw manifests, the Kubeflow community is not able to provide support for environment-specific issues or custom configurations.
-If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
-Nevertheless, we welcome contributions and bug reports very much.
-{{% /alert %}}
-
-<a id="next-steps"></a>
-
 ## Next steps
 
-- Review the Kubeflow <a href="/docs/components/">component documentation</a>
-- Explore the <a href="/docs/components/pipelines/sdk/">Kubeflow Pipelines SDK</a>
+- Check [the Kubeflow introduction page](/docs/started/introduction/).
+- Explore the [Kubeflow architecture](/docs/started/architecture) and how Kubeflow components fit
+  into the AI/ML lifecycle.
+- Review [the Kubeflow components documentation](/docs/components/).

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,13 +5,15 @@ weight = 20
 
 +++
 
-This pages describes how to install Kubeflow standalone components or Kubeflow Platform using package
-distributions or raw manifests. Check [the introduction guide](/docs/started/introduction) to
+This page describes how to install Kubeflow standalone components or Kubeflow Platform using package
+distributions or raw manifests.
+
+Read [the introduction guide](/docs/started/introduction) to
 understand what are Kubeflow standalone components and what is Kubeflow Platform.
 
 ## Installing Kubeflow
 
-You can install Kubeflow components using one of these methods:
+You can install Kubeflow using one of these methods:
 
 - [**Install Kubeflow Components Standalone**](#install-kubeflow-components-standalone)
 - [**Install Kubeflow Platform from Packaged Distributions**](#install-kubeflow-platform-from-packaged-distributions)
@@ -19,21 +21,24 @@ You can install Kubeflow components using one of these methods:
 
 ### Install Kubeflow Components Standalone
 
-Kubeflow components can be deployed as standalone applications. You can integrate those components
-to your existing AI/ML platform. This is the easiest method to get started with Kubeflow ecosystem
-since those components usually don't require additional management tools used in Kubeflow Platform.
+Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptual-overview) may be
+deployed as standalone services, without the need to install the full platform. You might integrate
+these services as part of your existing AI/ML platform or use them independently.
 
-This table points to the installation guide for every Kubeflow component, the GitHub repository,
-and corresponding [stage of ML lifecycle](/docs/started/architecture/#kubeflow-components-in-the-ml-lifecycle)
-for every Kubeflow component.
+This is the easiest method to get started with Kubeflow ecosystem since those components usually
+don't require additional management tools used in Kubeflow Platform.
+
+The following table lists Kubeflow components that may be deployed in a standalone mode. It also
+lists their associated GitHub repository and
+corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-components-in-the-ml-lifecycle).
 
 <div class="table-responsive distributions-table">
   <table class="table table-bordered">
     <thead>
       <tr>
         <th>Component</th>
+        <th>ML Lifecycle Stage</th>
         <th>Source Code</th>
-        <th>Stage of ML Lifecycle</th>
       </tr>
     </thead>
     <tbody>
@@ -44,12 +49,12 @@ for every Kubeflow component.
           </a>
         </td>
         <td>
+          Data Preparation
+        </td>
+        <td>
           <a href="https://github.com/kubeflow/spark-operator">
             <code>kubeflow/spark-operator</code>
           </a>
-        </td>
-        <td>
-          Data Preparation
         </td>
       </tr>
       <tr>
@@ -59,12 +64,12 @@ for every Kubeflow component.
           </a>
         </td>
         <td>
+          Model Optimization and AutoML
+        </td>
+        <td>
           <a href="https://github.com/kubeflow/katib">
             <code>kubeflow/katib</code>
           </a>
-        </td>
-        <td>
-          Model Optimization and AutoML
         </td>
       </tr>
       <tr>
@@ -74,12 +79,12 @@ for every Kubeflow component.
           </a>
         </td>
         <td>
+          Model Training and Fine-Tuning
+        </td>
+        <td>
           <a href="https://github.com/kubeflow/training-operator">
             <code>kubeflow/training-operator</code>
           </a>
-        </td>
-        <td>
-          Model Training and Fine-Tuning
         </td>
       </tr>
       <tr>
@@ -89,12 +94,12 @@ for every Kubeflow component.
           </a>
         </td>
         <td>
+          All-Reduce Model Training
+        </td>
+        <td>
           <a href="https://github.com/kubeflow/mpi-operator">
             <code>kubeflow/mpi-operator</code>
           </a>
-        </td>
-        <td>
-          All-Reduce Model Training
         </td>
       </tr>
       <tr>
@@ -104,12 +109,12 @@ for every Kubeflow component.
           </a>
         </td>
         <td>
+          Model Registry
+        </td>
+        <td>
           <a href="https://github.com/kubeflow/model-registry">
             <code>kubeflow/model-registry</code>
           </a>
-        </td>
-        <td>
-          Model Registry
         </td>
       </tr>
       <tr>
@@ -119,12 +124,12 @@ for every Kubeflow component.
           </a>
         </td>
         <td>
+          Model Serving
+        </td>
+        <td>
           <a href="https://github.com/kserve/kserve">
             <code>kserve/kserve</code>
           </a>
-        </td>
-        <td>
-          Model Serving
         </td>
       </tr>
       <tr>
@@ -134,12 +139,12 @@ for every Kubeflow component.
           </a>
         </td>
         <td>
+          ML Workflows and Schedules
+        </td>
+        <td>
           <a href="https://github.com/kubeflow/pipelines">
             <code>kubeflow/pipelines</code>
           </a>
-        </td>
-        <td>
-          ML Workflows and Schedulers
         </td>
       </tr>
     </tbody>
@@ -355,7 +360,6 @@ Nevertheless, we welcome contributions and bug reports very much.
 
 ## Next steps
 
-- Check [the Kubeflow introduction page](/docs/started/introduction/).
-- Explore the [Kubeflow architecture](/docs/started/architecture) and how Kubeflow components fit
-  into the ML lifecycle.
-- Review [the Kubeflow components documentation](/docs/components/).
+- Review our [Introduction to Kubeflow](/docs/started/introduction/).
+- Explore the [Architecture of Kubeflow](/docs/started/architecture).
+- Learn more about the [Components of Kubeflow](/docs/components/).

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -11,14 +11,14 @@ distributions or raw manifests.
 Read [the introduction guide](/docs/started/introduction) to learn more about Kubeflow, Kubeflow
 standalone components and Kubeflow Platform.
 
-## Installing Kubeflow
+## Installing Methods
 
 You can install Kubeflow using one of these methods:
 
-- [**Install Kubeflow Components Standalone**](#install-kubeflow-components-standalone)
-- [**Install Kubeflow Platform**](#install-kubeflow-platform)
+- [**Kubeflow Components Standalone**](#kubeflow-components-standalone)
+- [**Kubeflow Platform**](#kubeflow-platform)
 
-## Install Kubeflow Components Standalone
+### Kubeflow Components Standalone
 
 Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptual-overview) may be
 deployed as standalone services, without the need to install the full platform. You might integrate
@@ -150,12 +150,12 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
   </table>
 </div>
 
-## Install Kubeflow Platform
+### Kubeflow Platform
 
 You can use one of the following methods to install Kubeflow Platform to get full suite of Kubeflow
 components bundled together with additional integration and management tools.
 
-### Packaged Distributions
+#### Packaged Distributions
 
 Packaged distributions are maintained by various organizations and typically aim to provide
 a simplified installation and management experience for your **Kubeflow Platform**. Some distributions
@@ -331,7 +331,7 @@ The following table lists distributions which are <em>maintained</em> by their r
   </table>
 </div>
 
-### Raw Manifests
+#### Raw Manifests
 
 The raw Kubeflow Manifests are aggregated by the Manifests Working Group and are intended to be
 used as the **base of packaged distributions**.

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -11,21 +11,21 @@ distributions or raw manifests.
 Read [the introduction guide](/docs/started/introduction) to understand what are Kubeflow
 standalone components and what is Kubeflow Platform.
 
-## Installing Kubeflow
-
 You can install Kubeflow using one of these methods:
 
 - [**Install Kubeflow Components Standalone**](#install-kubeflow-components-standalone)
-- [**Install Kubeflow Platform from Packaged Distributions**](#install-kubeflow-platform-from-packaged-distributions)
-- [**Install Kubeflow Platform from Raw Manifests**](#install-kubeflow-platform-from-raw-manifests) <sup>(advanced users)</sup>
 
-### Install Kubeflow Components Standalone
+- Install Kubeflow Platform
+  - [**From Packaged Distributions**](#from-packaged-distributions)
+  - [**From Raw Manifests**](#from-raw-manifests) <sup>(advanced users)</sup>
+
+## Install Kubeflow Components Standalone
 
 Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptual-overview) may be
 deployed as standalone services, without the need to install the full platform. You might integrate
 these services as part of your existing AI/ML platform or use them independently.
 
-This is a easier method to get started with Kubeflow ecosystem since those components usually
+This is a quick and easier method to get started with Kubeflow ecosystem since those components usually
 don't require additional management tools used in a Kubeflow Platform.
 
 The following table lists Kubeflow components that may be deployed in a standalone mode. It also
@@ -154,7 +154,12 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
 **Note**. Currently, Kubeflow Notebooks can't be deployed as a standalone application, but Notebooks
 WG is working on that as part of [this issue](https://github.com/kubeflow/kubeflow/issues/7549).
 
-### Install Kubeflow Platform from Packaged Distributions
+## Install Kubeflow Platform
+
+You can use one of the following methods to install Kubeflow Platform to get full suite of Kubeflow
+components bundled together with additional integration and management tools.
+
+### From Packaged Distributions
 
 Packaged distributions are maintained by various organizations and typically aim to provide
 a simplified installation and management experience for your **Kubeflow Platform**. Some distributions
@@ -330,10 +335,10 @@ The following table lists distributions which are <em>maintained</em> by their r
   </table>
 </div>
 
-### Install Kubeflow Platform from Raw Manifests
+### From Raw Manifests
 
-The raw Kubeflow Manifests are aggregated by the
-Manifests Working Group and are intended to be used as the **base of packaged distributions**.
+The raw Kubeflow Manifests are aggregated by the Manifests Working Group and are intended to be
+used as the **base of packaged distributions**.
 
 Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
 applications which makes **Kubeflow Platform**. This installation is helpful when you want to try

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -150,9 +150,6 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
   </table>
 </div>
 
-**Note**. Currently, Kubeflow Notebooks can't be deployed as a standalone application, but Notebooks
-WG is working on that as part of [this issue](https://github.com/kubeflow/kubeflow/issues/7549).
-
 ## Install Kubeflow Platform
 
 You can use one of the following methods to install Kubeflow Platform to get full suite of Kubeflow

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -152,8 +152,8 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
 
 ## Kubeflow Platform
 
-You can use one of the following methods to install [Kubeflow Platform](/docs/started/introduction/#what-is-kubeflow-platform)
-to get full suite of standalone Kubeflow components bundled together with additional tools.
+You can use one of the following methods to install the [Kubeflow Platform](/docs/started/introduction/#what-is-kubeflow-platform)
+and get the full suite of Kubeflow components bundled together with additional tools.
 
 ### Packaged Distributions
 
@@ -337,8 +337,8 @@ The Kubeflow Manifests are aggregated by the Manifests Working Group and are int
 used as the **base of packaged distributions**.
 
 Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
-applications which makes **Kubeflow Platform**. This installation is helpful when you want to try
-out the end-to-end Kubeflow Platform capabilities.
+applications that comprise the **Kubeflow Platform**. This installation is helpful when you want to
+try out the end-to-end Kubeflow Platform capabilities.
 
 Users may choose to install the manifests for a specific Kubeflow version by following the
 instructions in the `README` of the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.
@@ -355,7 +355,7 @@ Kubeflow is a complex system with many components and dependencies.
 Using the Kubeflow manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
 
 When using the Kubeflow manifests, the community is not able to provide support for environment-specific issues or custom configurations.
-If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
+If you need support, please consider using a [packaged distribution](#packaged-distributions).
 Nevertheless, we welcome contributions and bug reports very much.
 {{% /alert %}}
 

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -18,7 +18,7 @@ You can install Kubeflow using one of these methods:
 - [**Standalone Kubeflow Components**](#standalone-kubeflow-components)
 - [**Kubeflow Platform**](#kubeflow-platform)
 
-### Standalone Kubeflow Components
+## Standalone Kubeflow Components
 
 Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptual-overview) may be
 deployed as standalone services, without the need to install the full Kubeflow platform. You might
@@ -150,12 +150,12 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
   </table>
 </div>
 
-### Kubeflow Platform
+## Kubeflow Platform
 
 You can use one of the following methods to install [Kubeflow Platform](/docs/started/introduction/#what-is-kubeflow-platform)
 to get full suite of standalone Kubeflow components bundled together with additional tools.
 
-#### Packaged Distributions
+### Packaged Distributions
 
 Packaged distributions are maintained by various organizations and typically aim to provide
 a simplified installation and management experience for your **Kubeflow Platform**. Some distributions
@@ -331,7 +331,7 @@ The following table lists distributions which are <em>maintained</em> by their r
   </table>
 </div>
 
-#### Kubeflow Manifests
+### Kubeflow Manifests
 
 The Kubeflow Manifests are aggregated by the Manifests Working Group and are intended to be
 used as the **base of packaged distributions**.

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -8,16 +8,15 @@ weight = 20
 This guide describes how to install Kubeflow standalone components or Kubeflow Platform using package
 distributions or raw manifests.
 
-Read [the introduction guide](/docs/started/introduction) to understand what are Kubeflow
-standalone components and what is Kubeflow Platform.
+Read [the introduction guide](/docs/started/introduction) to learn more about Kubeflow, Kubeflow
+standalone components and Kubeflow Platform.
+
+## Installing Kubeflow
 
 You can install Kubeflow using one of these methods:
 
 - [**Install Kubeflow Components Standalone**](#install-kubeflow-components-standalone)
-
-- Install Kubeflow Platform
-  - [**From Packaged Distributions**](#from-packaged-distributions)
-  - [**From Raw Manifests**](#from-raw-manifests) <sup>(advanced users)</sup>
+- [**Install Kubeflow Platform**](#install-kubeflow-platform)
 
 ## Install Kubeflow Components Standalone
 
@@ -159,7 +158,7 @@ WG is working on that as part of [this issue](https://github.com/kubeflow/kubefl
 You can use one of the following methods to install Kubeflow Platform to get full suite of Kubeflow
 components bundled together with additional integration and management tools.
 
-### From Packaged Distributions
+### Packaged Distributions
 
 Packaged distributions are maintained by various organizations and typically aim to provide
 a simplified installation and management experience for your **Kubeflow Platform**. Some distributions
@@ -335,7 +334,7 @@ The following table lists distributions which are <em>maintained</em> by their r
   </table>
 </div>
 
-### From Raw Manifests
+### Raw Manifests
 
 The raw Kubeflow Manifests are aggregated by the Manifests Working Group and are intended to be
 used as the **base of packaged distributions**.

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -37,17 +37,17 @@ This table points to the installation guide for every Kubeflow component, the Gi
     <tbody>
       <tr>
         <td>
-          <a href="/docs/components/training/installation/#installing-training-operator">
-            Kubeflow Training Operator
+          <a href="https://github.com/kubeflow/spark-operator/tree/master?tab=readme-ov-file#installation">
+            Kubeflow Spark Operator
           </a>
         </td>
         <td>
-          <a href="https://github.com/kubeflow/training-operator">
-            <code>kubeflow/training-operator</code>
+          <a href="https://github.com/kubeflow/spark-operator">
+            <code>kubeflow/spark-operator</code>
           </a>
         </td>
         <td>
-          Model Training and Fine-Tuning
+          Data Preparation
         </td>
       </tr>
       <tr>
@@ -63,6 +63,21 @@ This table points to the installation guide for every Kubeflow component, the Gi
         </td>
         <td>
           Model Optimization and AutoML
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/docs/components/training/installation/#installing-training-operator">
+            Kubeflow Training Operator
+          </a>
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/training-operator">
+            <code>kubeflow/training-operator</code>
+          </a>
+        </td>
+        <td>
+          Model Training and Fine-Tuning
         </td>
       </tr>
       <tr>

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,62 +5,134 @@ weight = 20
 
 +++
 
-## What is Kubeflow ?
-
-Kubeflow is a community and ecosystem of open-source projects to address each stage in the
-machine learning (ML) lifecycle. It makes ML on Kubernetes simple, portable, and scalable.
-Its goal is to facilitate the orchestration of Kubernetes workloads for ML and to empower users to
-deploy best-in-class open-source systems for ML to diverse cloud infrastructures.
-Whether you’re a researcher, data scientist, ML engineer, or a team of developers, Kubeflow offers
-modular and scalable tools that cater to all aspects of the ML lifecycle: from building ML models to
-deploying them to production for AI applications.
-
-## What are Kubeflow Standalone Components?
-
-Kubeflow is composed of multiple, independent open-source projects which address different aspects
-of a ML lifecycle. These standalone components are designed to be usable both within the Kubeflow
-platform and independently. These components can be installed on their own on a Kubernetes cluster,
-providing flexibility to users who may not require the full capabilities of Kubeflow Platform but
-wish to leverage specific functionalities in the ML lifecycle.
-
-## What is Kubeflow Platform ?
-
-The Kubeflow Platform refers to the full suite of Kubeflow components bundled together with
-additional integration and management tools. Installing Kubeflow as a platform means deploying a
-comprehensive ML toolkit that integrates these components into a cohesive system, optimized for
-managing the end-to-end ML lifecycle. These includes not only the standalone components but also:
-
-- Central Dashboard for easy navigation and management.
-- Multi-user capabilities and access management.
-- Additional tooling and services for data management, visualization, and more.
-
-This integrated environment ensures that all the different pieces work together seamlessly,
-providing a more robust and streamlined user experience.
-
-Kubeflow Platform can be installed via Raw Manifests or Package Distributions.
+This pages shows how to install Kubeflow standalone components or Kubeflow Platform using package
+distributions or raw manifests. Check [the introduction guide](/docs/started/introduction) to
+understand what are Kubeflow standalone components and what is Kubeflow Platform.
 
 ## Installing Kubeflow
 
+You can install Kubeflow components using one of these methods:
+
 - [**Install Kubeflow Components Standalone**](#install-kubeflow-components-standalone)
-- [**Install Kubeflow Platform from Packaged Distributions**](#install-kubeflow-platform-from-packages-distributions)
-- [**Install Kubeflow Platform from Raw Manifests**](#install-kubeflow-platform-from-raw-manifests)
+- [**Install Kubeflow Platform from Packaged Distributions**](#install-kubeflow-platform-from-packaged-distributions)
+- [**Install Kubeflow Platform from Raw Manifests**](#install-kubeflow-platform-from-raw-manifests) <sup>(advanced users)</sup>
 
 ### Install Kubeflow Components Standalone
 
 Kubeflow components can be deployed as standalone applications. You can integrate those components
-to your existing AI/ML platform. For example, for Model Training you can install Training Operator
-or for Model Serving you can install KServe.
+to your existing AI/ML platform. This is the easiest method to get started with Kubeflow ecosystem
+since those components don't require additional management used in Kubeflow Platform.
 
-Follow the appropriate guides to install required Kubeflow components in standalone mode:
+This table points to the installation guide for every Kubeflow component, the GitHub repository, and corresponding [stage of ML lifecycle](/docs/started/architecture/#kubeflow-components-in-the-ml-lifecycle) for every Kubeflow component.
 
-- Install [Kubeflow Pipelines](/docs/components/pipelines/v2/installation/quickstart/)
-- Install [Kubeflow Training Operator](/docs/components/training/installation/#installing-training-operator)
-- Install [Kubeflow MPI Operator](/docs/components/training/user-guides/mpi/#installation)
-- Install [Kubeflow Katib] (TODO: Add link after #3723)
-- Install [KServe](https://kserve.github.io/website/0.10/admin/serverless/serverless/)
-- Install Kubeflow Model Registry (TODO: Add link after #3698)
+<div class="table-responsive components-table">
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Component</th>
+        <th>Source Code</th>
+        <th>Stage of ML Lifecycle</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/docs/components/training/installation/#installing-training-operator">
+            Kubeflow Training Operator
+          </a>
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/training-operator">
+            <code>kubeflow/training-operator</code>
+          </a>
+        </td>
+        <td>
+          Model Training and Fine-Tuning
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/docs/components/katib/installation/#installing-katib">
+            Kubeflow Katib
+          </a>
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/katib">
+            <code>kubeflow/katib</code>
+          </a>
+        </td>
+        <td>
+          Model Optimization and AutoML
+        </td>
+      </tr>
+      <tr>
+        <td>
+         <a href="/docs/components/training/user-guides/mpi/#installation">
+            Kubeflow MPI Operator
+          </a>
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/mpi-operator">
+            <code>kubeflow/mpi-operator</code>
+          </a>
+        </td>
+        <td>
+          All-Reduce Model Training
+        </td>
+      </tr>
+      <tr>
+        <td>
+         <a href="/docs/components/model-registry/installation/#installing-model-registry">
+            Kubeflow Model Registry
+          </a>
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/model-registry">
+            <code>kubeflow/model-registry</code>
+          </a>
+        </td>
+        <td>
+          Model Registry
+        </td>
+      </tr>
+      <tr>
+        <td>
+         <a href="https://kserve.github.io/website/master/admin/serverless/serverless">
+            KServe
+          </a>
+        </td>
+        <td>
+          <a href="https://github.com/kserve/kserve">
+            <code>kserve/kserve</code>
+          </a>
+        </td>
+        <td>
+          Model Serving
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="docs/components/pipelines/v2/installation/quickstart/">
+            Kubeflow Pipelines
+          </a>
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/pipelines">
+            <code>kubeflow/pipelines</code>
+          </a>
+        </td>
+        <td>
+          ML Workflows and Schedulers
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
-## Install Kubeflow Platform from Packages Distributions
+**Note**. Currently, Kubeflow Notebooks can't be deployed as a standalone application, but Notebooks
+WG is working on that as part of [this issue](https://github.com/kubeflow/kubeflow/issues/7549).
+
+## Install Kubeflow Platform from Packaged Distributions
 
 Packaged distributions are maintained by various organizations and typically aim to provide
 a simplified installation and management experience for **Kubeflow Platform**. Some distributions
@@ -269,5 +341,5 @@ Nevertheless, we welcome contributions and bug reports very much.
 
 - Check [the Kubeflow introduction page](/docs/started/introduction/).
 - Explore the [Kubeflow architecture](/docs/started/architecture) and how Kubeflow components fit
-  into the AI/ML lifecycle.
+  into the ML lifecycle.
 - Review [the Kubeflow components documentation](/docs/components/).

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,11 +5,11 @@ weight = 20
 
 +++
 
-This guide describes how to install Kubeflow standalone components or Kubeflow Platform using package
+This guide describes how to install standalone Kubeflow components or Kubeflow Platform using package
 distributions or raw manifests.
 
-Read [the introduction guide](/docs/started/introduction) to learn more about Kubeflow, Kubeflow
-standalone components and Kubeflow Platform.
+Read [the introduction guide](/docs/started/introduction) to learn more about Kubeflow, standalone
+Kubeflow components and Kubeflow Platform.
 
 ## Installation Methods
 
@@ -21,8 +21,8 @@ You can install Kubeflow using one of these methods:
 ### Standalone Kubeflow Components
 
 Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptual-overview) may be
-deployed as standalone services, without the need to install the full platform. You might integrate
-these services as part of your existing AI/ML platform or use them independently.
+deployed as standalone services, without the need to install the full Kubeflow platform. You might
+integrate these services as part of your existing AI/ML platform or use them independently.
 
 This is a quick and easier method to get started with Kubeflow ecosystem since those components usually
 don't require additional management tools used in a Kubeflow Platform.
@@ -152,8 +152,8 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
 
 ### Kubeflow Platform
 
-You can use one of the following methods to install Kubeflow Platform to get full suite of Kubeflow
-components bundled together with additional integration and management tools.
+You can use one of the following methods to install [Kubeflow Platform](/docs/started/introduction/#what-is-kubeflow-platform)
+to get full suite of standalone Kubeflow components bundled together with additional tools.
 
 #### Packaged Distributions
 

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -44,21 +44,6 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
     <tbody>
       <tr>
         <td>
-          <a href="https://github.com/kubeflow/spark-operator/tree/master?tab=readme-ov-file#installation">
-            Kubeflow Spark Operator
-          </a>
-        </td>
-        <td>
-          Data Preparation
-        </td>
-        <td>
-          <a href="https://github.com/kubeflow/spark-operator">
-            <code>kubeflow/spark-operator</code>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
           <a href="/docs/components/katib/installation/#installing-katib">
             Kubeflow Katib
           </a>
@@ -69,51 +54,6 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
         <td>
           <a href="https://github.com/kubeflow/katib">
             <code>kubeflow/katib</code>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <a href="/docs/components/training/installation/#installing-training-operator">
-            Kubeflow Training Operator
-          </a>
-        </td>
-        <td>
-          Model Training and Fine-Tuning
-        </td>
-        <td>
-          <a href="https://github.com/kubeflow/training-operator">
-            <code>kubeflow/training-operator</code>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-         <a href="/docs/components/training/user-guides/mpi/#installation">
-            Kubeflow MPI Operator
-          </a>
-        </td>
-        <td>
-          All-Reduce Model Training
-        </td>
-        <td>
-          <a href="https://github.com/kubeflow/mpi-operator">
-            <code>kubeflow/mpi-operator</code>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-         <a href="/docs/components/model-registry/installation/#installing-model-registry">
-            Kubeflow Model Registry
-          </a>
-        </td>
-        <td>
-          Model Registry
-        </td>
-        <td>
-          <a href="https://github.com/kubeflow/model-registry">
-            <code>kubeflow/model-registry</code>
           </a>
         </td>
       </tr>
@@ -134,6 +74,36 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
       </tr>
       <tr>
         <td>
+         <a href="/docs/components/model-registry/installation/#installing-model-registry">
+            Kubeflow Model Registry
+          </a>
+        </td>
+        <td>
+          Model Registry
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/model-registry">
+            <code>kubeflow/model-registry</code>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+         <a href="/docs/components/training/user-guides/mpi/#installation">
+            Kubeflow MPI Operator
+          </a>
+        </td>
+        <td>
+          All-Reduce Model Training
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/mpi-operator">
+            <code>kubeflow/mpi-operator</code>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>
           <a href="docs/components/pipelines/v2/installation/quickstart/">
             Kubeflow Pipelines
           </a>
@@ -144,6 +114,36 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
         <td>
           <a href="https://github.com/kubeflow/pipelines">
             <code>kubeflow/pipelines</code>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="https://github.com/kubeflow/spark-operator/tree/master?tab=readme-ov-file#installation">
+            Kubeflow Spark Operator
+          </a>
+        </td>
+        <td>
+          Data Preparation
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/spark-operator">
+            <code>kubeflow/spark-operator</code>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/docs/components/training/installation/#installing-training-operator">
+            Kubeflow Training Operator
+          </a>
+        </td>
+        <td>
+          Model Training and Fine-Tuning
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/training-operator">
+            <code>kubeflow/training-operator</code>
           </a>
         </td>
       </tr>

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,18 +5,47 @@ weight = 20
 
 +++
 
-Kubeflow is an ecosystem of various applications created to address each stage in the AI/ML lifecycle,
-from exploration to training and serving. You can deploy Kubeflow components as standalone applications
-or deploy Kubeflow as an end-to-end AI/ML platform. Anywhere you are running Kubernetes,
-you should be able to run Kubeflow.
+## What is Kubeflow ?
 
-There are a few ways to install Kubeflow:
+Kubeflow is a community and ecosystem of open-source projects to address each stage in the
+machine learning (ML) lifecycle. It makes ML on Kubernetes simple, portable, and scalable.
+Its goal is to facilitate the orchestration of Kubernetes workloads for ML and to empower users to
+deploy best-in-class open-source systems for ML to diverse cloud infrastructures.
+Whether you’re a researcher, data scientist, ML engineer, or a team of developers, Kubeflow offers
+modular and scalable tools that cater to all aspects of the ML lifecycle: from building ML models to
+deploying them to production for AI applications.
+
+## What are Kubeflow Standalone Components?
+
+Kubeflow is composed of multiple, independent open-source projects which address different aspects
+of a ML lifecycle. These standalone components are designed to be usable both within the Kubeflow
+platform and independently. These components can be installed on their own on a Kubernetes cluster,
+providing flexibility to users who may not require the full capabilities of Kubeflow Platform but
+wish to leverage specific functionalities in the ML lifecycle.
+
+## What is Kubeflow Platform ?
+
+The Kubeflow Platform refers to the full suite of Kubeflow components bundled together with
+additional integration and management tools. Installing Kubeflow as a platform means deploying a
+comprehensive ML toolkit that integrates these components into a cohesive system, optimized for
+managing the end-to-end ML lifecycle. These includes not only the standalone components but also:
+
+- Central Dashboard for easy navigation and management.
+- Multi-user capabilities and access management.
+- Additional tooling and services for data management, visualization, and more.
+
+This integrated environment ensures that all the different pieces work together seamlessly,
+providing a more robust and streamlined user experience.
+
+Kubeflow Platform can be installed via Raw Manifests or Package Distributions.
+
+## Installing Kubeflow
 
 - [**Install Kubeflow Components Standalone**](#install-kubeflow-components-standalone)
-- [**Install Kubeflow Platform from Raw Manifests**](#install-kubeflow-platform-from-raw-manifests)
 - [**Install Kubeflow Platform from Packaged Distributions**](#install-kubeflow-platform-from-packages-distributions)
+- [**Install Kubeflow Platform from Raw Manifests**](#install-kubeflow-platform-from-raw-manifests)
 
-## Install Kubeflow Components Standalone
+### Install Kubeflow Components Standalone
 
 Kubeflow components can be deployed as standalone applications. You can integrate those components
 to your existing AI/ML platform. For example, for Model Training you can install Training Operator
@@ -30,35 +59,6 @@ Follow the appropriate guides to install required Kubeflow components in standal
 - Install [Kubeflow Katib] (TODO: Add link after #3723)
 - Install [KServe](https://kserve.github.io/website/0.10/admin/serverless/serverless/)
 - Install Kubeflow Model Registry (TODO: Add link after #3698)
-
-## Install Kubeflow Platform from Raw Manifests
-
-The raw Kubeflow Manifests are aggregated by the
-[Manifests Working Group](https://github.com/kubeflow/community/tree/master/wg-manifests)
-and are intended to be used as the **base of packaged distributions**.
-
-Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
-applications which makes **Kubeflow Platform**. This installation is helpful when you want to try
-out the end-to-end Kubeflow Platform capabilities.
-
-Users may choose to install the manifests for a specific Kubeflow version by following the
-instructions in the `README` of the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.
-
-- [**Kubeflow 1.8:**](/docs/releases/kubeflow-1.8/)
-  - [`v1.8-branch`](https://github.com/kubeflow/manifests/tree/v1.8-branch#installation) <sup>(development branch)</sup>
-  - [`v1.8.0`](https://github.com/kubeflow/manifests/tree/v1.8.0#installation)
-- [**Kubeflow 1.7:**](/docs/releases/kubeflow-1.7/)
-  - [`v1.7-branch`](https://github.com/kubeflow/manifests/tree/v1.7-branch#installation) <sup>(development branch)</sup>
-  - [`v1.7.0`](https://github.com/kubeflow/manifests/tree/v1.7.0#installation)
-
-{{% alert title="Warning" color="warning" %}}
-Kubeflow is a complex system with many components and dependencies.
-Using the raw manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
-
-When using the raw manifests, the Kubeflow community is not able to provide support for environment-specific issues or custom configurations.
-If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
-Nevertheless, we welcome contributions and bug reports very much.
-{{% /alert %}}
 
 ## Install Kubeflow Platform from Packages Distributions
 
@@ -235,6 +235,35 @@ The following table lists distributions which are <em>maintained</em> by their r
     </tbody>
   </table>
 </div>
+
+### Install Kubeflow Platform from Raw Manifests
+
+The raw Kubeflow Manifests are aggregated by the
+[Manifests Working Group](https://github.com/kubeflow/community/tree/master/wg-manifests)
+and are intended to be used as the **base of packaged distributions**.
+
+Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
+applications which makes **Kubeflow Platform**. This installation is helpful when you want to try
+out the end-to-end Kubeflow Platform capabilities.
+
+Users may choose to install the manifests for a specific Kubeflow version by following the
+instructions in the `README` of the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.
+
+- [**Kubeflow 1.8:**](/docs/releases/kubeflow-1.8/)
+  - [`v1.8-branch`](https://github.com/kubeflow/manifests/tree/v1.8-branch#installation) <sup>(development branch)</sup>
+  - [`v1.8.0`](https://github.com/kubeflow/manifests/tree/v1.8.0#installation)
+- [**Kubeflow 1.7:**](/docs/releases/kubeflow-1.7/)
+  - [`v1.7-branch`](https://github.com/kubeflow/manifests/tree/v1.7-branch#installation) <sup>(development branch)</sup>
+  - [`v1.7.0`](https://github.com/kubeflow/manifests/tree/v1.7.0#installation)
+
+{{% alert title="Warning" color="warning" %}}
+Kubeflow is a complex system with many components and dependencies.
+Using the raw manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
+
+When using the raw manifests, the Kubeflow community is not able to provide support for environment-specific issues or custom configurations.
+If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
+Nevertheless, we welcome contributions and bug reports very much.
+{{% /alert %}}
 
 ## Next steps
 

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,7 +5,7 @@ weight = 20
 
 +++
 
-Kubeflow is the ecosystem of various applications created to address each stage in the AI/ML lifecycle,
+Kubeflow is an ecosystem of various applications created to address each stage in the AI/ML lifecycle,
 from exploration to training and serving. You can deploy Kubeflow components as standalone applications
 or deploy Kubeflow as an end-to-end AI/ML platform. Anywhere you are running Kubernetes,
 you should be able to run Kubeflow.
@@ -38,7 +38,8 @@ The raw Kubeflow Manifests are aggregated by the
 and are intended to be used as the **base of packaged distributions**.
 
 Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
-applications which makes **Kubeflow Platform**.
+applications which makes **Kubeflow Platform**. This installation is helpful when you want to try
+out the end-to-end Kubeflow Platform capabilities.
 
 Users may choose to install the manifests for a specific Kubeflow version by following the
 instructions in the `README` of the [`kubeflow/manifests`](https://github.com/kubeflow/manifests) repository.

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -5,7 +5,7 @@ weight = 20
 
 +++
 
-This pages shows how to install Kubeflow standalone components or Kubeflow Platform using package
+This pages describes how to install Kubeflow standalone components or Kubeflow Platform using package
 distributions or raw manifests. Check [the introduction guide](/docs/started/introduction) to
 understand what are Kubeflow standalone components and what is Kubeflow Platform.
 
@@ -21,11 +21,13 @@ You can install Kubeflow components using one of these methods:
 
 Kubeflow components can be deployed as standalone applications. You can integrate those components
 to your existing AI/ML platform. This is the easiest method to get started with Kubeflow ecosystem
-since those components don't require additional management used in Kubeflow Platform.
+since those components usually don't require additional management tools used in Kubeflow Platform.
 
-This table points to the installation guide for every Kubeflow component, the GitHub repository, and corresponding [stage of ML lifecycle](/docs/started/architecture/#kubeflow-components-in-the-ml-lifecycle) for every Kubeflow component.
+This table points to the installation guide for every Kubeflow component, the GitHub repository,
+and corresponding [stage of ML lifecycle](/docs/started/architecture/#kubeflow-components-in-the-ml-lifecycle)
+for every Kubeflow component.
 
-<div class="table-responsive components-table">
+<div class="table-responsive distributions-table">
   <table class="table table-bordered">
     <thead>
       <tr>
@@ -147,7 +149,7 @@ This table points to the installation guide for every Kubeflow component, the Gi
 **Note**. Currently, Kubeflow Notebooks can't be deployed as a standalone application, but Notebooks
 WG is working on that as part of [this issue](https://github.com/kubeflow/kubeflow/issues/7549).
 
-## Install Kubeflow Platform from Packaged Distributions
+### Install Kubeflow Platform from Packaged Distributions
 
 Packaged distributions are maintained by various organizations and typically aim to provide
 a simplified installation and management experience for **Kubeflow Platform**. Some distributions

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -6,7 +6,7 @@ weight = 20
 +++
 
 This guide describes how to install standalone Kubeflow components or Kubeflow Platform using package
-distributions or raw manifests.
+distributions or Kubeflow manifests.
 
 Read [the introduction guide](/docs/started/introduction) to learn more about Kubeflow, standalone
 Kubeflow components and Kubeflow Platform.
@@ -43,21 +43,6 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
     <tbody>
       <tr>
         <td>
-          <a href="/docs/components/katib/installation/#installing-katib">
-            Kubeflow Katib
-          </a>
-        </td>
-        <td>
-          Model Optimization and AutoML
-        </td>
-        <td>
-          <a href="https://github.com/kubeflow/katib">
-            <code>kubeflow/katib</code>
-          </a>
-        </td>
-      </tr>
-      <tr>
-        <td>
          <a href="https://kserve.github.io/website/master/admin/serverless/serverless">
             KServe
           </a>
@@ -68,6 +53,21 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
         <td>
           <a href="https://github.com/kserve/kserve">
             <code>kserve/kserve</code>
+          </a>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/docs/components/katib/installation/#installing-katib">
+            Kubeflow Katib
+          </a>
+        </td>
+        <td>
+          Model Optimization and AutoML
+        </td>
+        <td>
+          <a href="https://github.com/kubeflow/katib">
+            <code>kubeflow/katib</code>
           </a>
         </td>
       </tr>
@@ -331,9 +331,9 @@ The following table lists distributions which are <em>maintained</em> by their r
   </table>
 </div>
 
-#### Raw Manifests
+#### Kubeflow Manifests
 
-The raw Kubeflow Manifests are aggregated by the Manifests Working Group and are intended to be
+The Kubeflow Manifests are aggregated by the Manifests Working Group and are intended to be
 used as the **base of packaged distributions**.
 
 Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
@@ -352,9 +352,9 @@ instructions in the `README` of the [`kubeflow/manifests`](https://github.com/ku
 
 {{% alert title="Warning" color="warning" %}}
 Kubeflow is a complex system with many components and dependencies.
-Using the raw manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
+Using the Kubeflow manifests requires a deep understanding of Kubernetes, Istio, and Kubeflow itself.
 
-When using the raw manifests, the Kubeflow community is not able to provide support for environment-specific issues or custom configurations.
+When using the Kubeflow manifests, the community is not able to provide support for environment-specific issues or custom configurations.
 If you need support, please consider using a [packaged distribution](#packaged-distributions-of-kubeflow).
 Nevertheless, we welcome contributions and bug reports very much.
 {{% /alert %}}

--- a/content/en/docs/started/installing-kubeflow.md
+++ b/content/en/docs/started/installing-kubeflow.md
@@ -24,7 +24,7 @@ Some components in the [Kubeflow ecosystem](/docs/started/architecture/#conceptu
 deployed as standalone services, without the need to install the full Kubeflow platform. You might
 integrate these services as part of your existing AI/ML platform or use them independently.
 
-This is a quick and easier method to get started with Kubeflow ecosystem since those components usually
+This is a quick and easy method to get started with Kubeflow ecosystem since those components usually
 don't require additional management tools used in a Kubeflow Platform.
 
 The following table lists Kubeflow components that may be deployed in a standalone mode. It also

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -41,7 +41,7 @@ In addition to the standalone Kubeflow components, the Kubeflow Platform include
 
 The Kubeflow Platform can be installed via
 [Packaged Distributions](/docs/started/installing-kubeflow/#packaged-distributions) or
-[Raw Manifests](/docs/started/installing-kubeflow/#raw-manifests).
+[Kubeflow Manifests](/docs/started/installing-kubeflow/#kubeflow-manifests).
 
 ## Getting started with Kubeflow
 

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -36,7 +36,9 @@ managing the end-to-end ML lifecycle. These includes not only the standalone com
 This integrated environment ensures that all the different pieces work together seamlessly,
 providing a more robust and streamlined user experience.
 
-Kubeflow Platform can be installed via Raw Manifests or Package Distributions.
+Kubeflow Platform can be installed via
+[Packaged Distributions](/docs/started/installing-kubeflow/#install-kubeflow-platform-from-packaged-distributions) or
+[Raw Manifests](/docs/started/installing-kubeflow/#install-kubeflow-platform-from-raw-manifests).
 
 ## Getting started with Kubeflow
 

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -96,9 +96,9 @@ To see what's coming up in future versions of Kubeflow, refer to the [Kubeflow r
 The following components also have roadmaps:
 
 - [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/blob/master/ROADMAP.md)
-- [KF Serving](https://github.com/kubeflow/kfserving/blob/master/ROADMAP.md)
+- [KServe](https://github.com/kserve/kserve/blob/master/ROADMAP.md)
 - [Katib](https://github.com/kubeflow/katib/blob/master/ROADMAP.md)
-- [Training Operator](https://github.com/kubeflow/common/blob/master/ROADMAP.md)
+- [Training Operator](https://github.com/kubeflow/training-operator/blob/master/docs/roadmap.md)
 
 ## Getting involved
 
@@ -108,5 +108,5 @@ Read the [contributor's guide](/docs/about/contributing/) to get started on the 
 
 ## Next Steps
 
-- Follow [the installation guide](/docs/started/installing-kubeflow) to deploy Kubeflow standalone
-  components or Kubeflow Platform.
+- Follow [the installation guide](/docs/started/installing-kubeflow) to deploy standalone
+  Kubeflow components or Kubeflow Platform.

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -10,17 +10,20 @@ Kubeflow is a community and ecosystem of open-source projects to address each st
 machine learning (ML) lifecycle. It makes ML on Kubernetes simple, portable, and scalable.
 The goal of Kubeflow is to facilitate the orchestration of Kubernetes ML workloads and to empower
 users to deploy best-in-class open-source tools on any Cloud infrastructure.
+
 Whether you’re a researcher, data scientist, ML engineer, or a team of developers, Kubeflow offers
 modular and scalable tools that cater to all aspects of the ML lifecycle: from building ML models to
 deploying them to production for AI applications.
 
 ## What are Kubeflow Standalone Components
 
-Kubeflow is composed of multiple open-source projects which address different aspects
-of the ML lifecycle. These standalone components are designed to be usable both within the Kubeflow
-Platform and independently. These components can be installed standalone on a Kubernetes cluster,
-providing flexibility to users who may not require the full Kubeflow Platform capabilities but
-wish to leverage specific ML functionalities.
+Kubeflow ecosystem is composed of multiple open-source projects that address different aspects of
+the ML lifecycle. Many of these projects are designed to be usable both within the
+Kubeflow Platform and independently.
+
+These Kubeflow components can be installed standalone on a Kubernetes cluster. It provides
+flexibility to users who may not require the full Kubeflow Platform capabilities but wish to
+leverage specific ML functionalities such as model training or model serving.
 
 ## What is Kubeflow Platform
 

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -4,11 +4,41 @@ description = "An introduction to Kubeflow"
 weight = 1
 +++
 
-The Kubeflow project is dedicated to making deployments of machine learning (ML)
-workflows on Kubernetes simple, portable and scalable. Our goal is not to
-recreate other services, but to provide a straightforward way to deploy
-best-of-breed open-source systems for ML to diverse infrastructures. Anywhere
-you are running Kubernetes, you should be able to run Kubeflow.
+## What is Kubeflow ?
+
+Kubeflow is a community and ecosystem of open-source projects to address each stage in the
+machine learning (ML) lifecycle. It makes ML on Kubernetes simple, portable, and scalable.
+Its goal is to facilitate the orchestration of Kubernetes workloads for ML and to empower users to
+deploy best-in-class open-source systems for ML to diverse cloud infrastructures.
+Whether you’re a researcher, data scientist, ML engineer, or a team of developers, Kubeflow offers
+modular and scalable tools that cater to all aspects of the ML lifecycle: from building ML models to
+deploying them to production for AI applications.
+
+## What are Kubeflow Standalone Components?
+
+Kubeflow is composed of multiple, independent open-source projects which address different aspects
+of a ML lifecycle. These standalone components are designed to be usable both within the Kubeflow
+Platform and independently. These components can be installed on their own on a Kubernetes cluster,
+providing flexibility to users who may not require the full capabilities of Kubeflow Platform but
+wish to leverage specific functionalities in the ML lifecycle.
+
+## What is Kubeflow Platform ?
+
+The Kubeflow Platform refers to the full suite of Kubeflow components bundled together with
+additional integration and management tools. Installing Kubeflow as a platform means deploying a
+comprehensive ML toolkit that integrates these components into a cohesive system, optimized for
+managing the end-to-end ML lifecycle. These includes not only the standalone components but also:
+
+- Central Dashboard for easy navigation and management.
+- Multi-user capabilities and access management.
+- Additional tooling and services for data management, visualization, and more.
+
+This integrated environment ensures that all the different pieces work together seamlessly,
+providing a more robust and streamlined user experience.
+
+Kubeflow Platform can be installed via Raw Manifests or Package Distributions.
+
+## Getting started with Kubeflow
 
 The following diagram shows the main Kubeflow components to cover each step of ML lifecycle
 on top of Kubernetes.
@@ -16,8 +46,6 @@ on top of Kubernetes.
 <img src="/docs/started/images/kubeflow-intro-diagram.drawio.svg"
   alt="Kubeflow overview"
   class="mt-3 mb-3">
-
-## Getting started with Kubeflow
 
 Read the [architecture overview](/docs/started/architecture/) for an
 introduction to the architecture of Kubeflow and to see how you can use Kubeflow
@@ -29,28 +57,6 @@ your environment and install Kubeflow.
 Watch the following video which provides an introduction to Kubeflow.
 
 {{< youtube id="cTZArDgbIWw" title="Introduction to Kubeflow">}}
-
-## What is Kubeflow?
-
-Kubeflow is _the machine learning toolkit for Kubernetes_.
-
-To use Kubeflow, the basic workflow is:
-
-- Download and run the Kubeflow deployment binary.
-- Customize the resulting configuration files.
-- Run the specified script to deploy your containers to your specific
-  environment.
-
-You can adapt the configuration to choose the platforms and services that you
-want to use for each stage of the ML workflow:
-
-1. data preparation
-2. model training,
-3. prediction serving
-4. service management
-
-You can choose to deploy your Kubernetes workloads locally, on-premises, or to
-a cloud environment.
 
 ## The Kubeflow mission
 
@@ -94,3 +100,8 @@ The following components also have roadmaps:
 There are many ways to contribute to Kubeflow, and we welcome contributions!
 
 Read the [contributor's guide](/docs/about/contributing/) to get started on the code, and learn about the community on the [community page](/docs/about/community/).
+
+## Next Steps
+
+- Follow [the installation guide](/docs/started/installing-kubeflow) to deploy Kubeflow standalone
+  components or Kubeflow Platform.

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -4,42 +4,40 @@ description = "An introduction to Kubeflow"
 weight = 1
 +++
 
-## What is Kubeflow ?
+## What is Kubeflow
 
 Kubeflow is a community and ecosystem of open-source projects to address each stage in the
 machine learning (ML) lifecycle. It makes ML on Kubernetes simple, portable, and scalable.
 The goal of Kubeflow is to facilitate the orchestration of Kubernetes ML workloads and to empower
-users to deploy best-in-class open-source systems to any Cloud infrastructure.
+users to deploy best-in-class open-source tools on any Cloud infrastructure.
 Whether you’re a researcher, data scientist, ML engineer, or a team of developers, Kubeflow offers
 modular and scalable tools that cater to all aspects of the ML lifecycle: from building ML models to
 deploying them to production for AI applications.
 
-## What are Kubeflow Standalone Components?
+## What are Kubeflow Standalone Components
 
-Kubeflow is composed of multiple, independent open-source projects which address different aspects
-of a ML lifecycle. These standalone components are designed to be usable both within the Kubeflow
-Platform and independently. These components can be installed independently on a Kubernetes cluster,
-providing flexibility to users who may not require the full capabilities of Kubeflow Platform but
+Kubeflow is composed of multiple open-source projects which address different aspects
+of the ML lifecycle. These standalone components are designed to be usable both within the Kubeflow
+Platform and independently. These components can be installed standalone on a Kubernetes cluster,
+providing flexibility to users who may not require the full Kubeflow Platform capabilities but
 wish to leverage specific ML functionalities.
 
-## What is Kubeflow Platform ?
+## What is Kubeflow Platform
 
 The Kubeflow Platform refers to the full suite of Kubeflow components bundled together with
-additional integration and management tools. Installing Kubeflow as a platform means deploying a
-comprehensive ML toolkit that integrates these components into a cohesive system, optimized for
-managing the end-to-end ML lifecycle. This includes the standalone components coupled with these
-integrations and management tools:
+additional integration and management tools. Using Kubeflow as a platform means deploying a
+comprehensive ML toolkit fot the entire ML lifecycle. This includes the standalone components
+coupled with these integrations and management tools:
 
-- Central Dashboard for easy navigation and management.
-- Multi-user capabilities and access management.
-- Additional tooling and services for data management, visualization, and more.
+- [**Central Dashboard**](/docs/components/central-dash/overview/) for easy navigation and management.
 
-This integrated environment ensures that all the different pieces work together seamlessly,
-providing a more robust and streamlined user experience.
+- Multi-user capabilities and access management with [Kubeflow Profiles](/docs/components/central-dash/profiles/).
 
-Kubeflow Platform can be installed via
-[Packaged Distributions](/docs/started/installing-kubeflow/#install-kubeflow-platform-from-packaged-distributions) or
-[Raw Manifests](/docs/started/installing-kubeflow/#install-kubeflow-platform-from-raw-manifests).
+- Additional tooling for data management (PVC Viewer), visualization (TensorBoards), and more.
+
+The Kubeflow Platform can be installed via
+[Packaged Distributions](/docs/started/installing-kubeflow/#packaged-distributions) or
+[Raw Manifests](/docs/started/installing-kubeflow/#raw-manifests).
 
 ## Getting started with Kubeflow
 

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -15,10 +15,10 @@ Whether you’re a researcher, data scientist, ML engineer, or a team of develop
 modular and scalable tools that cater to all aspects of the ML lifecycle: from building ML models to
 deploying them to production for AI applications.
 
-## What are Kubeflow Standalone Components
+## What are Standalone Kubeflow Components
 
-Kubeflow ecosystem is composed of multiple open-source projects that address different aspects of
-the ML lifecycle. Many of these projects are designed to be usable both within the
+The Kubeflow ecosystem is composed of multiple open-source projects that address different aspects
+of the ML lifecycle. Many of these projects are designed to be usable both within the
 Kubeflow Platform and independently.
 
 These Kubeflow components can be installed standalone on a Kubernetes cluster. It provides
@@ -29,8 +29,9 @@ leverage specific ML functionalities such as model training or model serving.
 
 The Kubeflow Platform refers to the full suite of Kubeflow components bundled together with
 additional integration and management tools. Using Kubeflow as a platform means deploying a
-comprehensive ML toolkit fot the entire ML lifecycle. This includes the standalone components
-coupled with these integrations and management tools:
+comprehensive ML toolkit for the entire ML lifecycle.
+
+In addition to the standalone Kubeflow components, the Kubeflow Platform includes
 
 - [Kubeflow Notebooks](/docs/components/notebooks/overview) for interactive data exploration and
   model development.

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -8,8 +8,8 @@ weight = 1
 
 Kubeflow is a community and ecosystem of open-source projects to address each stage in the
 machine learning (ML) lifecycle. It makes ML on Kubernetes simple, portable, and scalable.
-Its goal is to facilitate the orchestration of Kubernetes workloads for ML and to empower users to
-deploy best-in-class open-source systems for ML to diverse cloud infrastructures.
+The Kubeflow goal is to facilitate the orchestration of Kubernetes ML workloads and to empower users
+to deploy best-in-class open-source systems to any Cloud infrastructure.
 Whether you’re a researcher, data scientist, ML engineer, or a team of developers, Kubeflow offers
 modular and scalable tools that cater to all aspects of the ML lifecycle: from building ML models to
 deploying them to production for AI applications.
@@ -18,9 +18,9 @@ deploying them to production for AI applications.
 
 Kubeflow is composed of multiple, independent open-source projects which address different aspects
 of a ML lifecycle. These standalone components are designed to be usable both within the Kubeflow
-Platform and independently. These components can be installed on their own on a Kubernetes cluster,
+Platform and independently. These components can be installed independently on a Kubernetes cluster,
 providing flexibility to users who may not require the full capabilities of Kubeflow Platform but
-wish to leverage specific functionalities in the ML lifecycle.
+wish to leverage specific ML functionalities.
 
 ## What is Kubeflow Platform ?
 

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -29,10 +29,10 @@ additional integration and management tools. Using Kubeflow as a platform means 
 comprehensive ML toolkit fot the entire ML lifecycle. This includes the standalone components
 coupled with these integrations and management tools:
 
-- [**Central Dashboard**](/docs/components/central-dash/overview/) for easy navigation and management.
-
-- Multi-user capabilities and access management with [Kubeflow Profiles](/docs/components/central-dash/profiles/).
-
+- [Kubeflow Notebooks](/docs/components/notebooks/overview) for interactive data exploration and
+  model development.
+- [Central Dashboard](/docs/components/central-dash/overview/) for easy navigation and management
+  with [Kubeflow Profiles](/docs/components/central-dash/profiles/) for access control.
 - Additional tooling for data management (PVC Viewer), visualization (TensorBoards), and more.
 
 The Kubeflow Platform can be installed via

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -19,11 +19,9 @@ deploying them to production for AI applications.
 
 The Kubeflow ecosystem is composed of multiple open-source projects that address different aspects
 of the ML lifecycle. Many of these projects are designed to be usable both within the
-Kubeflow Platform and independently.
-
-These Kubeflow components can be installed standalone on a Kubernetes cluster. It provides
-flexibility to users who may not require the full Kubeflow Platform capabilities but wish to
-leverage specific ML functionalities such as model training or model serving.
+Kubeflow Platform and independently. These Kubeflow components can be installed standalone on a
+Kubernetes cluster. It provides flexibility to users who may not require the full Kubeflow Platform
+capabilities but wish to leverage specific ML functionalities such as model training or model serving.
 
 ## What is Kubeflow Platform
 

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -8,8 +8,8 @@ weight = 1
 
 Kubeflow is a community and ecosystem of open-source projects to address each stage in the
 machine learning (ML) lifecycle. It makes ML on Kubernetes simple, portable, and scalable.
-The Kubeflow goal is to facilitate the orchestration of Kubernetes ML workloads and to empower users
-to deploy best-in-class open-source systems to any Cloud infrastructure.
+The goal of Kubeflow is to facilitate the orchestration of Kubernetes ML workloads and to empower
+users to deploy best-in-class open-source systems to any Cloud infrastructure.
 Whether you’re a researcher, data scientist, ML engineer, or a team of developers, Kubeflow offers
 modular and scalable tools that cater to all aspects of the ML lifecycle: from building ML models to
 deploying them to production for AI applications.

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -27,7 +27,8 @@ wish to leverage specific ML functionalities.
 The Kubeflow Platform refers to the full suite of Kubeflow components bundled together with
 additional integration and management tools. Installing Kubeflow as a platform means deploying a
 comprehensive ML toolkit that integrates these components into a cohesive system, optimized for
-managing the end-to-end ML lifecycle. These includes not only the standalone components but also:
+managing the end-to-end ML lifecycle. This includes the standalone components coupled with these
+integrations and management tools:
 
 - Central Dashboard for easy navigation and management.
 - Multi-user capabilities and access management.


### PR DESCRIPTION
As we discussed multiple times before, we want to explain our users that Kubeflow components can be deployed:
- in **Standalone** mode.
- in **Kubeflow Platform** for end-to-end AI/ML experience.

In this PR I made changes to the installation section:
I removed  `What is Kubeflow?` section from this page since we already have this section here: https://www.kubeflow.org/docs/started/introduction/#what-is-kubeflow, we can update it if you think it is out-of-date.

I made these sections:
  - Install Kubeflow Components Standalone 
   - Install Kubeflow Platform from Raw Manifests 
   - Install Kubeflow Platform from Packaged Distributions

From my point of view this is logically correct, for users to learn about Kubeflow ecosystem. Firstly, users will explore the value of individual Kubeflow components. Secondly, if users need end-to-end AI/ML experience with all Kubeflow components, they will explore the **Raw Manifests** and **Package Distributions** installation.

What do you think about it ?   

I am happy to work on the language to make it less confusing for our users if you have other ideas on how we can improve it.

/hold for review

/assign @kubeflow/wg-notebooks-leads @kubeflow/wg-pipeline-leads @kubeflow/wg-training-leads @kubeflow/wg-data-leads @kubeflow/release-team @kubeflow/kubeflow-steering-committee @kubeflow/wg-deployment-leads 