### PR TITLE
Removed reference to non existing path

### DIFF
--- a/content/en/docs/components/pipelines/v1/installation/localcluster-deployment.md
+++ b/content/en/docs/components/pipelines/v1/installation/localcluster-deployment.md
@@ -318,11 +318,10 @@ Executors](https://argoproj.github.io/argo-workflows/workflow-executors/) and re
 1. To deploy the Kubeflow Pipelines, run the following commands:
 
     ```shell
-    # env/platform-agnostic-pns hasn't been publically released, so you will install it from master
     export PIPELINE_VERSION={{% pipelines/latest-version %}}
     kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
     kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
-    kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=$PIPELINE_VERSION"
+    kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic?ref=$PIPELINE_VERSION"
     ```
 
     The Kubeflow Pipelines deployment may take several minutes to complete.


### PR DESCRIPTION
Looks like `platform-agnostic-pns` folder seems to be removed in [this](https://github.com/kubeflow/pipelines/commit/809d5766fc9ec436ff05c083e9a2ae65ad2667b7) commit

I hope `platform-agnostic` is the new one to use. 

Also, there was an error with `workflow-controller` and `metadata-envoy-deployment` using the same port causing crash loop. I modified the `workflow-controller` deployment to change the to a non conflicting port.

<img width="562" alt="image" src="https://github.com/kubeflow/website/assets/6300095/454d8d49-a422-4160-9602-1c64834efd8a">
