### PR TITLE
Block web crawlers on `v0.2-branch`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,8 @@
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.40"
+  NODE_VERSION = "8"
 
 [context.production.environment]
   HUGO_VERSION = "0.40"
+  NODE_VERSION = "8"

--- a/themes/kf/layouts/_default/baseof.html
+++ b/themes/kf/layouts/_default/baseof.html
@@ -14,6 +14,9 @@
 
   <link rel="home" href="/">
 
+	<!-- Prevent search engines from indexing this old site -->
+	<meta name="robots" content="noindex">
+
 	<!-- favicons -->
 	<link rel="apple-touch-icon" sizes="57x57" href="/images/favicons/apple-icon-57x57.png">
 	<link rel="apple-touch-icon" sizes="60x60" href="/images/favicons/apple-icon-60x60.png">


### PR DESCRIPTION
Google keeps surfacing links from very old versions of the Kubeflow docs website, which is confusing to users.

This PR adds the [`<meta name="robots" content="noindex">` meta tag](https://developers.google.com/search/docs/crawling-indexing/block-indexing) to tell Google to stop indexing the pages from the `v0.2-branch` branch.

It will take probably a few months (or longer) for Google to re-index these pages, I have left `nofollow` off, so that google will re-index the whole site quicker by following links.