### PR TITLE
Add missing import to containerized pipelines example

### DIFF
--- a/content/en/docs/components/pipelines/user-guides/components/containerized-python-components.md
+++ b/content/en/docs/components/pipelines/user-guides/components/containerized-python-components.md
@@ -88,7 +88,7 @@ If you have a [configured Docker to use a private image registry](https://docs.d
 Finally, you can use the component in a pipeline:
 
 ```python
-from kfp import dsl
+from kfp import compiler, dsl
 
 @dsl.pipeline
 def addition_pipeline(x: int, y: int) -> int:


### PR DESCRIPTION
The import for `compiler` was missing.