### PR TITLE
KF 1.9 release: fix date and link to video

### DIFF
--- a/content/en/docs/releases/kubeflow-1.9.md
+++ b/content/en/docs/releases/kubeflow-1.9.md
@@ -22,7 +22,7 @@ weight = 95
           <a href="https://blog.kubeflow.org/kubeflow-1.9-release/">Kubeflow 1.9 Release Announcement</a>
         <br>
         <b>Video:</b> 
-          <a href="https://www.youtube.com/watch?v=3sZzE-vPsMI">Kubeflow 1.9 Release Update</a>
+          <a href="https://www.youtube.com/watch?v=bzu2Qqv4Ij0">Kubeflow 1.9 Release Update</a>
         <br>
         <b>Roadmap:</b>
           <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-19-release-planned-for-release-jul-2024">Kubeflow 1.9 Features</a>

--- a/content/en/docs/releases/kubeflow-1.9.md
+++ b/content/en/docs/releases/kubeflow-1.9.md
@@ -12,7 +12,7 @@ weight = 95
     <tr>
       <th class="table-light">Release Date</th>
       <td>
-        2023-03-29
+        2024-07-22
       </td>
     </tr>
     <tr>
@@ -22,7 +22,7 @@ weight = 95
           <a href="https://blog.kubeflow.org/kubeflow-1.9-release/">Kubeflow 1.9 Release Announcement</a>
         <br>
         <b>Video:</b> 
-          To be published
+          <a href="https://www.youtube.com/watch?v=3sZzE-vPsMI">Kubeflow 1.9 Release Update</a>
         <br>
         <b>Roadmap:</b>
           <a href="https://github.com/kubeflow/kubeflow/blob/master/ROADMAP.md#kubeflow-19-release-planned-for-release-jul-2024">Kubeflow 1.9 Features</a>


### PR DESCRIPTION
1. fix the release date,
ref: https://github.com/kubeflow/manifests/releases/tag/v1.9.0
as noticed by @thesuperzapper 

2. link to Kubeflow 1.9 Release Update youtube video

👉 if the PR is approved, I will update the video from Unlisted -> Published

@kubeflow/release-team @rimolive @StefanoFioravanzo @andreyvelich @hbelmiro @jbottum @juliusvonkohout 