### PR TITLE
Fix links to packaged distributions section

### DIFF
--- a/content/en/docs/components/central-dash/access.md
+++ b/content/en/docs/components/central-dash/access.md
@@ -11,13 +11,13 @@ How you access the Istio gateway varies depending on how you've configured it.
 
 ## Packaged Distributions
 
-Each [packaged distribution of Kubeflow](/docs/started/installing-kubeflow/#packaged-distributions-of-kubeflow) will have its own way of accessing the central dashboard.
+Each [packaged distribution of Kubeflow](/docs/started/installing-kubeflow/#packaged-distributions) will have its own way of accessing the central dashboard.
 
 For more information, please see the documentation of the distribution you are using.
 
 ## Raw Manifests
 
-If you are using the [Raw Kubeflow Manifests](/docs/started/installing-kubeflow/#raw-kubeflow-manifests), you may access the Istio gateway with `kubectl` port-forwarding or another method.
+If you are using the default [Kubeflow Manifests](/docs/started/installing-kubeflow/#kubeflow-manifests), you may access the Istio gateway with `kubectl` port-forwarding or another method.
 
 ### kubectl port-forwarding
 

--- a/content/en/docs/distributions/list.md
+++ b/content/en/docs/distributions/list.md
@@ -2,7 +2,7 @@
 title = "List of Kubeflow Distributions"
 description = "A list showing packaged distributions of Kubeflow"
 weight = 10
-manualLinkRelref = "../started/installing-kubeflow.md#packaged-distributions-of-kubeflow"
+manualLinkRelref = "../started/installing-kubeflow.md#packaged-distributions"
 +++
 
-We maintain a list showing __packaged distributions of Kubeflow__ on the [Installing Kubeflow](/docs/started/installing-kubeflow/#packaged-distributions-of-kubeflow) page.
+We maintain a list showing __packaged distributions of Kubeflow__ on the [Installing Kubeflow](/docs/started/installing-kubeflow/#packaged-distributions) page.


### PR DESCRIPTION
After https://github.com/kubeflow/website/pull/3724, some of the links to the Packaged Distributions section were incorrect (after the heading changed).