### PR TITLE
Fix invalid labels and broken links on PyTorch Training page

### DIFF
--- a/content/en/docs/components/training/user-guides/pytorch.md
+++ b/content/en/docs/components/training/user-guides/pytorch.md
@@ -31,13 +31,13 @@ kubectl create -f https://raw.githubusercontent.com/kubeflow/training-operator/m
 You should now be able to see the created pods matching the specified number of replicas.
 
 ```
-kubectl get pods -l job-name=pytorch-simple -n kubeflow
+kubectl get pods -l training.kubeflow.org/job-name=pytorch-simple -n kubeflow
 ```
 
 Training takes 5-10 minutes on a cpu cluster. Logs can be inspected to see its training progress.
 
 ```
-PODNAME=$(kubectl get pods -l job-name=pytorch-simple,replica-type=master,replica-index=0 -o name -n kubeflow)
+PODNAME=$(kubectl get pods -l training.kubeflow.org/job-name=pytorch-simple,training.kubeflow.org/replica-type=master,training.kubeflow.org/replica-index=0 -o name -n kubeflow)
 kubectl logs -f ${PODNAME} -n kubeflow
 ```
 
@@ -123,4 +123,4 @@ status:
 
 - Learn about [distributed training](/docs/components/training/reference/distributed-training/) in Training Operator.
 
-- See how to [run a job with gang-scheduling](/docs/use-cases/job-scheduling#running-jobs-with-gang-scheduling).
+- See how to [run a job with gang-scheduling](/docs/components/training/user-guides/job-scheduling#running-jobs-with-gang-scheduling).


### PR DESCRIPTION
This PR fixes invalid label names and broken links on [PyTorch Training (PyTorchJob)](https://www.kubeflow.org/docs/components/training/user-guides/pytorch/).

PS:
Now labels on derived Pods by Training Operator all with `training.kubeflow.org` prefix, like:
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    training.kubeflow.org/job-name: pytorch-simple
    training.kubeflow.org/job-role: master
    training.kubeflow.org/operator-name: pytorchjob-controller
    training.kubeflow.org/replica-index: "0"
    training.kubeflow.org/replica-type: master
  name: pytorch-simple-master-0
  namespace: kubeflow
```