### PR TITLE
Block web crawlers on `v0.4-branch`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -108,7 +108,7 @@ copyright = "The Kubeflow Authors."
 privacy_policy = "https://policies.google.com/privacy"
 
 # Text label for the version menu in the top bar of the website.
-version_menu = "v0.4"
+version_menu = "Archive: 0.4"
 
 # The major.minor version tag for the version of the docs represented in this
 # branch of the repository. Used in the "version-banner" partial to display a
@@ -121,7 +121,7 @@ archived_version = true
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "https://kubeflow.org/docs/"
+url_latest_version = "https://www.kubeflow.org/docs/"
 
 # A variable used in various docs to determine URLs for config files etc.
 # To find occurrences, search the repo for 'params "githubbranch"'.
@@ -130,19 +130,21 @@ githubbranch = "v0.4-branch"
 # Add new release versions here. These entries appear in the drop-down menu
 # at the top of the website.
 [[params.versions]]
-  version = "master"
+  version = "Latest"
   githubbranch = "master"
-  url = "https://master.kubeflow.org"
-
+  url = "https://www.kubeflow.org"
 [[params.versions]]
-  version = "v0.2"
-  githubbranch = "v0.2-branch"
-  url = "https://v0-2.kubeflow.org"
-
+  version = "Archive: 0.4"
+  githubbranch = "v0.4-branch"
+  url = "https://v0-4.kubeflow.org"
 [[params.versions]]
-  version = "v0.3"
+  version = "Archive: 0.3"
   githubbranch = "v0.3-branch"
   url = "https://v0-3.kubeflow.org"
+[[params.versions]]
+  version = "Archive: 0.2"
+  githubbranch = "v0.2-branch"
+  url = "https://v0-2.kubeflow.org"
 
 # Docsy: User interface configuration
 [params.ui]

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,5 +1,5 @@
 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-	{{ .Site.Params.version }}
+	{{ .Site.Params.version_menu }}
 </a>
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
 	{{ range .Site.Params.versions }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,9 @@
   command = "hugo"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.56"
+  HUGO_VERSION = "0.56.3"
   NODE_VERSION = "10"
 
 [context.production.environment]
-  HUGO_VERSION = "0.56"
+  HUGO_VERSION = "0.56.3"
   NODE_VERSION = "10"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,8 @@
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.51"
+  NODE_VERSION = "8"
 
 [context.production.environment]
   HUGO_VERSION = "0.51"
+  NODE_VERSION = "8"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,9 @@
   command = "hugo"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.51"
+  HUGO_VERSION = "0.56"
   NODE_VERSION = "10"
 
 [context.production.environment]
-  HUGO_VERSION = "0.51"
+  HUGO_VERSION = "0.56"
   NODE_VERSION = "10"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,8 +4,8 @@
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.51"
-  NODE_VERSION = "8"
+  NODE_VERSION = "10"
 
 [context.production.environment]
   HUGO_VERSION = "0.51"
-  NODE_VERSION = "8"
+  NODE_VERSION = "10"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,9 @@
   command = "hugo"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.56.3"
+  HUGO_VERSION = "0.81.0"
   NODE_VERSION = "10"
 
 [context.production.environment]
-  HUGO_VERSION = "0.56.3"
+  HUGO_VERSION = "0.81.0"
   NODE_VERSION = "10"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "website",
+  "devDependencies": {
+    "autoprefixer": "^9.4.3",
+    "postcss": "^7.0.6",
+    "postcss-cli": "^6.1.0"
+  }
+}

--- a/themes/docsy/layouts/partials/head.html
+++ b/themes/docsy/layouts/partials/head.html
@@ -1,11 +1,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ .Hugo.Generator }}
-{{ if eq (getenv "HUGO_ENV") "production" }}
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
-{{ else }}
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-{{ end }}
+<!-- Prevent search engines from indexing this old site -->
+<meta name="robots" content="noindex">
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}


### PR DESCRIPTION
Google keeps surfacing links from very old versions of the Kubeflow docs website, which is confusing to users.

This PR adds the [`<meta name="robots" content="noindex">` meta tag](https://developers.google.com/search/docs/crawling-indexing/block-indexing) to tell Google to stop indexing the pages from the `v0.4-branch` branch.

It will take probably a few months (or longer) for Google to re-index these pages, I have left `nofollow` off, so that google will re-index the whole site quicker by following links.

---

It also backports the changes from https://github.com/kubeflow/website/pull/3863 so the version selector is consistent across each archive version.