### PR TITLE
configure-experiment.md - missing annotation value in yaml example

### DIFF
--- a/content/en/docs/components/katib/user-guides/hp-tuning/configure-experiment.md
+++ b/content/en/docs/components/katib/user-guides/hp-tuning/configure-experiment.md
@@ -117,7 +117,8 @@ trialSpec:
   spec:
     template:
       metadata:
-        "sidecar.istio.io/inject": "false"
+        annotations:
+          "sidecar.istio.io/inject": "false"
 ```
 
 If you use `PyTorchJob` or other Training Operator jobs in your Trial template check


### PR DESCRIPTION
add missing annotation value in yaml example otherwise the apply of the experiment will fail as invalid:
```
Error from server: error when creating "random.yaml": admission webhook "validator.experiment.katib.kubeflow.org" denied the request: invalid spec.trialTemplate: unable to convert: /spec/template/metadata/sidecar.istio.io~1inject - false to Job, converted template: {"kind":"Job","apiVersion":"batch/v1","metadata":{"creationTimestamp":null},"spec":{"template":{"metadata":{"creationTimestamp":null},"spec":{"containers":[{"name":"training-container","image":"docker.io/kubeflowkatib/pytorch-mnist-cpu:latest","command":["python3","/opt/pytorch-mnist/mnist.py","--epochs=1","--batch-size=16","--lr=test-value","--momentum=test-value"],"resources":{"limits":{"cpu":"500m","memory":"1Gi"}}}],"restartPolicy":"Never","nodeSelector":{"type":"gpu"}}}},"status":{}}
```