### PR TITLE
Block web crawlers on `v1.0-branch`

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,32 +1,7 @@
 approvers:
-  - abhi-g
-  - jlewi
-  - richardsliu
-  - joeliedtke
-  - animeshsingh
-  - rmgogogo
-  - janeman98
-reviewers:
-  - aronchick
-  - carmine
-  - dansanche
-  - Jeffwan
-  - jinchihe
-  - kunmingg
-  - lluunn
-  - nickchase
-  - pdmack
+  - andreyvelich
+  - james-jwu
+  - jbottum
+  - johnugeorge
   - terrytangyuan
-  - willingc
-  - dsdinter
-  - Ark-kun
-  - gaoning777
-  - hongye-sun
-  - IronPan
-  - neuromage 
-  - paveldournov
-  - qimingj
-  - rileyjbauer
-  - vicaire
-  - berndverst
-
+  - zijianjoy

--- a/config.toml
+++ b/config.toml
@@ -115,7 +115,7 @@ privacy_policy = "https://policies.google.com/privacy"
 gcs_engine_id = "007239566369470735695:624rglujm-w"
 
 # Text label for the version menu in the top bar of the website.
-version_menu = "v1.0"
+version_menu = "Archive: 1.0"
 
 # The major.minor version tag for the version of the docs represented in this
 # branch of the repository. Used in the "version-banner" partial to display a
@@ -128,7 +128,7 @@ archived_version = true
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.
-url_latest_version = "https://kubeflow.org/docs/"
+url_latest_version = "https://www.kubeflow.org/docs/"
 
 # A variable used in various docs to determine URLs for config files etc.
 # To find occurrences, search the repo for 'params "githubbranch"'.
@@ -137,39 +137,33 @@ githubbranch = "v1.0-branch"
 # Add new release versions here. These entries appear in the drop-down menu
 # at the top of the website.
 [[params.versions]]
-  version = "master"
+  version = "Latest"
   githubbranch = "master"
-  url = "https://master.kubeflow.org"
-
+  url = "https://www.kubeflow.org"
 [[params.versions]]
-  version = "v0.2"
-  githubbranch = "v0.2-branch"
-  url = "https://v0-2.kubeflow.org"
-
+  version = "Archive: 1.0"
+  githubbranch = "v1.0-branch"
+  url = "https://v1-0-branch.kubeflow.org"
 [[params.versions]]
-  version = "v0.3"
-  githubbranch = "v0.3-branch"
-  url = "https://v0-3.kubeflow.org"
-
-[[params.versions]]
-  version = "v0.4"
-  githubbranch = "v0.4-branch"
-  url = "https://v0-4.kubeflow.org"
-
-[[params.versions]]
-  version = "v0.5"
-  githubbranch = "v0.5-branch"
-  url = "https://v0-5.kubeflow.org"
-
-[[params.versions]]
-  version = "v0.6"
-  githubbranch = "v0.6-branch"
-  url = "https://v0-6.kubeflow.org"
-
-[[params.versions]]
-  version = "v0.7"
+  version = "Archive: 0.7"
   githubbranch = "v0.7-branch"
   url = "https://v0-7.kubeflow.org"
+[[params.versions]]
+  version = "Archive: 0.6"
+  githubbranch = "v0.6-branch"
+  url = "https://v0-6.kubeflow.org"
+[[params.versions]]
+  version = "Archive: 0.5"
+  githubbranch = "v0.5-branch"
+  url = "https://v0-5.kubeflow.org"
+[[params.versions]]
+  version = "Archive: 0.4"
+  githubbranch = "v0.4-branch"
+  url = "https://v0-4.kubeflow.org"
+[[params.versions]]
+  version = "Archive: 0.3"
+  githubbranch = "v0.3-branch"
+  url = "https://v0-3.kubeflow.org"
 
 # Docsy: User interface configuration
 [params.ui]

--- a/config.toml
+++ b/config.toml
@@ -124,7 +124,7 @@ version = "v1.0"
 
 # Flag used in the "version-banner" partial to decide whether to display a 
 # banner on every page indicating that this is an archived version of the docs.
-archived_version = false
+archived_version = true
 
 # A link to latest version of the docs. Used in the "version-banner" partial to
 # point people to the main doc site.

--- a/config.toml
+++ b/config.toml
@@ -115,7 +115,7 @@ privacy_policy = "https://policies.google.com/privacy"
 gcs_engine_id = "007239566369470735695:624rglujm-w"
 
 # Text label for the version menu in the top bar of the website.
-version_menu = "Archive: 1.0"
+version_menu = "v1.0"
 
 # The major.minor version tag for the version of the docs represented in this
 # branch of the repository. Used in the "version-banner" partial to display a
