### PR TITLE
feat: Add Francisco as OWNER for Feature Store documentation

### DIFF
--- a/content/en/docs/external-add-ons/feature-store/OWNERS
+++ b/content/en/docs/external-add-ons/feature-store/OWNERS
@@ -1,2 +1,3 @@
 approvers:
   - woop
+  - franciscojavierarceo


### PR DESCRIPTION
I am one of the [maintainers of Feast](https://github.com/feast-dev/feast/blob/311efc5005b24d1fc9bc389ee7579e102e2cd4ea/community/maintainers.md) and I'd like to update the documentation here. 

So I have proposed to add myself as an OWNER for the Feature Store documentation.