### PR TITLE
Partial Revert of #3787

### DIFF
--- a/content/en/docs/components/pipelines/getting-started.md
+++ b/content/en/docs/components/pipelines/getting-started.md
@@ -57,4 +57,14 @@ The client will print a link to view the pipeline execution graph and logs in th
 
 ## Next steps
 
+In the next few sections, you'll learn more about the core concepts of authoring pipelines and how to create more expressive, useful pipelines.
+
 * Learn more about [Connecting the Pipelines SDK to Kubeflow Pipelines](/docs/components/pipelines/user-guides/core-functions/connect-api/).
+
+[installation]: /docs/components/pipelines/operator-guides/installation/
+[client]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/client.html#kfp.client.Client
+[compiler]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/compiler.html#kfp.compiler.Compiler
+[ir-yaml]: /docs/components/pipelines/user-guides/core-functions/compile-a-pipeline#ir-yaml
+[compile-a-pipeline]: /docs/components/pipelines/user-guides/core-functions/compile-a-pipeline/
+[dsl-pipeline]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.pipeline
+[dsl-component]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.component


### PR DESCRIPTION
Partially Reverts kubeflow/website#3787

That PR should not have been merged, it created a bunch of dead links in the page by removing the `[XXX]` anchors at the bottom of the page.