### PR TITLE
Improve the KFP / User Guides / Core Functions docs

### DIFF
--- a/content/en/docs/components/katib/user-guides/katib-config.md
+++ b/content/en/docs/components/katib/user-guides/katib-config.md
@@ -8,7 +8,7 @@ This guide describes
 [the Katib Config](https://github.com/kubeflow/katib/blob/19268062f1b187dde48114628e527a2a35b01d64/manifests/v1beta1/installs/katib-standalone/katib-config.yaml) —
 the main configuration file for every Katib component. We use Kubernetes
 [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) to
-fetch that config into [the Katib control plane components](/docs/components/katib/installation/#installing-control-plane).
+fetch that config into [the Katib control plane components](/docs/components/katib/reference/architecture/#katib-control-plane-components).
 
 The ConfigMap must be deployed in the
 [`KATIB_CORE_NAMESPACE`](/docs/components/katib/user-guides/env-variables/#katib-controller)

--- a/content/en/docs/components/pipelines/legacy-v1/tutorials/api-pipelines.md
+++ b/content/en/docs/components/pipelines/legacy-v1/tutorials/api-pipelines.md
@@ -39,7 +39,7 @@ wget -O ${PIPELINE_FILE} ${PIPELINE_URL}
 dsl-compile --py ${PIPELINE_FILE} --output ${PIPELINE_NAME}.tar.gz
 ```
 
-After running the commands above, you should get two files in your current directory: `sequential.py` and `sequential.tar.gz`. Run the following command to deploy the generated `.tar.gz` file as you would do using the [Kubeflow Pipelines UI](/docs/components/pipelines/user-guides/core-functions/run-a-pipeline/#1-run-from-the-kfp-dashboard), but this time using the REST API.
+After running the commands above, you should get two files in your current directory: `sequential.py` and `sequential.tar.gz`. Run the following command to deploy the generated `.tar.gz` file as you would do using the [Kubeflow Pipelines UI](/docs/components/pipelines/user-guides/core-functions/run-a-pipeline/#run-pipeline---kfp-dashboard), but this time using the REST API.
 
 ```
 SVC=localhost:8888

--- a/content/en/docs/components/pipelines/operator-guides/multi-user.md
+++ b/content/en/docs/components/pipelines/operator-guides/multi-user.md
@@ -42,10 +42,10 @@ Pipeline definitions are not isolated right now, and are shared across all names
 
 How to connect Pipelines SDK to Kubeflow Pipelines will depend on __what kind__ of Kubeflow deployment you have, and __from where you are running your code__.
 
-* [Full Kubeflow (from inside cluster)](/docs/components/pipelines/user-guides/core-functions/connect-api/#full-kubeflow-subfrom-inside-clustersub)
-* [Full Kubeflow (from outside cluster)](/docs/components/pipelines/user-guides/core-functions/connect-api/#full-kubeflow-subfrom-outside-clustersub)
-* [Standalone Kubeflow Pipelines (from inside cluster)](/docs/components/pipelines/user-guides/core-functions/connect-api/#standalone-kubeflow-pipelines-subfrom-inside-clustersub)
-* [Standalone Kubeflow Pipelines (from outside cluster)](/docs/components/pipelines/user-guides/core-functions/connect-api/#standalone-kubeflow-pipelines-subfrom-outside-clustersub)
+* [Full Kubeflow (from inside cluster)](/docs/components/pipelines/user-guides/core-functions/connect-api/#kubeflow-platform---inside-the-cluster)
+* [Full Kubeflow (from outside cluster)](/docs/components/pipelines/user-guides/core-functions/connect-api/#kubeflow-platform---outside-the-cluster)
+* [Standalone Kubeflow Pipelines (from inside cluster)](/docs/components/pipelines/user-guides/core-functions/connect-api/#standalone-kfp---inside-the-cluster)
+* [Standalone Kubeflow Pipelines (from outside cluster)](/docs/components/pipelines/user-guides/core-functions/connect-api/#standalone-kfp---outside-the-cluster)
 
 The following Python code will create an experiment (and associated run) from a Pod inside a full Kubeflow cluster.
 

--- a/content/en/docs/components/pipelines/user-guides/components/_index.md
+++ b/content/en/docs/components/pipelines/user-guides/components/_index.md
@@ -1,5 +1,6 @@
 +++
 title = "Create components"
+description = "Create pipelines with reusable components."
 weight = 3
 +++
 

--- a/content/en/docs/components/pipelines/user-guides/core-functions/_index.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Core Functions"
-description = "Documentation for users of Kubeflow Pipelines."
+description = "Learn about the core functions of Kubeflow Pipelines."
 weight = 2
 +++

--- a/content/en/docs/components/pipelines/user-guides/core-functions/build-advanced-pipeline.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/build-advanced-pipeline.md
@@ -1,6 +1,7 @@
 +++
 title = "Build a More Advanced ML Pipeline"
-weight = 6
+description = "Create a more advanced pipeline that leverages additional KFP features."
+weight = 199
 +++
 
 {{% kfp-v2-keywords %}}

--- a/content/en/docs/components/pipelines/user-guides/core-functions/caching.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/caching.md
@@ -1,7 +1,7 @@
 +++
 title = "Use Caching"
-description = "How to use caching in Kubeflow Pipelines."
-weight = 5
+description = "Learn about caching in Kubeflow Pipelines."
+weight = 104
 +++
 
 Kubeflow Pipelines support caching to eliminate redundant executions and improve
@@ -26,7 +26,7 @@ be marked with a green "arrow from cloud" icon.
 ## How to use caching
 
 Caching is enabled by default for all components in KFP. You can disable caching
-for a component by calling `.set_caching_options(False)` on a task object.
+for a component by calling [`.set_caching_options(enable_caching=False)`](https://kubeflow-pipelines.readthedocs.io/en/latest/source/dsl.html#kfp.dsl.PipelineTask.set_caching_options) on a task object.
 
 ```python
 from kfp import dsl

--- a/content/en/docs/components/pipelines/user-guides/core-functions/cli.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/cli.md
@@ -1,6 +1,7 @@
 +++
-title = "Interact with KFP via the CLI"
-weight = 4
+title = "Use the KFP CLI"
+description = "Learn how to interact with Kubeflow Pipelines using the KFP CLI."
+weight = 203
 +++
 
 {{% kfp-v2-keywords %}}

--- a/content/en/docs/components/pipelines/user-guides/core-functions/connect-api.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/connect-api.md
@@ -245,7 +245,7 @@ class KFPClientManager:
             # no cookies are needed
             return ""
 
-        # if we are at `.../auth` path, we need to select an auth type
+        # if we are at `../auth` path, we need to select an auth type
         url_obj = urlsplit(resp.url)
         if re.search(r"/auth$", url_obj.path):
             url_obj = url_obj._replace(

--- a/content/en/docs/components/pipelines/user-guides/core-functions/control-flow.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/control-flow.md
@@ -1,24 +1,53 @@
 +++
-title = "Create pipelines with control flow"
-weight = 9
+title = "Control Flow"
+description = "Use control flow such as conditionals, loops, and exit handling in Kubeflow Pipelines."
+weight = 103
 +++
 
 {{% kfp-v2-keywords %}}
 
-Although a KFP pipeline decorated with the `@dsl.pipeline` decorator looks like a normal Python function, it is actually an expression of pipeline topology and control flow semantics, constructed using the KFP domain-specific language (DSL). [Pipeline Basics][pipeline-basics] covered how data passing expresses [pipeline topology through task dependencies][data-passing]. This section describes how to use control flow in your pipelines using the KFP DSL. The DSL features three types of control flow, each implemented by a Python context manager:
+## Overview
 
-1. Conditions
-2. Looping
-3. Exit handling
+Although a KFP pipeline decorated with the `@dsl.pipeline` decorator looks like a normal Python function, it is actually an expression of pipeline topology and control flow semantics, constructed using the KFP domain-specific language (DSL). 
 
-### Conditions (dsl.If, dsl.Elif, dsl.Else)
+The [components guide][pipeline-basics] shows how pipeline topology is expressed by [data passing and task dependencies][data-passing]. 
+This section describes how to introduce control flow in your pipelines to create more complex workflows.
 
-The [`dsl.If`][dsl-if] context manager enables conditional execution of tasks within its scope based on the output of an upstream task or pipeline input parameter. The context manager takes two arguments: a required `condition` and an optional `name`. The `condition` is a comparative expression where at least one of the two operands is an output from an upstream task or a pipeline input parameter.
+The core types of control flow in KFP pipelines are:
+
+1. [__Conditions__](#conditions)
+2. [__Loops__](#loops)
+3. [__Exit handling__](#exit-handling)
+
+## Conditions
+
+Kubeflow Pipelines supports common conditional control flow constructs. 
+You can use these constructs to conditionally execute tasks based on the output of an upstream task or pipeline input parameter.
+
+{{% alert title="Deprecated" color="warning" %}}
+The `dsl.Condition` is deprecated in favor of the functionally identical `dsl.If`, which is concise, Pythonic, and consistent with the `dsl.Elif` and `dsl.Else` objects.
+{{% /alert %}}
+
+### **dsl.If** / **dsl.Elif** / **dsl.Else**
+
+The [`dsl.If`][dsl-if] context manager enables conditional execution of tasks within its scope based on the output of an upstream task or pipeline input parameter. 
+
+The context manager takes two arguments: a required `condition` and an optional `name`. 
+The `condition` is a comparative expression where at least one of the two operands is an output from an upstream task or a pipeline input parameter.
 
 In the following pipeline, `conditional_task` only executes if `coin_flip_task` has the output `'heads'`.
 
 ```python
 from kfp import dsl
+
+@dsl.component
+def flip_coin() -> str:
+    import random
+    return random.choice(['heads', 'tails'])
+
+#@dsl.component
+#def my_comp():
+#    print('Conditional task executed!')
 
 @dsl.pipeline
 def my_pipeline():
@@ -32,6 +61,15 @@ You may also use [`dsl.Elif`][dsl-elif] and [`dsl.Else`][dsl-else] context manag
 ```python
 from kfp import dsl
 
+@dsl.component
+def flip_three_sided_coin() -> str:
+    import random
+    return random.choice(['heads', 'tails', 'draw'])
+
+@dsl.component
+def print_comp(text: str):
+    print(text)
+
 @dsl.pipeline
 def my_pipeline():
     coin_flip_task = flip_three_sided_coin()
@@ -43,16 +81,32 @@ def my_pipeline():
         print_comp(text='Draw!')
 ```
 
-{{% alert title="Deprecated" color="warning" %}}
-dsl.Condition is deprecated in favor of the functionally identical dsl.If, which is concise, Pythonic, and consistent with the dsl.Elif and dsl.Else objects.
-{{% /alert %}}
+### **dsl.OneOf**
 
-#### dsl.OneOf
+[`dsl.OneOf`][dsl-oneof] can be used to gather outputs from mutually exclusive branches into a single task output which can be consumed by a downstream task or outputted from a pipeline.
+Branches are mutually exclusive if exactly one will be executed. 
+To enforce this, the KFP SDK compiler requires `dsl.OneOf` consume from tasks within a logically associated group of conditional branches and that one of the branches is a `dsl.Else` branch.
 
-[`dsl.OneOf`][dsl-oneof] can be used to gather outputs from mutually exclusive branches into a single task output which can be consumed by a downstream task or outputted from a pipeline. Branches are mutually exclusive if exactly one will be executed. To enforce this, the KFP SDK compiler requires `dsl.OneOf` consume from taksks within a logically associated group of conditional branches and that one of the branches is a `dsl.Else` branch.
+{{% oss-be-unsupported feature_name="`dsl.OneOf`" %}}
+
+For example, the following pipeline uses `dsl.OneOf` to gather outputs from mutually exclusive branches:
 
 ```python
 from kfp import dsl
+
+@dsl.component
+def flip_three_sided_coin() -> str:
+    import random
+    return random.choice(['heads', 'tails', 'draw'])
+
+@dsl.component
+def print_and_return(text: str) -> str:
+    print(text)
+    return text
+
+@dsl.component
+def announce_result(result: str):
+    print(f'The result is: {result}')
 
 @dsl.pipeline
 def my_pipeline() -> str:
@@ -69,19 +123,34 @@ def my_pipeline() -> str:
     return oneof
 ```
 
-You should provide task outputs to the `dsl.OneOf` using `.output` or `.outputs[<key>]`, just as you would pass an output to a downstream task. The outputs provided to `dsl.OneOf` must be of the same type and cannot be other instances of `dsl.OneOf` or [`dsl.Collected`][dsl-collected].
+You should provide task outputs to the `dsl.OneOf` using `.output` or `.outputs[<key>]`, just as you would pass an output to a downstream task. 
+The outputs provided to `dsl.OneOf` must be of the same type and cannot be other instances of `dsl.OneOf` or [`dsl.Collected`][dsl-collected].
 
-{{% oss-be-unsupported feature_name="`dsl.OneOf`" %}}
+## Loops
 
-### Parallel looping (dsl.ParallelFor)
+Kubeflow Pipelines supports loops which cause fan-out and fan-in of tasks.
 
-The [`dsl.ParallelFor`][dsl-parallelfor] context manager allows parallel execution of tasks over a static set of items. The context manager takes three arguments: a required `items`, an optional `parallelism`, and an optional `name`. `items` is the static set of items to loop over and `parallelism` is the maximum number of concurrent iterations permitted while executing the `dsl.ParallelFor` group. `parallelism=0` indicates unconstrained parallelism.
+### **dsl.ParallelFor**
 
+The [`dsl.ParallelFor`][dsl-parallelfor] context manager allows parallel execution of tasks over a static set of items. 
+
+The context manager takes three arguments:
+
+- `items`: static set of items to loop over
+- `name` (optional): is the name of the loop context
+- `parallelism` (optional): is the maximum number of concurrent iterations while executing the `dsl.ParallelFor` group
+     - note, `parallelism=0` indicates unconstrained parallelism
+
+{{% oss-be-unsupported feature_name="Setting `parallelism`" gh_issue_link=https://github.com/kubeflow/pipelines/issues/8718 %}}
 
 In the following pipeline, `train_model` will train a model for 1, 5, 10, and 25 epochs, with no more than two training tasks running at one time:
 
 ```python
 from kfp import dsl
+
+#@dsl.component
+#def train_model(epochs: int) -> Model:
+#    ...
 
 @dsl.pipeline
 def my_pipeline():
@@ -91,44 +160,73 @@ def my_pipeline():
     ) as epochs:
         train_model(epochs=epochs)
 ```
-{{% oss-be-unsupported feature_name="Setting `parallelism`" gh_issue_link=https://github.com/kubeflow/pipelines/issues/8718 %}}
 
-#### dsl.Collected
+### **dsl.Collected**
 
-Use [`dsl.Collected`][dsl-collected] with `dsl.ParallelFor` to gather outputs from a parallel loop of tasks:
+Use [`dsl.Collected`][dsl-collected] with `dsl.ParallelFor` to gather outputs from a parallel loop of tasks.
 
-```python
-from kfp import dsl
+{{% oss-be-unsupported feature_name="`dsl.Collected`" gh_issue_link=https://github.com/kubeflow/pipelines/issues/6161 %}}
 
-@dsl.pipeline
-def my_pipeline():
-    with dsl.ParallelFor(
-        items=[1, 5, 10, 25],
-    ) as epochs:
-        train_model_task = train_model(epochs=epochs)
-    max_accuracy(models=dsl.Collected(train_model_task.outputs['model']))
-```
+#### **Example:** Using `dsl.Collected` as an input to a downstream task
 
-Downstream tasks might consume `dsl.Collected` outputs via an input annotated with a `List` of parameters or a `List` of artifacts. For example, `select_best` in the preceding example has the input `models` with type `Input[List[Model]]`, as shown by the following component definition:
+Downstream tasks might consume `dsl.Collected` outputs via an input annotated with a `List` of parameters or a `List` of artifacts. 
+
+For example, in the following pipeline, `max_accuracy` has the input `models` with type `Input[List[Model]]`, and will find the model with the highest accuracy from the models trained in the parallel loop:
 
 ```python
 from kfp import dsl
 from kfp.dsl import Model, Input
 
+#def score_model(model: Model) -> float:
+#    return ...
+
+#@dsl.component
+#def train_model(epochs: int) -> Model:
+#    ...
+
 @dsl.component
-def select_best(models: Input[List[Model]]) -> float:
+def max_accuracy(models: Input[List[Model]]) -> float:
     return max(score_model(model) for model in models)
+
+@dsl.pipeline
+def my_pipeline():
+    
+    # Train a model for 1, 5, 10, and 25 epochs
+    with dsl.ParallelFor(
+        items=[1, 5, 10, 25],
+    ) as epochs:
+        train_model_task = train_model(epochs=epochs)
+        
+    # Find the model with the highest accuracy
+    max_accuracy(
+        models=dsl.Collected(train_model_task.outputs['model'])
+    )
 ```
 
-You can use `dsl.Collected` to collect outputs from nested loops in a *nested list* of parameters. For example, output parameters from two nested `dsl.ParallelFor` groups are collected in a multilevel nested list of parameters, where each nested list contains the output parameters from one of the `dsl.ParallelFor` groups. The number of nested levels is based on the number of nested `dsl.ParallelFor` contexts.
+#### **Example:** Nested lists of parameters
+
+You can use `dsl.Collected` to collect outputs from nested loops in a *nested list* of parameters. 
+
+For example, output parameters from two nested `dsl.ParallelFor` groups are collected in a multilevel nested list of parameters, where each nested list contains the output parameters from one of the `dsl.ParallelFor` groups. 
+The number of nested levels is based on the number of nested `dsl.ParallelFor` contexts.
 
 By comparison, *artifacts* created in nested loops are collected in a *flat* list.
 
-You can also return a `dsl.Collected` from a pipeline. Use a `List` of parameters or a `List` of artifacts in the return annotation, as shown in the following example:
+#### **Example:** Returning `dsl.Collected` from a pipeline
+
+You can also return a `dsl.Collected` from a pipeline.
+
+Use a `List` of parameters or a `List` of artifacts in the return annotation, as shown in the following example:
 
 ```python
+from typing import List
+
 from kfp import dsl
 from kfp.dsl import Model
+
+#@dsl.component
+#def train_model(epochs: int) -> Model:
+#    ...
 
 @dsl.pipeline
 def my_pipeline() -> List[Model]:
@@ -139,16 +237,38 @@ def my_pipeline() -> List[Model]:
     return dsl.Collected(train_model_task.outputs['model'])
 ```
 
-{{% oss-be-unsupported feature_name="`dsl.Collected`" gh_issue_link=https://github.com/kubeflow/pipelines/issues/6161 %}}
+## Exit handling
 
-### Exit handling (dsl.ExitHandler)
+Kubeflow Pipelines supports exit handlers for implementing cleanup and error handling tasks that run after the main pipeline tasks finish execution.
 
-The [`dsl.ExitHandler`][dsl-exithandler] context manager allows pipeline authors to specify an exit task which will run after the tasks within the context manager's scope finish execution, even if one of those tasks fails. This is analogous to using a `try:` block followed by a `finally:` block in normal Python, where the exit task is in the `finally:` block. The context manager takes two arguments: a required `exit_task` and an optional `name`. `exit_task` accepts an instantiated [`PipelineTask`][dsl-pipelinetask].
+### **dsl.ExitHandler**
 
-In the following pipeline, `clean_up_task` will execute after both `create_dataset` and `train_and_save_models` finish or either of them fail:
+The [`dsl.ExitHandler`][dsl-exithandler] context manager allows pipeline authors to specify an exit task which will run after the tasks within the context manager's scope finish execution, even if one of those tasks fails. 
+
+This construct is analogous to using a `try:` block followed by a `finally:` block in normal Python, where the exit task is in the `finally:` block. 
+The context manager takes two arguments: a required `exit_task` and an optional `name`. `exit_task` accepts an instantiated [`PipelineTask`][dsl-pipelinetask].
+
+#### **Example:** Basic cleanup task
+
+The most common use case for `dsl.ExitHandler` is to run a cleanup task after the main pipeline tasks finish execution.
+
+In the following pipeline, `clean_up_task` will execute after both `create_dataset` and `train_and_save_models` finish (regardless of whether they succeed or fail):
 
 ```python
 from kfp import dsl
+from kfp.dsl import Dataset
+
+#@dsl.component
+#def clean_up_resources():
+#    ...
+
+#@dsl.component
+#def create_datasets():
+#    ...
+
+#@dsl.component
+#def train_and_save_models(dataset: Dataset):
+#    ...
 
 @dsl.pipeline
 def my_pipeline():
@@ -158,7 +278,13 @@ def my_pipeline():
         train_task = train_and_save_models(dataset=dataset_task.output)
 ```
 
-The task you use as an exit task may use a special input that provides access to pipeline and task status metadata, including pipeline failure or success status. You can use this special input by annotating your exit task with the [`dsl.PipelineTaskFinalStatus`][dsl-pipelinetaskfinalstatus] annotation. The argument for this parameter will be provided by the backend automatically at runtime. You should not provide any input to this annotation when you instantiate your exit task.
+### **Example:** Accessing pipeline and task status metadata
+
+The task you use as an exit task may use a special input that provides access to pipeline and task status metadata, including pipeline failure or success status. 
+
+You can use this special input by annotating your exit task with the [`dsl.PipelineTaskFinalStatus`][dsl-pipelinetaskfinalstatus] annotation. 
+The argument for this parameter will be provided by the backend automatically at runtime. 
+You should not provide any input to this annotation when you instantiate your exit task.
 
 The following pipeline uses `dsl.PipelineTaskFinalStatus` to obtain information about the pipeline and task failure, even after `fail_op` fails:
 
@@ -166,6 +292,9 @@ The following pipeline uses `dsl.PipelineTaskFinalStatus` to obtain information 
 from kfp import dsl
 from kfp.dsl import PipelineTaskFinalStatus
 
+@dsl.component
+def print_op(message: str):
+    print(message)
 
 @dsl.component
 def exit_op(user_input: str, status: PipelineTaskFinalStatus):
@@ -184,29 +313,43 @@ def fail_op():
 
 @dsl.pipeline
 def my_pipeline():
-    print_op()
+    print_op(message='Starting pipeline...')
     print_status_task = exit_op(user_input='Task execution status:')
     with dsl.ExitHandler(exit_task=print_status_task):
         fail_op()
 ```
 
-#### Ignore upstream failure
+#### **Example:** Ignoring upstream task failures
 
-The [`.ignore_upstream_failure()`][ignore-upstream-failure] task method on [`PipelineTask`][dsl-pipelinetask] enables another approach to author pipelines with exit handling behavior. Calling this method on a task causes the task to ignore failures of any specified upstream tasks (as established by data exchange or by use of [`.after()`][dsl-pipelinetask-after]). If the task has no upstream tasks, this method has no effect.
+The [`.ignore_upstream_failure()`][ignore-upstream-failure] task method on [`PipelineTask`][dsl-pipelinetask] enables another approach to author pipelines with exit handling behavior. 
+Calling this method on a task causes the task to ignore failures of any specified upstream tasks (as established by data exchange or by use of [`.after()`][dsl-pipelinetask-after]). 
+If the task has no upstream tasks, this method has no effect.
 
-In the following pipeline definition, `clean_up_task` is executed after `fail_op`, regardless of whether `fail_op` succeeds:
+In the following pipeline definition, `clean_up_task` is executed after `fail_task`, regardless of whether `fail_op` succeeds:
 
 ```python
 from kfp import dsl
 
+@dsl.component
+def cleanup_op(message: str = 'Cleaning up...'):
+    print(message)
+
+@dsl.component
+def fail_op(message: str):
+    print(message)
+    raise ValueError('Task failed!')
+
 @dsl.pipeline()
 def my_pipeline(text: str = 'message'):
-    task = fail_op(message=text)
-    clean_up_task = print_op(
-        message=task.output).ignore_upstream_failure()
+    fail_task = fail_op(message=text)
+    clean_up_task = cleanup_op(
+        message=fail_task.output
+    ).ignore_upstream_failure()
 ```
 
-Note that the component used for the caller task (`print_op` in the example above) requires a default value for all inputs it consumes from an upstream task. The default value is applied if the upstream task fails to produce the outputs that are passed to the caller task. Specifying default values ensures that the caller task always succeeds, regardless of the status of the upstream task.
+Note that the component used for the caller task (`cleanup_op` in the example above) requires a default value for all inputs it consumes from an upstream task. 
+The default value is applied if the upstream task fails to produce the outputs that are passed to the caller task. 
+Specifying default values ensures that the caller task always succeeds, regardless of the status of the upstream task.
 
 [data-passing]: /docs/components/pipelines/user-guides/components/compose-components-into-pipelines#data-passing-and-task-dependencies
 [pipeline-basics]: /docs/components/pipelines/user-guides/components/compose-components-into-pipelines

--- a/content/en/docs/components/pipelines/user-guides/core-functions/platform-specific-features.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/platform-specific-features.md
@@ -1,6 +1,6 @@
 +++
 title = "Use Platform-Specific Features"
-description = "Learn how to use platform-specific features in Kubeflow Pipelines in your pipelines."
+description = "Learn how to use platform-specific features in Kubeflow Pipelines."
 weight = 105
 +++
 

--- a/content/en/docs/components/pipelines/user-guides/core-functions/run-a-pipeline.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/run-a-pipeline.md
@@ -1,83 +1,150 @@
 +++
 title = "Run a Pipeline"
 description = "Execute a pipeline on the KFP backend"
-weight = 1
+weight = 100
 +++
 
 {{% kfp-v2-keywords %}}
 
-The KFP offers three ways to run a pipeline.
+## Overview
 
-## 1. Run from the KFP Dashboard
+Kubeflow Pipelines (KFP) provides several ways to trigger a pipeline run:
+
+1. [__KFP Dashboard__](#run-pipeline---kfp-dashboard)
+2. [__KFP SDK Client__](#run-pipeline---kfp-sdk-client)
+3. [__KFP CLI__](#run-pipeline---kfp-cli)
+
+{{% alert title="Tip" color="info" %}}
+This guide only covers how to trigger an immediate pipeline run. 
+For more advanced scheduling options please see the "Recurring Runs" section of the dashboard and API.
+{{% /alert %}}
+
+## Run Pipeline - KFP Dashboard
+
 The first and easiest way to run a pipeline is by submitting it via the KFP dashboard.
 
-To submit a pipeline to the KFP Dashboard:
+To submit a pipeline for an immediate run:
 
-1. [Compile the pipeline][compile-a-pipeline] to IR YAML.
+1. [Compile a pipeline][compile-a-pipeline] to IR YAML.
 
-2.  From the Dashboard, select "+ Upload pipeline".
+2. From the "Pipelines" tab in the dashboard, select `+ Upload pipeline`:
 
-<img src="/docs/images/pipelines/submit-a-pipeline-on-dashboard.png" 
-  alt="Upload pipeline button"
-  class="mt-3 mb-3 border border-info rounded">
+   <img src="/docs/images/pipelines/submit-a-pipeline-on-dashboard.png" 
+        alt="Upload pipeline button"
+        class="mt-3 mb-3 border border-info rounded">
 
-3. Upload the pipeline IR YAML file or an archived pipeline as a .zip or .tar.gz file, populate the upload pipeline form, and click “Create”.
+3. Upload the pipeline `.yaml`, `.zip` or `.tar.gz` file, populate the upload form, then click `Create`.
 
-<img src="/docs/images/pipelines/upload-a-pipeline.png" 
-  alt="Upload pipeline screen"
-  class="mt-3 mb-3 border border-info rounded">
+   <img src="/docs/images/pipelines/upload-a-pipeline.png" 
+        alt="Upload pipeline screen" 
+        class="mt-3 mb-3 border border-info rounded">
 
-4. From the Runs tab, select "+ Create run":
+4. From the "Runs" tab, select `+ Create run`:
 
-<img src="/docs/images/pipelines/create-run.png" 
-  alt="Create run button"
-  class="mt-3 mb-3 border border-info rounded">
+   <img src="/docs/images/pipelines/create-run.png" 
+        alt="Create run button"
+        class="mt-3 mb-3 border border-info rounded">
 
-5. Choose the pipeline you uploaded, provide a name, any run parameters, and click "Start".
-<img src="/docs/images/pipelines/start-a-run.png" 
-  alt="Start a run screen"
-  class="mt-3 mb-3 border border-info rounded">
+5. Select the pipeline you want to run, populate the run form, then click `Start`:
 
+   <img src="/docs/images/pipelines/start-a-run.png" 
+        alt="Start a run screen"
+        class="mt-3 mb-3 border border-info rounded">
 
-## 2. Run from the KFP SDK client
-You may also programatically submit pipeline runs from the KFP SDK client. The client supports two ways of submitting runs: from IR YAML or from a Python pipeline function. For either approach, start by instantiating a `Client` using the `host` URL of your KFP instance:
+## Run Pipeline - KFP SDK Client
 
-```python
-from kfp.client import Client
-client = Client(host='<YOUR_HOST_URL>')
-```
+You may also programmatically submit pipeline runs from the KFP SDK client. 
+The client supports two ways of submitting runs: _from IR YAML_ or _from a Python pipeline function_. 
 
-To submit IR YAML for execution use the `.create_run_from_pipeline_package` method:
+{{% alert title="Note" color="dark" %}}
+See the [Connect the SDK to the API](/docs/components/pipelines/user-guides/core-functions/connect-api/) guide for more information about creating a KFP client.
+{{% /alert %}}
 
-```python
-client.create_run_from_pipeline_package('pipeline.yaml', arguments={'param': 'a', 'other_param': 2})
-```
-
-To submit a Python pipeline function for execution use the `.create_run_from_pipeline_func` convenience method, which wraps compilation and run submission into one method:
+For either approach, start by instantiating a [`kfp.Client()`][kfp-client]:
 
 ```python
-client.create_run_from_pipeline_func(pipeline_func, arguments={'param': 'a', 'other_param': 2})
+import kfp
+
+# TIP: you may need to authenticate with the KFP instance
+kfp_client = kfp.Client()
 ```
 
-See the [KFP SDK Client reference documentation][kfp-sdk-api-ref-client] for a detailed description of the `Client` constructor and method parameters.
+To submit __IR YAML__ for execution use the [`.create_run_from_pipeline_package()`][kfp-client-create_run_from_pipeline_package] method:
 
-## 3. Run from the KFP SDK CLI
-The `kfp run create` command allows you to submit a pipeline from the command line. `kfp run create --help` shows that this command takes the form:
+```python
+#from kfp import compiler, dsl
+#
+#@dsl.component
+#def add(a: float, b: float) -> float:
+#   return a + b
+#
+#@dsl.pipeline(name="Add two Numbers")
+#def add_pipeline(a: float, b: float):
+#   add_task = add(a=a, b=b)
+#
+#compiler.Compiler().compile(
+#    add_pipeline, 
+#    package_path="./add-pipeline.yaml"
+#)
+
+kfp_client.create_run_from_pipeline_package(
+    "./add-pipeline.yaml", 
+    arguments={
+        "a": 1,
+        "b": 2,
+    }
+)
+```
+
+To submit a python __pipeline function__ for execution use the [`.create_run_from_pipeline_func()`][kfp-client-create_run_from_pipeline_func] convenience method, which wraps compilation and run submission into one method:
+
+```python
+#from kfp import dsl
+#
+#@dsl.component
+#def add(a: float, b: float) -> float:
+#    return a + b
+#
+#@dsl.pipeline(name="Add two Numbers")
+#def add_pipeline(a: float, b: float):
+#    add_task = add(a=a, b=b)
+
+kfp_client.create_run_from_pipeline_func(
+    add_pipeline,
+    arguments={
+        "a": 1,
+        "b": 2,
+    }
+)
+```
+
+## Run Pipeline - KFP CLI
+
+The [`kfp run create`][kfp-cli-run-create] command allows you to submit a pipeline from the command line. 
+
+Here is the output of `kfp run create --help`:
 
 ```shell
 kfp run create [OPTIONS] [ARGS]...
 ```
 
-For example, the following command submits the `path/to/pipeline.yaml` IR YAML to the KFP backend:
+For example, the following command submits the `./path/to/pipeline.yaml` IR YAML to the KFP backend:
 
 ```shell
-kfp run create --experiment-name my-experiment --package-file path/to/pipeline.yaml
+kfp run create \
+  --experiment-name "my-experiment" \
+  --package-file "./path/to/pipeline.yaml"
 ```
 
-For more information about the `kfp run create` command, see [Command Line Interface][kfp-run-create-reference-docs] in the [KFP SDK reference documentation][kfp-sdk-api-ref]. For a summary of the available commands in the KFP CLI, see [Command-line Interface][kfp-cli].
+For more information about the `kfp` CLI, please see:
 
-[kfp-sdk-api-ref]: https://kubeflow-pipelines.readthedocs.io/en/master/index.html
+- [Use the CLI][use-the-cli]
+- [CLI Reference][kfp-cli]
+
 [compile-a-pipeline]: /docs/components/pipelines/user-guides/core-functions/compile-a-pipeline/
-[kfp-sdk-api-ref-client]: https://kubeflow-pipelines.readthedocs.io/en/master/source/client.html
-[kfp-cli]: /docs/components/pipelines/user-guides/core-functions/cli/
-[kfp-run-create-reference-docs]: https://kubeflow-pipelines.readthedocs.io/en/master/source/cli.html#kfp-run-create
+[use-the-cli]: /docs/components/pipelines/user-guides/core-functions/cli/
+[kfp-cli]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/cli.html
+[kfp-cli-run-create]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/cli.html#kfp-run-create
+[kfp-client]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/client.html#kfp.client.Client
+[kfp-client-create_run_from_pipeline_func]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/client.html#kfp.client.Client.create_run_from_pipeline_func
+[kfp-client-create_run_from_pipeline_package]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/client.html#kfp.client.Client.create_run_from_pipeline_package

--- a/content/en/docs/components/pipelines/user-guides/data-handling/_index.md
+++ b/content/en/docs/components/pipelines/user-guides/data-handling/_index.md
@@ -1,4 +1,5 @@
 +++
 title = "Data Handling"
+description = "Learn how to handle data in Kubeflow Pipelines."
 weight = 4
 +++

--- a/content/en/docs/components/pipelines/user-guides/data-handling/artifacts.md
+++ b/content/en/docs/components/pipelines/user-guides/data-handling/artifacts.md
@@ -245,7 +245,7 @@ On the [KFP open source][oss-be] UI, `ClassificationMetrics`, `SlicedClassificat
 [python-components]: /docs/components/pipelines/user-guides/components/lightweight-python-components
 [dsl-parallelfor]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/dsl.html#kfp.dsl.ParallelFor
 [dsl-collected]: https://kubeflow-pipelines.readthedocs.io/en/latest/source/dsl.html#kfp.dsl.Collected
-[parallel-looping]: /docs/components/pipelines/user-guides/core-functions/control-flow/#parallel-looping-dslparallelfor
+[parallel-looping]: /docs/components/pipelines/user-guides/core-functions/control-flow/#dslparallelfor
 [traditional-artifact-syntax]: /docs/components/pipelines/user-guides/data-handling/artifacts/#traditional-artifact-syntax
 [multiple-outputs]: /docs/components/pipelines/user-guides/data-handling/parameters/#multiple-output-parameters
 [pythonic-artifact-syntax]: /docs/components/pipelines/user-guides/data-handling/artifacts/#new-pythonic-artifact-syntax

--- a/content/en/docs/components/pipelines/user-guides/migration.md
+++ b/content/en/docs/components/pipelines/user-guides/migration.md
@@ -24,7 +24,7 @@ The following table shows which versions of KFP backend are included in each ver
 
 Release Date | Kubeflow Platform Version | KFP Backend Version | SDK Mode: [`v1`](/docs/components/pipelines/legacy-v1/sdk/) | SDK Mode: [`v2`](/docs/components/pipelines/user-guides/core-functions/compile-a-pipeline/) | SDK Mode: [`v2-compatible`](https://v1-7-branch.kubeflow.org/docs/components/pipelines/v1/sdk-v2/)
 --- | --- | --- | --- | --- | ---
-Unreleased | [Kubeflow 1.9](/docs/releases/kubeflow-1.9/) | [2.2.0](https://github.com/kubeflow/pipelines/releases/tag/2.2.0) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i>
+2024-07-22 | [Kubeflow 1.9](/docs/releases/kubeflow-1.9/) | [2.2.0](https://github.com/kubeflow/pipelines/releases/tag/2.2.0) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i>
 2023-11-01 | [Kubeflow 1.8](/docs/releases/kubeflow-1.8/) | [2.0.3](https://github.com/kubeflow/pipelines/releases/tag/2.0.3) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i>
 2023-03-29 | [Kubeflow 1.7](/docs/releases/kubeflow-1.7/) | [2.0.0-alpha.7](https://github.com/kubeflow/pipelines/releases/tag/2.0.0-alpha.7) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i> | <i class="fa-solid fa-check"></i> 
 2022-10-10 | [Kubeflow 1.6](/docs/releases/kubeflow-1.6/) | [2.0.0-alpha.5](https://github.com/kubeflow/pipelines/releases/tag/2.0.0-alpha.5) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i> | <i class="fa-solid fa-check"></i> 

--- a/content/en/docs/components/pipelines/user-guides/migration.md
+++ b/content/en/docs/components/pipelines/user-guides/migration.md
@@ -694,7 +694,7 @@ If you believe we missed a breaking change or an important migration step, pleas
 [new-issue]: https://github.com/kubeflow/pipelines/issues/new
 [oss-be-v1]: /docs/components/pipelines/legacy-v1/
 [oss-be-v2]: /docs/components/pipelines/operator-guides/installation/
-[parallelfor-control-flow]: /docs/components/pipelines/user-guides/core-functions/control-flow/#parallel-looping-dslparallelfor
+[parallelfor-control-flow]: /docs/components/pipelines/user-guides/core-functions/control-flow/#dslparallelfor
 [parameters]: /docs/components/pipelines/user-guides/data-handling/parameters
 [pipelines-repo]: https://github.com/kubeflow/pipelines
 [semver-minor-version]: https://semver.org/#:~:text=MINOR%20version%20when%20you%20add%20functionality%20in%20a%20backwards%20compatible%20manner

--- a/content/en/docs/components/pipelines/user-guides/migration.md
+++ b/content/en/docs/components/pipelines/user-guides/migration.md
@@ -1,258 +1,77 @@
 +++
-title = "Migrate from KFP SDK v1"
-description = "v1 to v2 migration instructions and breaking changes"
+title = "Migrate to Kubeflow Pipelines v2"
+description = "Migrate to the new Kubeflow Pipelines v2 backend and SDK."
 weight = 1
 +++
 
 {{% kfp-v2-keywords %}}
 
-If you have existing KFP pipelines, either compiled to [Argo Workflow][argo] (using the SDK v1 main namespace) or to [IR YAML][ir-YAML] (using the SDK v1 v2-namespace), you can run these pipelines on the new [KFP v2 backend][oss-be-v2] without any changes.
+## Overview 
 
-If you wish to author new pipelines, there are some recommended and required steps to migrate your pipeline authoring code to the KFP SDK v2.
+Kubeflow Pipelines V2 is a significant update to the Kubeflow Pipelines (KFP) platform.
+
+The key features introduced by KFP V2 are:
+
+- A more pythonic SDK - use decorators like ([`@dsl.pipeline`][dsl-pipeline], [`@dsl.component`][dsl-component], [`@dsl.container_component`][dsl-container-component])
+- Decouple from Argo Workflows - compile pipelines to a generic [IR YAML][ir-yaml] rather than Argo `Workflow` YAML
+- Enhanced Workflow GUI - visualize pipelines, sub-DAGs (nested pipelines), loops, and artifacts (datasets, models, and metrics) to understand and debug your pipelines
+
+## Version Matrix
+
+The first version of [Kubeflow Platform](/docs/started/introduction/#what-is-kubeflow-platform) to include the Kubeflow Pipelines V2 backend was [Kubeflow 1.8](/docs/releases/kubeflow-1.8/).
+
+The following table shows which versions of KFP backend are included in each version of Kubeflow Platform:
+
+Release Date | Kubeflow Platform Version | KFP Backend Version | SDK Mode: [`v1`](/docs/components/pipelines/legacy-v1/sdk/) | SDK Mode: [`v2`](/docs/components/pipelines/user-guides/core-functions/compile-a-pipeline/) | SDK Mode: [`v2-compatible`](https://v1-7-branch.kubeflow.org/docs/components/pipelines/v1/sdk-v2/)
+--- | --- | --- | --- | --- | ---
+Unreleased | [Kubeflow 1.9](/docs/releases/kubeflow-1.9/) | [2.2.0](https://github.com/kubeflow/pipelines/releases/tag/2.2.0) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i>
+2023-11-01 | [Kubeflow 1.8](/docs/releases/kubeflow-1.8/) | [2.0.3](https://github.com/kubeflow/pipelines/releases/tag/2.0.3) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i>
+2023-03-29 | [Kubeflow 1.7](/docs/releases/kubeflow-1.7/) | [2.0.0-alpha.7](https://github.com/kubeflow/pipelines/releases/tag/2.0.0-alpha.7) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i> | <i class="fa-solid fa-check"></i> 
+2022-10-10 | [Kubeflow 1.6](/docs/releases/kubeflow-1.6/) | [2.0.0-alpha.5](https://github.com/kubeflow/pipelines/releases/tag/2.0.0-alpha.5) | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i> | <i class="fa-solid fa-check"></i> 
+2022-06-15 | [Kubeflow 1.5](/docs/releases/kubeflow-1.5/) | [1.8.2](https://github.com/kubeflow/pipelines/releases/tag/1.8.2)  | <i class="fa-solid fa-check"></i> | <i class="fa-solid fa-xmark"></i> | <i class="fa-solid fa-xmark"></i>
+
+## Backward Compatibility
+
+If you have existing KFP Pipelines that you compiled with the V1 SDK, you can run them on the new KFP V2 backend without any changes.
+If you wish to author new pipelines, there are some recommended and required steps to migrate which are detailed below.
+
+{{% alert title="Warning" color="warning" %}}
+Running V1 pipelines on KFP V2 requires that you compile and submit them using the V1 SDK.
+The last version of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), there will be no further releases.
+{{% /alert %}}
 
 ## Terminology
 
-- **SDK v1**: The `1.x.x` versions of the KFP SDK. `1.8` is the highest [minor version][semver-minor-version] of the v1 KFP SDK that will be released.
-- **SDK v1 v2-namespace**: Refers to the v1 KFP SDK's `v2` module (i.e., `from kfp.v2 import *`), which permits access to v2 authoring syntax and compilation to [IR YAML][ir-yaml] from the v1 SDK. You should assume that references to the v1 SDK *do not* refer to the v2-namespace unless explicitly stated. Until the release of the [v2 KFP OSS backend][oss-be-v2], these pipelines were only executable on [Google Cloud Vertex AI Pipelines][vertex-pipelines].
-- **SDK v2**: The `2.x.x` versions of the KFP SDK. Uses the v2 authoring syntax and compiles to IR YAML.
+Term | Definition
+--- | ---
+SDK v1 | The `1.x.x` versions of the [`kfp`](https://pypi.org/project/kfp/1.8.22/) Python SDK.
+SDK v2 | The `2.x.x` versions of the [`kfp`](https://pypi.org/project/kfp/) Python SDK.
+SDK v1 (v2-namespace) | The preview V2 module that was available in the V1 SDK (e.g. `from kfp.v2 import *`).<br>_Only ever used by [Google Cloud Vertex AI Pipelines][vertex-pipelines] users._
+
+## Migration Paths
+
+How you migrate to KFP V2 will depend on your current SDK version and usage.
 
 There are two common migration paths:
 
-1. If your existing `kfp==1.x.x` code imports from the `v2` namespace (i.e., `from kfp.v2 import *`), follow the [SDK v1 v2-namespace to SDK v2](#sdk-v1-v2-namespace-to-sdk-v2) migration instructions. This migration path only affects v1 SDK users that were running pipelines on [Google Cloud Vertex AI Pipelines][vertex-pipelines].
-1. If your existing `kfp==1.x.x` code imports from the main namespace (i.e., `from kfp import *`), follow the [SDK v1 to SDK v2](#sdk-v1-to-sdk-v2) migration instructions.
+1. [__SDK v1__ → __SDK v2__](#migrate-from-sdk-v1-to-sdk-v2)
+2. [__SDK v1 (v2-namespace) → SDK v2__](#migrate-from-sdk-v1-v2-namespace-to-sdk-v2)
 
-## SDK v1 v2-namespace to SDK v2
+<br>
 
-With few exceptions, KFP SDK v2 is backward compatible with user code that uses the KFP SDK v1 v2-namespace.
-
-### Non-breaking changes
-
-This section documents non-breaking changes in SDK v2 relative to the SDK v1 v2-namespace. We suggest you migrate your code to the "New usage", even though the "Previous usage" will still work with warnings.
-
-#### Import namespace
-
-KFP SDK v1 v2-namespace imports (`from kfp.v2 import *`) should be converted to imports from the primary namespace (`from kfp import *`).
-
-**Change:** Remove the `.v2` module from any KFP SDK v1 v2-namespace imports.
-
-<style>
-    th {
-        text-align: center;
-    }
-</style>
-
-<table>
-<tr>
-<th>Previous usage</th>
-<th>New usage</th>
-</tr>
-<tr>
-<td>
-
-```python
-from kfp.v2 import dsl
-from kfp.v2 import compiler
-
-@dsl.pipeline(name='my-pipeline')
-def pipeline():
-  ...
-
-compiler.Compiler().compile(...)
-```
-
-</td>
-<td>
-
-```python
-from kfp import dsl
-from kfp import compiler
-
-@dsl.pipeline(name='my-pipeline')
-def pipeline():
-  ...
-
-compiler.Compiler().compile(...)
-```
-
-</td>
-</tr>
-</table>
-
-#### output_component_file parameter
-
-In KFP SDK v2, components can be [compiled][compile] to and [loaded][load] from [IR YAML][ir-yaml] in the same way as pipelines.
-
-KFP SDK v1 v2-namespace supported compiling components via the [`@dsl.component`][dsl-component] decorator's `output_component_file` parameter. This is deprecated in KFP SDK v2. If you choose to still use this parameter, your pipeline will be compiled to [IR YAML][ir-yaml] instead of v1 component YAML.
-
-**Change:** Remove uses of `output_component_file`. Replace with a call to [`Compiler().compile()`][compiler-compile].
-
-<table>
-<tr>
-<th>Previous usage</th>
-<th>New usage</th>
-</tr>
-<tr>
-<td>
-
-```python
-from kfp.v2.dsl import component
-
-@component(output_component_file='my_component.yaml')
-def my_component(input: str):
-   ...
-```
-
-</td>
-<td>
-
-```python
-from kfp.dsl import component
-from kfp import compiler
-
-@component()
-def my_component(input: str):
-   ...
-
-compiler.Compiler().compile(my_component, 'my_component.yaml')
-```
-
-</td>
-</tr>
-</table>
-
-#### Pipeline package file extension
-
-The KFP compiler will compile your pipeline according to the extension provided to the compiler (`.yaml` or `.json`).
-
-In KFP SDK v2, YAML is the preferred serialization format.
-
-**Change:** Convert `package_path` arguments that use a `.json` extension to use a `.yaml` extension.
-
-<table>
-<tr>
-<th>Previous usage</th>
-<th>New usage</th>
-</tr>
-<tr>
-<td>
-
-```python
-from kfp.v2 import compiler
-# .json extension, deprecated format
-compiler.Compiler().compile(pipeline, package_path='my_pipeline.json')
-```
-
-</td>
-<td>
-
-```python
-from kfp import compiler
-# .yaml extension, preferred format
-compiler.Compiler().compile(pipeline, package_path='my_pipeline.yaml')
-```
-
-</td>
-</tr>
-</table>
-
-### Breaking changes
-
-There are only a few subtle breaking changes in SDK v2 relative to the SDK v1 v2-namespace.
-
-#### Drop support for Python 3.6
-
-KFP SDK v1 supported Python 3.6. KFP SDK v2 supports Python >=3.7.0,\<3.12.0.
-
-#### CLI output change
-
-The v2 [KFP CLI][cli] is more consistent, readable, and parsable. Code that parsed the v1 CLI output may fail to parse the v2 CLI output.
-
-#### .after referencing upstream task in a dsl.ParallelFor loop
-
-The following pipeline cannot be compiled in KFP SDK v2:
-
-```python
-with dsl.ParallelFor(...):
-    t1 = comp()
-t2 = comp().after(t1)
-```
-
-This usage was primarily used by KFP SDK v1 users who implemented a custom `dsl.ParallelFor` fan-in. KFP SDK v2 natively supports fan-in from [`dsl.ParallelFor`][dsl-parallelfor] using [`dsl.Collected`][dsl-collected]. See [Control Flow][parallelfor-control-flow] user docs for instructions.
-
-#### Importer component import statement
-
-The location of the `importer_node` object has changed.
-
-**Change:** Import from `kfp.dsl`.
-
-<table>
-<tr>
-<th>Previous usage</th>
-<th>New usage</th>
-</tr>
-<tr>
-<td>
-
-```python
-from kfp.components import importer_node
-```
-
-</td>
-<td>
-
-```python
-from kfp.dsl import importer_node
-```
-
-</td>
-</tr>
-</table>
-
-#### Adding node selector constraint/accelerator
-
-The task method `.add_node_selector_constraint` is deprecated in favor of `.add_node_selector_constraint`. Compared to the previous implementation of `.add_node_selector_constraint`, both methods have the `label_name` parameter removed and the `value` parameter is replaced by the parameter `accelerator`.
-
-**Change:** Use `task.set_accelerator_type(accelerator=...)`. Provide the previous `value` argument to the `accelerator` parameter. Omit the `label_name`.
-
-<table>
-<tr>
-<th>Previous usage</th>
-<th>New usage</th>
-</tr>
-<tr>
-<td>
-
-```python
-@dsl.pipeline
-def my_pipeline():
-    task.add_node_selector_constraint(
-        label_name='cloud.google.com/gke-accelerator',
-        value='NVIDIA_TESLA_A100',
-    )
-```
-
-</td>
-<td>
-
-```python
-@dsl.pipeline
-def my_pipeline():
-    task.set_accelerator_type(accelerator="NVIDIA_TESLA_K80")
-```
-
-</td>
-</tr>
-</table>
-
-## SDK v1 to SDK v2
+### **Migrate from 'SDK v1' to 'SDK v2'**
 
 KFP SDK v2 is generally not backward compatible with user code that uses the KFP SDK v1 main namespace. This section describes some of the important breaking changes and migration steps to upgrade to KFP SDK v2.
 
 We indicate whether each breaking change affects [KFP OSS backend][oss-be-v1] users or [Google Cloud Vertex AI Pipelines][vertex-pipelines] users.
 
-### Breaking changes
+#### **Breaking changes**
 
-#### create_component_from_func and func_to_container_op support
+<details>
+<summary>Click to expand</summary>
+<hr>
+
+##### **create_component_from_func and func_to_container_op support**
 
 **Affects:** KFP OSS users and Vertex AI Pipelines users
 
@@ -323,7 +142,9 @@ def pipeline():
 </tr>
 </table>
 
-#### Keyword arguments required
+---
+
+##### **Keyword arguments required**
 
 **Affects:** KFP OSS users and Vertex AI Pipelines users
 
@@ -356,8 +177,9 @@ def my_pipeline():
 </tr>
 </table>
 
+---
 
-#### ContainerOp support
+##### **ContainerOp support**
 
 **Affects:** KFP OSS users
 
@@ -403,7 +225,9 @@ def flip_coin(rand: int, result: dsl.OutputPath(str)):
 </tr>
 </table>
 
-#### VolumeOp and ResourceOp support
+---
+
+##### **VolumeOp and ResourceOp support**
 
 **Affects:** KFP OSS users
 
@@ -411,7 +235,9 @@ def flip_coin(rand: int, result: dsl.OutputPath(str)):
 
 KFP v2 enables support for [platform-specific features](/docs/components/pipelines/user-guides/core-functions/platform-specific-features/) via KFP SDK extension libraries. Kubernetes-specific features are supported in KFP v2 via the [`kfp-kubernetes`](https://kfp-kubernetes.readthedocs.io/) extension library.
 
-#### v1 component YAML support
+---
+
+##### **v1 component YAML support**
 
 **Affects:** KFP OSS users and Vertex AI Pipelines users
 
@@ -423,7 +249,9 @@ KFP v2 will continue to support loading existing v1 component YAML using the [`c
 
 **Change:** To author components via custom image, command, and args, use the [`@dsl.container_component`][dsl-container-component] decorator as described in [Container Components][container-components]. Note that unlike when authoring v1 component YAML, Container Components do not support setting environment variables on the component itself. Environment variables should be set on the task instantiated from the component within a pipeline definition using the [`.set_env_variable`][dsl-pipelinetask-set-env-variable] task [configuration method][task-configuration-methods].
 
-#### v1 lightweight component types InputTextFile, InputBinaryFile, OutputTextFile and OutputBinaryFile support
+---
+
+##### **v1 lightweight component types InputTextFile, InputBinaryFile, OutputTextFile and OutputBinaryFile support**
 
 **Affects:** KFP OSS users and Vertex AI Pipelines users
 
@@ -433,7 +261,9 @@ KFP SDK v2 does not support authoring with these types since users can easily do
 
 **Change:** Component authors should inputs and outputs using KFP's [artifact][artifacts] and [parameter][parameters] types.
 
-#### AIPlatformClient support
+---
+
+##### **AIPlatformClient support**
 
 **Affects:** Vertex AI Pipelines users
 
@@ -489,7 +319,9 @@ job.submit()
 </tr>
 </table>
 
-#### run_as_aiplatform_custom_job support
+---
+
+##### **run_as_aiplatform_custom_job support**
 
 **Affects:** Vertex AI Pipelines users
 
@@ -541,7 +373,9 @@ def pipeline():
 </tr>
 </table>
 
-#### Typecasting behavior change
+---
+
+##### **Typecasting behavior change**
 
 **Affects:** KFP OSS users and Vertex AI Pipelines users
 
@@ -571,9 +405,274 @@ def training_pipeline(number_of_epochs: int = 1):
 
 **Change:** We recommend updating your components and pipelines to use types strictly.
 
+---
+
+</details>
+
+<br>
+<br>
+
+### **Migrate from 'SDK v1 (v2-namespace)' to 'SDK v2'**
+
+With few exceptions, KFP SDK v2 is backward compatible with user code that uses the KFP SDK v1 v2-namespace.
+
+{{% alert title="Note" color="dark" %}}
+This migration path ONLY affects v1 SDK users that were running pipelines on Google Cloud's Vertex AI Pipelines.
+{{% /alert %}}
+
+#### **Non-breaking changes**
+
+This section documents non-breaking changes in SDK v2 relative to the SDK v1 v2-namespace.
+We suggest you migrate your code to the "New usage", even though the "Previous usage" will still work with warnings.
+
+<details>
+<summary>Click to expand</summary>
+<hr>
+
+##### **Import namespace**
+
+KFP SDK v1 v2-namespace imports (`from kfp.v2 import *`) should be converted to imports from the primary namespace (`from kfp import *`).
+
+**Change:** Remove the `.v2` module from any KFP SDK v1 v2-namespace imports.
+
+<style>
+    th {
+        text-align: center;
+    }
+</style>
+
+<table>
+<tr>
+<th>Previous usage</th>
+<th>New usage</th>
+</tr>
+<tr>
+<td>
+
+```python
+from kfp.v2 import dsl
+from kfp.v2 import compiler
+
+@dsl.pipeline(name='my-pipeline')
+def pipeline():
+  ...
+
+compiler.Compiler().compile(...)
+```
+
+</td>
+<td>
+
+```python
+from kfp import dsl
+from kfp import compiler
+
+@dsl.pipeline(name='my-pipeline')
+def pipeline():
+  ...
+
+compiler.Compiler().compile(...)
+```
+
+</td>
+</tr>
+</table>
+
+---
+
+##### **output_component_file parameter**
+
+In KFP SDK v2, components can be [compiled][compile] to and [loaded][load] from [IR YAML][ir-yaml] in the same way as pipelines.
+
+KFP SDK v1 v2-namespace supported compiling components via the [`@dsl.component`][dsl-component] decorator's `output_component_file` parameter. This is deprecated in KFP SDK v2. If you choose to still use this parameter, your pipeline will be compiled to [IR YAML][ir-yaml] instead of v1 component YAML.
+
+**Change:** Remove uses of `output_component_file`. Replace with a call to [`Compiler().compile()`][compiler-compile].
+
+<table>
+<tr>
+<th>Previous usage</th>
+<th>New usage</th>
+</tr>
+<tr>
+<td>
+
+```python
+from kfp.v2.dsl import component
+
+@component(output_component_file='my_component.yaml')
+def my_component(input: str):
+   ...
+```
+
+</td>
+<td>
+
+```python
+from kfp.dsl import component
+from kfp import compiler
+
+@component()
+def my_component(input: str):
+   ...
+
+compiler.Compiler().compile(my_component, 'my_component.yaml')
+```
+
+</td>
+</tr>
+</table>
+
+---
+
+##### **Pipeline package file extension**
+
+The KFP compiler will compile your pipeline according to the extension provided to the compiler (`.yaml` or `.json`).
+
+In KFP SDK v2, YAML is the preferred serialization format.
+
+**Change:** Convert `package_path` arguments that use a `.json` extension to use a `.yaml` extension.
+
+<table>
+<tr>
+<th>Previous usage</th>
+<th>New usage</th>
+</tr>
+<tr>
+<td>
+
+```python
+from kfp.v2 import compiler
+# .json extension, deprecated format
+compiler.Compiler().compile(pipeline, package_path='my_pipeline.json')
+```
+
+</td>
+<td>
+
+```python
+from kfp import compiler
+# .yaml extension, preferred format
+compiler.Compiler().compile(pipeline, package_path='my_pipeline.yaml')
+```
+
+</td>
+</tr>
+</table>
+
+---
+
+</details>
+
+#### **Breaking changes**
+
+There are only a few subtle breaking changes in SDK v2 relative to the SDK v1 v2-namespace.
+
+<details>
+<summary>Click to expand</summary>
+<hr>
+
+##### **Drop support for Python 3.6**
+
+KFP SDK v1 supported Python 3.6. KFP SDK v2 supports Python >=3.7.0,\<3.12.0.
+
+---
+
+##### **CLI output change**
+
+The v2 [KFP CLI][cli] is more consistent, readable, and parsable. Code that parsed the v1 CLI output may fail to parse the v2 CLI output.
+
+---
+
+##### **.after referencing upstream task in a dsl.ParallelFor loop**
+
+The following pipeline cannot be compiled in KFP SDK v2:
+
+```python
+with dsl.ParallelFor(...):
+    t1 = comp()
+t2 = comp().after(t1)
+```
+
+This usage was primarily used by KFP SDK v1 users who implemented a custom `dsl.ParallelFor` fan-in. KFP SDK v2 natively supports fan-in from [`dsl.ParallelFor`][dsl-parallelfor] using [`dsl.Collected`][dsl-collected]. See [Control Flow][parallelfor-control-flow] user docs for instructions.
+
+---
+
+##### **Importer component import statement**
+
+The location of the `importer_node` object has changed.
+
+**Change:** Import from `kfp.dsl`.
+
+<table>
+<tr>
+<th>Previous usage</th>
+<th>New usage</th>
+</tr>
+<tr>
+<td>
+
+```python
+from kfp.components import importer_node
+```
+
+</td>
+<td>
+
+```python
+from kfp.dsl import importer_node
+```
+
+</td>
+</tr>
+</table>
+
+---
+
+##### **Adding node selector constraint/accelerator**
+
+The task method `.add_node_selector_constraint` is deprecated in favor of `.add_node_selector_constraint`. Compared to the previous implementation of `.add_node_selector_constraint`, both methods have the `label_name` parameter removed and the `value` parameter is replaced by the parameter `accelerator`.
+
+**Change:** Use `task.set_accelerator_type(accelerator=...)`. Provide the previous `value` argument to the `accelerator` parameter. Omit the `label_name`.
+
+<table>
+<tr>
+<th>Previous usage</th>
+<th>New usage</th>
+</tr>
+<tr>
+<td>
+
+```python
+@dsl.pipeline
+def my_pipeline():
+    task.add_node_selector_constraint(
+        label_name='cloud.google.com/gke-accelerator',
+        value='NVIDIA_TESLA_A100',
+    )
+```
+
+</td>
+<td>
+
+```python
+@dsl.pipeline
+def my_pipeline():
+    task.set_accelerator_type(accelerator="NVIDIA_TESLA_K80")
+```
+
+</td>
+</tr>
+</table>
+
+---
+
+</details>
+
+<br>
+
 ## Did we miss something?
 
-If you believe we missed a breaking change or an important migration step, please [create an issue][new-issue] describing the change in the [kubeflow/pipelines repository][pipelines-repo].
+If you believe we missed a breaking change or an important migration step, please [create an issue][new-issue] describing the change in the [`kubeflow/pipelines` repository][pipelines-repo].
 
 [artifacts]: /docs/components/pipelines/user-guides/data-handling/artifacts
 [cli]: /docs/components/pipelines/user-guides/core-functions/cli/
@@ -586,6 +685,7 @@ If you believe we missed a breaking change or an important migration step, pleas
 [dsl-collected]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.Collected
 [dsl-component]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.component
 [dsl-container-component]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.container_component
+[dsl-pipeline]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.pipeline
 [dsl-parallelfor]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.ParallelFor
 [gcpc]: https://cloud.google.com/vertex-ai/docs/pipelines/components-introduction
 [ir-yaml]: /docs/components/pipelines/user-guides/core-functions/compile-a-pipeline/#ir-yaml
@@ -602,6 +702,5 @@ If you believe we missed a breaking change or an important migration step, pleas
 [vertex-customjob]: https://cloud.google.com/vertex-ai/docs/training/create-custom-job
 [vertex-pipelines]: https://cloud.google.com/vertex-ai/docs/pipelines/introduction
 [vertex-sdk]: https://cloud.google.com/vertex-ai/docs/pipelines/run-pipeline#vertex-ai-sdk-for-python
-[argo]: https://argoproj.github.io/argo-workflows/
 [dsl-pipelinetask-set-env-variable]: https://kubeflow-pipelines.readthedocs.io/en/2.0.0b13/source/dsl.html#kfp.dsl.PipelineTask.set_env_variable
 [task-configuration-methods]: /docs/components/pipelines/user-guides/components/compose-components-into-pipelines/#task-configurations


### PR DESCRIPTION
This PR makes significant formatting updates and rewording to the `Kubeflow Pipelines` / `User Guides` / `Core Functions`, and `Migrate to Kubeflow Pipelines v2` guides.

For the most part this is a formatting update, but I draw reviwers attention to a content change I made on the `Connect the SDK to the API` page. I have updated the Python script given as an example for connecting the KFP SDK with Dex. I have used the same [reference example as in the deployKF docs](https://www.deploykf.org/user-guides/access-kubeflow-pipelines-api/#dex-static-credentials). (Note, it will work for all other distributions, including manifests, as long as they use Dex).

The most important changes in this PR are:

- Re-naming the `Core Functions` pages to have shorter titles to be more clear
- Re-ordering the `Core Functions` pages to better tell a story and be readable from top to bottom
- Significantly improving the `Migrate to Kubeflow Pipelines v2` page which was very hard to read before.

__The easiest way to review this PR will be to look at the Netlify preview and review the following pages:__

- `Kubeflow Pipelines`
     - `User Guides`:
          - [`Migrate to Kubeflow Pipelines v2`](https://deploy-preview-3795--competent-brattain-de2d6d.netlify.app/docs/components/pipelines/user-guides/migration/)
          - [`Core Functions`](https://deploy-preview-3795--competent-brattain-de2d6d.netlify.app/docs/components/pipelines/user-guides/core-functions/):
              - _(all pages)_
              
After we merge this, we will need to do the same thing for the "Create Components" and "Data Handling" sections.