### PR TITLE
Update Kubeflow Pipelines Legacy V1 warning text

### DIFF
--- a/content/en/docs/components/pipelines/legacy-v1/_index.md
+++ b/content/en/docs/components/pipelines/legacy-v1/_index.md
@@ -4,7 +4,8 @@ description = "Kubeflow Pipelines v1 Documentation"
 weight = 999
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}

--- a/content/en/docs/components/pipelines/legacy-v1/installation/_index.md
+++ b/content/en/docs/components/pipelines/legacy-v1/installation/_index.md
@@ -4,7 +4,8 @@ description = "Options for installing Kubeflow Pipelines"
 weight = 35
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}

--- a/content/en/docs/components/pipelines/legacy-v1/installation/choose-executor.md
+++ b/content/en/docs/components/pipelines/legacy-v1/installation/choose-executor.md
@@ -4,9 +4,10 @@ description = "How to choose an Argo Workflows Executor"
 weight = 80
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 An Argo workflow executor is a process that conforms to a specific interface that allows Argo to perform certain actions like monitoring pod logs, collecting artifacts, managing container lifecycles, etc.

--- a/content/en/docs/components/pipelines/legacy-v1/installation/compatibility-matrix.md
+++ b/content/en/docs/components/pipelines/legacy-v1/installation/compatibility-matrix.md
@@ -4,9 +4,10 @@ description = "Kubeflow Pipelines compatibility matrix with TensorFlow Extended 
 weight = 100
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 ## Kubeflow Pipelines Backend and TFX compatibility

--- a/content/en/docs/components/pipelines/legacy-v1/installation/localcluster-deployment.md
+++ b/content/en/docs/components/pipelines/legacy-v1/installation/localcluster-deployment.md
@@ -4,9 +4,10 @@ description = "Information about local Deployment of Kubeflow Pipelines (kind, K
 weight = 20
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This guide shows how to deploy Kubeflow Pipelines standalone on a local

--- a/content/en/docs/components/pipelines/legacy-v1/installation/overview.md
+++ b/content/en/docs/components/pipelines/legacy-v1/installation/overview.md
@@ -5,9 +5,10 @@ weight = 10
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 Kubeflow Pipelines offers a few installation options.

--- a/content/en/docs/components/pipelines/legacy-v1/installation/standalone-deployment.md
+++ b/content/en/docs/components/pipelines/legacy-v1/installation/standalone-deployment.md
@@ -4,9 +4,10 @@ description = "Information about Standalone Deployment of Kubeflow Pipelines"
 weight = 30
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 As an alternative to deploying Kubeflow Pipelines (KFP) as part of the

--- a/content/en/docs/components/pipelines/legacy-v1/installation/upgrade.md
+++ b/content/en/docs/components/pipelines/legacy-v1/installation/upgrade.md
@@ -4,9 +4,10 @@ description = "Notices and breaking changes when you upgrade Kubeflow Pipelines 
 weight = 90
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This page introduces notices and breaking changes you need to know when upgrading Kubeflow Pipelines Backend.

--- a/content/en/docs/components/pipelines/legacy-v1/introduction.md
+++ b/content/en/docs/components/pipelines/legacy-v1/introduction.md
@@ -5,9 +5,10 @@ weight = 10
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 {{% stable-status %}}

--- a/content/en/docs/components/pipelines/legacy-v1/introduction.md
+++ b/content/en/docs/components/pipelines/legacy-v1/introduction.md
@@ -11,8 +11,6 @@ Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we 
 For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
-{{% stable-status %}}
-
 Kubeflow Pipelines is a platform for building and deploying portable, 
 scalable machine learning (ML) workflows based on Docker containers.
 

--- a/content/en/docs/components/pipelines/legacy-v1/overview/_index.md
+++ b/content/en/docs/components/pipelines/legacy-v1/overview/_index.md
@@ -4,7 +4,8 @@ description = "Overview of Kubeflow Pipelines"
 weight = 20
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}

--- a/content/en/docs/components/pipelines/legacy-v1/overview/caching.md
+++ b/content/en/docs/components/pipelines/legacy-v1/overview/caching.md
@@ -5,9 +5,10 @@ weight = 40
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 ## Before you start

