### PR TITLE
Katib: Fix getting started example

### DIFF
--- a/content/en/docs/components/katib/getting-started.md
+++ b/content/en/docs/components/katib/getting-started.md
@@ -59,7 +59,7 @@ parameters = {
 }
 
 # [3] Create Katib Experiment with 12 Trials and 2 CPUs per Trial.
-katib_client = KatibClient(namespace="kubeflow")
+katib_client = katib.KatibClient(namespace="kubeflow")
 
 name = "tune-experiment"
 katib_client.tune(

--- a/content/en/docs/components/katib/installation.md
+++ b/content/en/docs/components/katib/installation.md
@@ -65,13 +65,19 @@ for the Katib DB component.
 Katib [implements Python SDK](https://pypi.org/project/kubeflow-katib/)
 to simplify creation of Katib Experiments for Data Scientists.
 
-Run the following command to install the stable release of Katib SDK:
+Run the following command to install the latest stable release of Katib SDK:
 
 ```shell
 pip install -U kubeflow-katib
 ```
 
-You can also install the Python SDK using the specific GitHub commit, for example:
+Run the following command to install the latest changes of Katib SDK:
+
+```shell
+pip install git+https://github.com/kubeflow/katib.git@master#subdirectory=sdk/python/v1beta1
+```
+
+Otherwise, you can also install the Katib SDK using the specific GitHub commit, for example:
 
 ```shell
 pip install git+https://github.com/kubeflow/katib.git@ea46a7f2b73b2d316b6b7619f99eb440ede1909b#subdirectory=sdk/python/v1beta1

--- a/content/en/docs/components/training/installation.md
+++ b/content/en/docs/components/training/installation.md
@@ -67,13 +67,19 @@ xgboostjobs.kubeflow.org                                 2023-06-09T00:31:04Z
 Training Operator [implements Python SDK](https://pypi.org/project/kubeflow-training/)
 to simplify creation of distributed training and fine-tuning jobs for Data Scientists.
 
-Run the following command to install the stable release of Training Operator SDK:
+Run the following command to install the latest stable release of Training SDK:
 
 ```shell
 pip install -U kubeflow-training
 ```
 
-You can also install the Python SDK using the specific GitHub commit, for example:
+Run the following command to install the latest changes of Training SDK:
+
+```shell
+pip install git+https://github.com/kubeflow/training-operator.git@master#subdirectory=sdk/python
+```
+
+Otherwise, you can also install the Training SDK using the specific GitHub commit, for example:
 
 ```shell
 pip install git+https://github.com/kubeflow/training-operator.git@7345e33b333ba5084127efe027774dd7bed8f6e6#subdirectory=sdk/python


### PR DESCRIPTION
I fixed the Katib getting started example.

Also, I added the command to install SDK from the `master` branch and from the commit.

/assign @tenzen-y @johnugeorge @helenxie-bit 