### PR TITLE
chore: bump model registry python client version

### DIFF
--- a/content/en/docs/components/model-registry/getting-started.md
+++ b/content/en/docs/components/model-registry/getting-started.md
@@ -29,7 +29,7 @@ To follow along the examples in this guide, you will need a Kubeflow installatio
 To use Model Registry on a notebook you should first install the Python client:
 
 ```raw
-!pip install --pre model-registry=="0.2.3a1"
+!pip install --pre model-registry=="0.2.5a1"
 ```
 
 Note that depending on your environment there might be conflicting dependency versions for packages that depend on


### PR DESCRIPTION
This PR bumps the model registry python client version to the latest one, in the Model Registry "Getting Started" page.

1.  changed from "0.2.3a1" to "0.2.5a1"