### PR TITLE
Issue 3829: Remove missing template preventing local build

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -61,7 +61,5 @@
   {{ $enableGtagForUniversalAnalytics := not .Site.Params.disableGtagForUniversalAnalytics -}}
   {{ if (or $enableGtagForUniversalAnalytics (hasPrefix .Site.GoogleAnalytics "G-")) -}}
     {{ template "_internal/google_analytics_gtag.html" . -}}
-  {{ else -}}
-    {{ template "_internal/google_analytics_async.html" . -}}
   {{ end -}}
 {{ end -}}


### PR DESCRIPTION
As outlined in https://github.com/kubeflow/website/issues/3829, the missing `_internal/google_analytics_async.html ` script fails the local startup of the hugo server (as outlined in the docs).

I've removed the template code reference as it's not in the repo.

Let me know if this isn't the correct thing, happy to revise or update the docs accordingly.

I was also able to get the huge server to start up locally by just adding an empty file but I suspect that's not the correct solution.