@@ -141,27 +141,27 @@ githubbranch = "v1.0-branch"
   githubbranch = "master"
   url = "https://www.kubeflow.org"
 [[params.versions]]
-  version = "Archive: 1.0"
+  version = "v1.0"
   githubbranch = "v1.0-branch"
   url = "https://v1-0-branch.kubeflow.org"
 [[params.versions]]
-  version = "Archive: 0.7"
+  version = "v0.7"
   githubbranch = "v0.7-branch"
   url = "https://v0-7.kubeflow.org"
 [[params.versions]]
-  version = "Archive: 0.6"
+  version = "v0.6"
   githubbranch = "v0.6-branch"
   url = "https://v0-6.kubeflow.org"
 [[params.versions]]
-  version = "Archive: 0.5"
+  version = "v0.5"
   githubbranch = "v0.5-branch"
   url = "https://v0-5.kubeflow.org"
 [[params.versions]]
-  version = "Archive: 0.4"
+  version = "v0.4"
   githubbranch = "v0.4-branch"
   url = "https://v0-4.kubeflow.org"
 [[params.versions]]
-  version = "Archive: 0.3"
+  version = "v0.3"
   githubbranch = "v0.3-branch"
   url = "https://v0-3.kubeflow.org"
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,11 +1,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}
-{{ if eq (getenv "HUGO_ENV") "production" }}
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
-{{ else }}
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-{{ end }}
+<!-- Prevent search engines from indexing this old site -->
+<meta name="robots" content="noindex">
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,33 @@
+<!-- Check the variable that indicates whether this is an archived doc set. If yes, display a banner. -->
+{{- $latest_version_url := .Site.Params.url_latest_version }}
+{{- $current_version := replace .Site.Params.version "v" "" | markdownify }}
+{{- if .Site.Params.archived_version }}
+  <style>
+    .version-banner {
+      padding: 1.5rem;
+      margin: 2rem 0;
+      max-width: 40rem;
+      border-style: solid;
+      border-color: #f0ad4e;
+      background-color: #faf5b6;
+      border-radius: 0.25rem;
+    }
+    .version-banner h3 {
+      margin-top: 0;
+      margin-bottom: 0.6em;
+      font-size: 1.25em;
+    }
+    .version-banner p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  </style>
+  <div class="version-banner">
+    <h3>You are viewing documentation for <strong>Kubeflow {{ $current_version }}</strong></h3>
+    <p>
+      This is a static snapshot from the time of the Kubeflow {{ $current_version }} release.
+      <br>
+      For up-to-date information, see the <a href="{{ $latest_version_url | safeURL }}">latest version</a>.
+    </p>
+  </div>
+{{- end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,10 +4,13 @@
 
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.68.3"
+  NODE_VERSION = "12"
 
 [context.production.environment]
   HUGO_VERSION = "0.68.3"
+  NODE_VERSION = "12"
   HUGO_ENV = "production"
 
 [context.branch-deploy.environment]
   HUGO_VERSION = "0.68.3"
+  NODE_VERSION = "12"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,14 +3,14 @@
   command = "hugo"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.68.3"
+  HUGO_VERSION = "0.81.0"
   NODE_VERSION = "12"
 
 [context.production.environment]
-  HUGO_VERSION = "0.68.3"
+  HUGO_VERSION = "0.81.0"
   NODE_VERSION = "12"
   HUGO_ENV = "production"
 
 [context.branch-deploy.environment]
-  HUGO_VERSION = "0.68.3"
+  HUGO_VERSION = "0.81.0"
   NODE_VERSION = "12"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "website",
+  "devDependencies": {
+    "autoprefixer": "^9.4.3",
+    "postcss": "^7.0.6",
+    "postcss-cli": "^6.1.0"
+  }
+}


### PR DESCRIPTION
Google keeps surfacing links from very old versions of the Kubeflow docs website, which is confusing to users.

This PR adds the [`<meta name="robots" content="noindex">` meta tag](https://developers.google.com/search/docs/crawling-indexing/block-indexing) to tell Google to stop indexing the pages from the `v1.0-branch` branch.

It will take probably a few months (or longer) for Google to re-index these pages, I have left `nofollow` off, so that google will re-index the whole site quicker by following links.

---

It also backports the changes from https://github.com/kubeflow/website/pull/3863 so the version selector is consistent across each archive version.

And updates the OWNERS file of this very old branch to align with [the current `OWNERS` in `master`](https://github.com/kubeflow/website/blob/89d8f792625e6c95fad4774570358ecd773830e7/OWNERS) to make it easier to approve PRs in the future without GitHub admin overrides.