--- a/content/en/docs/components/pipelines/legacy-v1/overview/multi-user.md
+++ b/content/en/docs/components/pipelines/legacy-v1/overview/multi-user.md
@@ -4,9 +4,10 @@ description = "How multi-user isolation works in Kubeflow Pipelines"
 weight = 30
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 Multi-user isolation for Kubeflow Pipelines is part of Kubeflow's overall [multi-tenancy](/docs/concepts/multi-tenancy/) feature.

--- a/content/en/docs/components/pipelines/legacy-v1/overview/quickstart.md
+++ b/content/en/docs/components/pipelines/legacy-v1/overview/quickstart.md
@@ -10,7 +10,6 @@ This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](
 Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
 For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
-{{% stable-status %}}
 
 Use this guide if you want to get an introduction to the Kubeflow Piplines user interface (UI) and get a simple pipeline running quickly. 
 

--- a/content/en/docs/components/pipelines/legacy-v1/overview/quickstart.md
+++ b/content/en/docs/components/pipelines/legacy-v1/overview/quickstart.md
@@ -5,9 +5,10 @@ weight = 10
 
 +++ 
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 {{% stable-status %}}
 

--- a/content/en/docs/components/pipelines/legacy-v1/reference/_index.md
+++ b/content/en/docs/components/pipelines/legacy-v1/reference/_index.md
@@ -4,7 +4,8 @@ description = "Reference docs for Kubeflow Pipelines Version 1"
 weight = 100
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}

