### PR TITLE
Fix Kubeflow 1.9 release date

### DIFF
--- a/content/en/docs/releases/kubeflow-1.9.md
+++ b/content/en/docs/releases/kubeflow-1.9.md
@@ -12,7 +12,7 @@ weight = 95
     <tr>
       <th class="table-light">Release Date</th>
       <td>
-        2023-03-29
+        2024-07-22
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
In the interest of fixing the incorrect date while we wait for https://github.com/kubeflow/website/pull/3835 to be ready (we need to upload the video to the `Kubeflow` channel before we publish), I am raising a separate PR to only fix the date.