### PR TITLE
add unsupported notice for PipelineTaskFinalStatus

### DIFF
--- a/content/en/docs/components/pipelines/user-guides/core-functions/control-flow.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/control-flow.md
@@ -319,6 +319,8 @@ def my_pipeline():
         fail_op()
 ```
 
+{{% oss-be-unsupported feature_name="Setting `PipelineTaskFinalStatus`" gh_issue_link=https://github.com/kubeflow/pipelines/issues/10917 %}}
+
 #### **Example:** Ignoring upstream task failures
 
 The [`.ignore_upstream_failure()`][ignore-upstream-failure] task method on [`PipelineTask`][dsl-pipelinetask] enables another approach to author pipelines with exit handling behavior. 


### PR DESCRIPTION
This is an unsupported field in kfp, and should be indicated as such. More Context [here](https://github.com/kubeflow/pipelines/issues/10917#issuecomment-2289974966)