--- a/content/en/docs/components/pipelines/legacy-v1/reference/sdk.md
+++ b/content/en/docs/components/pipelines/legacy-v1/reference/sdk.md
@@ -5,9 +5,10 @@ weight = 20
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 See the [generated reference docs for the Python 

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/_index.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/_index.md
@@ -4,7 +4,8 @@ description = "Information about the Kubeflow Pipelines SDK"
 weight = 40
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/best-practices.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/best-practices.md
@@ -5,9 +5,10 @@ weight = 60
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This page describes some recommended practices for designing

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/build-pipeline.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/build-pipeline.md
@@ -4,9 +4,10 @@ description = "A tutorial on building pipelines to orchestrate your ML workflow"
 weight = 30
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 <!--

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/component-development.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/component-development.md
@@ -4,9 +4,10 @@ description = "A tutorial on how to create components and use them in a pipeline
 weight = 40
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 A pipeline component is a self-contained set of code that performs one step in

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/dsl-recursion.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/dsl-recursion.md
@@ -5,9 +5,10 @@ weight = 110
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This page describes how to write recursive functions in the domain specific language (DSL) provided by the Kubeflow Pipelines SDK.

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/enviroment_variables.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/enviroment_variables.md
@@ -5,9 +5,10 @@ weight = 115
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This page describes how to pass environment variables to Kubeflow pipeline 

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/gcp.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/gcp.md
@@ -5,9 +5,10 @@ weight = 130
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 For pipeline features that are specific to GCP, including SDK features, see the 

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/install-sdk.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/install-sdk.md
@@ -5,9 +5,10 @@ weight = 20
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This guide tells you how to install the 

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/manipulate-resources.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/manipulate-resources.md
@@ -5,9 +5,10 @@ weight = 1350
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This page describes how to manipulate Kubernetes resources through individual

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/output-viewer.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/output-viewer.md
@@ -5,9 +5,10 @@ weight = 80
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/parameters.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/parameters.md
@@ -5,9 +5,10 @@ weight = 70
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 The [`kfp.dsl.PipelineParam` 

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/pipelines-with-tekton.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/pipelines-with-tekton.md
@@ -5,9 +5,10 @@ weight = 140
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 You can use the [KFP-Tekton SDK](https://github.com/kubeflow/kfp-tekton/tree/master/sdk)

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/python-based-visualizations.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/python-based-visualizations.md
@@ -4,9 +4,10 @@ description = "Predefined and custom visualizations of pipeline outputs"
 weight = 1400
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 {{% alert title="Deprecated" color="warning" %}}

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/python-function-components.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/python-function-components.md
@@ -4,9 +4,10 @@ description = "Building your own lightweight pipelines components using Python"
 weight = 50
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 <!--

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md
@@ -5,9 +5,10 @@ weight = 10
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 {{% stable-status %}}

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md
@@ -11,8 +11,6 @@ Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we 
 For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
-{{% stable-status %}}
-
 The [Kubeflow Pipelines 
 SDK](https://kubeflow-pipelines.readthedocs.io/en/stable/source/html)
 provides a set of Python packages that you can use to specify and run your 

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/static-type-checking.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/static-type-checking.md
@@ -5,9 +5,10 @@ weight = 100
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This page describes how to integrate the type information in the pipeline and utilize the 

--- a/content/en/docs/components/pipelines/legacy-v1/troubleshooting.md
+++ b/content/en/docs/components/pipelines/legacy-v1/troubleshooting.md
@@ -5,9 +5,10 @@ weight = 90
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This page presents some hints for troubleshooting specific problems that you

--- a/content/en/docs/components/pipelines/legacy-v1/tutorials/_index.md
+++ b/content/en/docs/components/pipelines/legacy-v1/tutorials/_index.md
@@ -4,7 +4,8 @@ description = "Samples and tutorials for Kubeflow Pipelines"
 weight = 90
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}

--- a/content/en/docs/components/pipelines/legacy-v1/tutorials/api-pipelines.md
+++ b/content/en/docs/components/pipelines/legacy-v1/tutorials/api-pipelines.md
@@ -5,9 +5,10 @@ weight = 20
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This tutorial demonstrates how to use the Kubeflow Pipelines API to build, run, and manage pipelines. This guide is recommended for users who would like to learn how to manage Kubeflow Pipelines using the REST API.

--- a/content/en/docs/components/pipelines/legacy-v1/tutorials/benchmark-examples.md
+++ b/content/en/docs/components/pipelines/legacy-v1/tutorials/benchmark-examples.md
@@ -4,9 +4,10 @@ description = "How to use the Kubeflow Pipelines Benchmark Scripts"
 weight = 10
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This guide explains the Kubeflow Pipelines [benchmark scripts](https://github.com/kubeflow/pipelines/tree/sdk/release-1.8/tools/benchmarks)

--- a/content/en/docs/components/pipelines/legacy-v1/tutorials/build-pipeline.md
+++ b/content/en/docs/components/pipelines/legacy-v1/tutorials/build-pipeline.md
@@ -5,9 +5,10 @@ weight = 30
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 You can learn how to build and deploy pipelines by running the samples

--- a/content/en/docs/components/pipelines/legacy-v1/tutorials/cloud-tutorials.md
+++ b/content/en/docs/components/pipelines/legacy-v1/tutorials/cloud-tutorials.md
@@ -5,9 +5,10 @@ weight = 40
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 {{% alert title="Opportunity to add cloud tutorials" color="info" %}}

--- a/content/en/docs/components/pipelines/legacy-v1/tutorials/sdk-examples.md
+++ b/content/en/docs/components/pipelines/legacy-v1/tutorials/sdk-examples.md
@@ -5,9 +5,10 @@ weight = 10
                     
 +++
 {{% alert title="Old Version" color="warning" %}}
-This page is about __Kubeflow Pipelines V1__, for information about __Kubeflow Pipelines V2__, please see the [new docs](/docs/components/pipelines).
+This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
-Please note that Kubeflow Pipelines V2 supports running V1 pipelines in a [backwards compatible mode](/docs/components/pipelines/user-guides/migration).
+Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This guide provides examples that demonstrate how to use the Kubeflow Pipelines SDK.


### PR DESCRIPTION
~~DO NOT MERGE UNTIL https://github.com/kubeflow/website/pull/3791 has been merged 
(I don't want to break that revert, so I will update this PR to also update the warnings on those pages after that PR is merged).~~

This PR updates the warning in the `"Kubeflow Pipelines"` / `"Legacy (v1)"` section to be more useful, this new text is much more helpful and explains more about what they need to do to migrate.

The original PR that added this text https://github.com/kubeflow/website/pull/3775 was seemingly merged without responding to review comments.

I have also removed the "stable status" notice on some of the KFP v1 pages, as the component is now deprecated.

