### PR TITLE
misc updates to KF Model Registry tutorial

### DIFF
--- a/content/en/docs/components/model-registry/getting-started.md
+++ b/content/en/docs/components/model-registry/getting-started.md
@@ -31,7 +31,7 @@ This section details a step by step example on using Model Registry from a Noteb
 You can install the Model Registry python client in a Notebook, for instance with:
 
 ```
-!pip install model-registry
+!pip install --pre model-registry=="0.2.2a1"
 ```
 
 Note: depending on your Python and Notebook environment, you might need to fine-tune the dependencies of: `ml-metadata`, `protobuf`, `grpcio`, or `tensorflow` if used.

--- a/content/en/docs/components/model-registry/getting-started.md
+++ b/content/en/docs/components/model-registry/getting-started.md
@@ -102,7 +102,7 @@ from model_registry import ModelRegistry
 registry = ModelRegistry(server_address="model-registry-service.kubeflow.svc.cluster.local", port=9090, author="mmortari", is_secure=False)
 
 lookup_name = "mnist"
-lookup_version="v20231206163028"
+lookup_version = "v0.1"
 
 print("RegisteredModel:")
 registered_model = registry.get_registered_model(lookup_name)

--- a/content/en/docs/components/model-registry/getting-started.md
+++ b/content/en/docs/components/model-registry/getting-started.md
@@ -41,7 +41,7 @@ You can now create a client instance pointing to your deployed Model Registry fr
 ```python
 from model_registry import ModelRegistry
 
-registry = ModelRegistry(server_address="model-registry-service.kubeflow.svc.cluster.local", port=9090, author="your name")
+registry = ModelRegistry(server_address="model-registry-service.kubeflow.svc.cluster.local", port=9090, author="your name", is_secure=False)
 ```
 
 You now have a Model Registry client instance: `registry`.
@@ -99,7 +99,7 @@ You can use the Model Registry Python client to retrieve the needed ML artifact 
 ```python
 from model_registry import ModelRegistry
 
-registry = ModelRegistry(server_address="model-registry-service.kubeflow.svc.cluster.local", port=9090, author="mmortari")
+registry = ModelRegistry(server_address="model-registry-service.kubeflow.svc.cluster.local", port=9090, author="mmortari", is_secure=False)
 
 lookup_name = "mnist"
 lookup_version="v20231206163028"

--- a/content/en/docs/components/model-registry/installation.md
+++ b/content/en/docs/components/model-registry/installation.md
@@ -72,6 +72,24 @@ curl -X 'GET' \
 
 If you are not receiving a `2xx` response, it might be the case you are trying to consume a different version (`v1alphaX`) of the REST API than intended.
 
+### Perform the check from within a Notebook
+
+To check the connection to the Model Registry from a Notebook instead, start a Terminal from the Notebook environment, then you can dry-run the connection with the following command:
+
+```
+curl model-registry-service.kubeflow.svc.cluster.local:8080/api/model_registry/v1alpha3/registered_models
+```
+
+or, alternatively, with the following command:
+
+```
+wget -nv -O- model-registry-service.kubeflow.svc.cluster.local:8080/api/model_registry/v1alpha3/registered_models
+```
+
+If the command executes without any error, you will get a JSON response from Model Registry, indicating the connection and request was successful.
+
+You can use the same commands in a Jupyter Notebook cell by prefixing the command with `!` (e.g.: `! curl ...`).
+
 ## Next steps
 
 - Run some examples following the [getting started guide](/docs/components/model-registry/getting-started/)

--- a/content/en/docs/components/model-registry/installation.md
+++ b/content/en/docs/components/model-registry/installation.md
@@ -34,20 +34,20 @@ of Model Registry, you can install the Model Registry manifests directly from th
 
 By default, the manifests deploy the Model Registry in the `kubeflow` namespace;
 you must ensure the `kubeflow` namespace is available (for example: `kubectl create namespace kubeflow`)
-or modify [the kustomization file](https://github.com/kubeflow/model-registry/blob/v0.2.0-alpha/manifests/kustomize/overlays/db/kustomization.yaml#L3) to your desired namespace.
+or modify [the kustomization file](https://github.com/kubeflow/model-registry/blob/v0.2.2-alpha/manifests/kustomize/overlays/db/kustomization.yaml#L3) to your desired namespace.
 
 See the list of available versions on the [GitHub releases](https://github.com/kubeflow/model-registry/releases) of the `kubeflow/model-registry` repository. To install a specific release of the Model Registry, modify the following commands with the desired `ref=<GIT_TAG>`.
 
-Run the following command to install the `v0.2.0-alpha` release of Model Registry:
+Run the following command to install the `v0.2.2-alpha` release of Model Registry:
 
 ```shell
-kubectl apply -k "https://github.com/kubeflow/model-registry/manifests/kustomize/overlays/db?ref=v0.2.0-alpha"
+kubectl apply -k "https://github.com/kubeflow/model-registry/manifests/kustomize/overlays/db?ref=v0.2.2-alpha"
 ```
 
 If your Kubernetes cluster uses Istio, you MUST apply the Istio-compatibility manifests (e.g. when using a full Kubeflow Platform). However, these are NOT required for non-Istio clusters.
 
 ```shell
-kubectl apply -k "https://github.com/kubeflow/model-registry/manifests/kustomize/options/istio?ref=v0.2.0-alpha"
+kubectl apply -k "https://github.com/kubeflow/model-registry/manifests/kustomize/options/istio?ref=v0.2.2-alpha"
 ```
 
 


### PR DESCRIPTION
- add suggestions of commands to dry-run connection from Notebook, this for instance was a feedback emerged interacting with users in https://github.com/kubeflow/model-registry/issues/90#issuecomment-2143788711
- refresh versions, by pinning to the latest version (and not just `main`, per previous KF community leads request)
- to make the tutorial flow easier, align model-version used for the mnist example ML model
