### PR TITLE
Training: Fix SDK install for LLMs Fine-Tuning API

### DIFF
--- a/content/en/docs/components/training/installation.md
+++ b/content/en/docs/components/training/installation.md
@@ -91,7 +91,7 @@ If you want to use `train` API for LLM fine-tuning with Training Operator, insta
 with the additional packages from HuggingFace:
 
 ```shell
-pip install -U kubeflow-training[huggingface]
+pip install -U "kubeflow-training[huggingface]"
 ```
 
 ## Next steps


### PR DESCRIPTION
We should use quotes when we install Training SDK with HuggingFace dependencies.

/assign @kubeflow/wg-training-leads 

