### PR TITLE
Block web crawlers on `v1.9-branch`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -129,7 +129,7 @@ enable = true
   gcs_engine_id = "007239566369470735695:624rglujm-w"
 
   # Text label for the version menu in the top bar of the website.
-  version_menu = "Kubeflow Version"
+  version_menu = "Archive: 1.9"
 
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
@@ -142,7 +142,7 @@ enable = true
 
   # A link to latest version of the docs. Used in the "version-banner" partial to
   # point people to the main doc site.
-  url_latest_version = "https://kubeflow.org/docs/"
+  url_latest_version = "https://www.kubeflow.org/docs/"
 
   # A variable used in various docs to determine URLs for config files etc.
   # To find occurrences, search the repo for 'params "githubbranch"'.
@@ -154,67 +154,67 @@ enable = true
 
   # These entries appear in the drop-down menu at the top of the website.
   [[params.versions]]
-    version = "master"
+    version = "Latest"
     githubbranch = "master"
-    url = "https://master.kubeflow.org"
+    url = "https://www.kubeflow.org"
   [[params.versions]]
-    version = "v1.9"
+    version = "Archive: 1.9"
     githubbranch = "v1.9-branch"
     url = "https://v1-9-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.8"
+    version = "Archive: 1.8"
     githubbranch = "v1.8-branch"
     url = "https://v1-8-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.7"
+    version = "Archive: 1.7"
     githubbranch = "v1.7-branch"
     url = "https://v1-7-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.6"
+    version = "Archive: 1.6"
     githubbranch = "v1.6-branch"
     url = "https://v1-6-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.5"
+    version = "Archive: 1.5"
     githubbranch = "v1.5-branch"
     url = "https://v1-5-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.4"
+    version = "Archive: 1.4"
     githubbranch = "v1.4-branch"
     url = "https://v1-4-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.3"
+    version = "Archive: 1.3"
     githubbranch = "v1.3-branch"
     url = "https://v1-3-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.2"
+    version = "Archive: 1.2"
     githubbranch = "v1.2-branch"
     url = "https://v1-2-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.1"
+    version = "Archive: 1.1"
     githubbranch = "v1.1-branch"
     url = "https://v1-1-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.0"
+    version = "Archive: 1.0"
     githubbranch = "v1.0-branch"
     url = "https://v1-0-branch.kubeflow.org"
   [[params.versions]]
-    version = "v0.7"
+    version = "Archive: 0.7"
     githubbranch = "v0.7-branch"
     url = "https://v0-7.kubeflow.org"
   [[params.versions]]
-    version = "v0.6"
+    version = "Archive: 0.6"
     githubbranch = "v0.6-branch"
     url = "https://v0-6.kubeflow.org"
   [[params.versions]]
-    version = "v0.5"
+    version = "Archive: 0.5"
     githubbranch = "v0.5-branch"
     url = "https://v0-5.kubeflow.org"
   [[params.versions]]
-    version = "v0.4"
+    version = "Archive: 0.4"
     githubbranch = "v0.4-branch"
     url = "https://v0-4.kubeflow.org"
   [[params.versions]]
-    version = "v0.3"
+    version = "Archive: 0.3"
     githubbranch = "v0.3-branch"
     url = "https://v0-3.kubeflow.org"
 

--- a/config.toml
+++ b/config.toml
@@ -134,11 +134,11 @@ enable = true
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "master"
+  version = "v1.9"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.
-  archived_version = false
+  archived_version = true
 
   # A link to latest version of the docs. Used in the "version-banner" partial to
   # point people to the main doc site.
@@ -146,7 +146,7 @@ enable = true
 
   # A variable used in various docs to determine URLs for config files etc.
   # To find occurrences, search the repo for 'params "githubbranch"'.
-  github_branch = "master"
+  github_branch = "v1.9-branch"
 
   # Disable MathJax by default
   # NOTE: enable it per-page with `mathjax: true` in front matter
@@ -157,6 +157,10 @@ enable = true
     version = "master"
     githubbranch = "master"
     url = "https://master.kubeflow.org"
+  [[params.versions]]
+    version = "v1.9"
+    githubbranch = "v1.9-branch"
+    url = "https://v1-9-branch.kubeflow.org"
   [[params.versions]]
     version = "v1.8"
     githubbranch = "v1.8-branch"

--- a/config.toml
+++ b/config.toml
@@ -129,7 +129,7 @@ enable = true
   gcs_engine_id = "007239566369470735695:624rglujm-w"
 
   # Text label for the version menu in the top bar of the website.
-  version_menu = "Archive: 1.9"
+  version_menu = "v1.9"
 
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
@@ -158,63 +158,63 @@ enable = true
     githubbranch = "master"
     url = "https://www.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.9"
+    version = "v1.9"
     githubbranch = "v1.9-branch"
     url = "https://v1-9-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.8"
+    version = "v1.8"
     githubbranch = "v1.8-branch"
     url = "https://v1-8-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.7"
+    version = "v1.7"
     githubbranch = "v1.7-branch"
     url = "https://v1-7-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.6"
+    version = "v1.6"
     githubbranch = "v1.6-branch"
     url = "https://v1-6-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.5"
+    version = "v1.5"
     githubbranch = "v1.5-branch"
     url = "https://v1-5-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.4"
+    version = "v1.4"
     githubbranch = "v1.4-branch"
     url = "https://v1-4-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.3"
+    version = "v1.3"
     githubbranch = "v1.3-branch"
     url = "https://v1-3-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.2"
+    version = "v1.2"
     githubbranch = "v1.2-branch"
     url = "https://v1-2-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.1"
+    version = "v1.1"
     githubbranch = "v1.1-branch"
     url = "https://v1-1-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.0"
+    version = "v1.0"
     githubbranch = "v1.0-branch"
     url = "https://v1-0-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 0.7"
+    version = "v0.7"
     githubbranch = "v0.7-branch"
     url = "https://v0-7.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 0.6"
+    version = "v0.6"
     githubbranch = "v0.6-branch"
     url = "https://v0-6.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 0.5"
+    version = "v0.5"
     githubbranch = "v0.5-branch"
     url = "https://v0-5.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 0.4"
+    version = "v0.4"
     githubbranch = "v0.4-branch"
     url = "https://v0-4.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 0.3"
+    version = "v0.3"
     githubbranch = "v0.3-branch"
     url = "https://v0-3.kubeflow.org"
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,12 +5,8 @@
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
 
-{{ $outputFormat := partial "outputformat.html" . -}}
-{{ if and hugo.IsProduction (ne $outputFormat "print") -}}
-<meta name="robots" content="index, follow">
-{{ else -}}
-<meta name="robots" content="noindex, nofollow">
-{{ end -}}
+<!-- Prevent search engines from indexing this old site -->
+<meta name="robots" content="noindex">
 
 {{ partialCached "favicons.html" . }}
 <title>

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,33 @@
+<!-- Check the variable that indicates whether this is an archived doc set. If yes, display a banner. -->
+{{- $latest_version_url := .Site.Params.url_latest_version }}
+{{- $current_version := replace .Site.Params.version "v" "" | markdownify }}
+{{- if .Site.Params.archived_version }}
+  <style>
+    .version-banner {
+      padding: 1.5rem;
+      margin: 2rem 0;
+      max-width: 40rem;
+      border-style: solid;
+      border-color: #f0ad4e;
+      background-color: #faf5b6;
+      border-radius: 0.25rem;
+    }
+    .version-banner h3 {
+      margin-top: 0;
+      margin-bottom: 0.6em;
+      font-size: 1.25em;
+    }
+    .version-banner p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  </style>
+  <div class="version-banner">
+    <h3>You are viewing documentation for <strong>Kubeflow {{ $current_version }}</strong></h3>
+    <p>
+      This is a static snapshot from the time of the Kubeflow {{ $current_version }} release.
+      <br>
+      For up-to-date information, see the <a href="{{ $latest_version_url | safeURL }}">latest version</a>.
+    </p>
+  </div>
+{{- end }}


### PR DESCRIPTION
Google keeps surfacing links from very old versions of the Kubeflow docs website, which is confusing to users.

This PR adds the [`<meta name="robots" content="noindex">` meta tag](https://developers.google.com/search/docs/crawling-indexing/block-indexing) to tell Google to stop indexing the pages from the `v1.9-branch` branch.

It will take probably a few months (or longer) for Google to re-index these pages, I have left `nofollow` off, so that google will re-index the whole site quicker by following links.

---

It also backports the changes from https://github.com/kubeflow/website/pull/3863 so the version selector is consistent across each archive version.

----

__You might be wondering, why should we do this for the 1.9 branch, isn't that the latest version?__

1. There is still no reason for google to index these pages:
      - The latest content is on the main site.
      - Google will take a long time to remove things from the index if we add this metadata at a later date.
3. The `"The site that you are currently viewing is an archived snapshot"` header is applicable:
      - It's a snapshot from the time of the 1.9 release.
      - We don't typically make any further updates to the versioned branches. 
      - It's hard for users to realize they ended up on a snapshotted version of the docs without that warning header.