### PR TITLE
Improve version selector & rename "master" to "latest"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -133,26 +133,33 @@ enable = true
   # Google Custom Search Engine ID.
   gcs_engine_id = "007239566369470735695:624rglujm-w"
 
-  # Text label for the version menu in the top bar of the website, depends on the branch:
-  #  - master -> "Latest"
-  #  - v1.0-branch -> "v1.0"
-  version_menu = "Latest"
+  # The text label for the version menu in the top bar.
+  # The value depends on the branch:
+  #  - `master` -> "Versions"
+  #  - `v1.0-branch` -> "v1.0"
+  version_menu = "Versions"
 
-  # The major.minor version tag for the version of the docs represented in this
-  # branch of the repository. Used in the "version-banner" partial to display a
-  # version number for this doc set.
+  # The version of the docs. This is used in the "version-banner" partial.
+  # The value depends on the branch:
+  #  - `master` -> "REPLACE_WITH_VERSION_ON_ARCHIVE"
+  #  - `v1.0-branch` -> "v1.0"
   version = "REPLACE_WITH_VERSION_ON_ARCHIVE"
 
-  # Flag used in the "version-banner" partial to decide whether to display a
-  # banner on every page indicating that this is an archived version of the docs.
+  # If the "version-banner" partial should display at the top of each page.
+  # The value depends on the branch:
+  #  - `master` -> false
+  #  - `v*-branch` -> true
   archived_version = false
 
-  # A link to latest version of the docs. Used in the "version-banner" partial to
-  # point people to the main doc site.
+  # The URL of the latest version of the docs.
+  # Used in the "version-banner" partial.
   url_latest_version = "https://www.kubeflow.org/docs/"
 
-  # A variable used in various docs to determine URLs for config files etc.
-  # To find occurrences, search the repo for 'params "githubbranch"'.
+  # The GitHub branch for the current version of the docs.
+  # Used to generate the "Edit this page" link.
+  # The value depends on the branch:
+  #  - `master` -> "master"
+  #  - `v1.0-branch` -> "v1.0-branch"
   github_branch = "master"
 
   # Disable MathJax by default
@@ -214,14 +221,6 @@ enable = true
     version = "v1.0"
     githubbranch = "v1.0-branch"
     url = "https://v1-0-branch.kubeflow.org"
-  [[params.versions]]
-    version = "v0.7"
-    githubbranch = "v0.7-branch"
-    url = "https://v0-7.kubeflow.org"
-  [[params.versions]]
-    version = "v0.6"
-    githubbranch = "v0.6-branch"
-    url = "https://v0-6.kubeflow.org"
 
   # User interface configuration
   [params.ui]

--- a/config.toml
+++ b/config.toml
@@ -222,18 +222,6 @@ enable = true
     version = "Archive: 0.6"
     githubbranch = "v0.6-branch"
     url = "https://v0-6.kubeflow.org"
-  [[params.versions]]
-    version = "Archive: 0.5"
-    githubbranch = "v0.5-branch"
-    url = "https://v0-5.kubeflow.org"
-  [[params.versions]]
-    version = "Archive: 0.4"
-    githubbranch = "v0.4-branch"
-    url = "https://v0-4.kubeflow.org"
-  [[params.versions]]
-    version = "Archive: 0.3"
-    githubbranch = "v0.3-branch"
-    url = "https://v0-3.kubeflow.org"
 
   # User interface configuration
   [params.ui]

--- a/config.toml
+++ b/config.toml
@@ -133,13 +133,15 @@ enable = true
   # Google Custom Search Engine ID.
   gcs_engine_id = "007239566369470735695:624rglujm-w"
 
-  # Text label for the version menu in the top bar of the website.
-  version_menu = "Version"
+  # Text label for the version menu in the top bar of the website, depends on the branch:
+  #  - master -> "Latest"
+  #  - v1.0-branch -> "Archive: 1.0"
+  version_menu = "Latest"
 
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "master"
+  version = "REPLACE_WITH_VERSION_ON_ARCHIVE"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.
@@ -147,7 +149,7 @@ enable = true
 
   # A link to latest version of the docs. Used in the "version-banner" partial to
   # point people to the main doc site.
-  url_latest_version = "https://kubeflow.org/docs/"
+  url_latest_version = "https://www.kubeflow.org/docs/"
 
   # A variable used in various docs to determine URLs for config files etc.
   # To find occurrences, search the repo for 'params "githubbranch"'.
@@ -169,67 +171,67 @@ enable = true
 
   # These entries appear in the drop-down menu at the top of the website.
   [[params.versions]]
-    version = "master"
+    version = "Latest"
     githubbranch = "master"
-    url = "https://master.kubeflow.org"
+    url = "https://www.kubeflow.org"
   [[params.versions]]
-    version = "v1.9"
+    version = "Archive: 1.9"
     githubbranch = "v1.9-branch"
     url = "https://v1-9-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.8"
+    version = "Archive: 1.8"
     githubbranch = "v1.8-branch"
     url = "https://v1-8-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.7"
+    version = "Archive: 1.7"
     githubbranch = "v1.7-branch"
     url = "https://v1-7-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.6"
+    version = "Archive: 1.6"
     githubbranch = "v1.6-branch"
     url = "https://v1-6-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.5"
+    version = "Archive: 1.5"
     githubbranch = "v1.5-branch"
     url = "https://v1-5-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.4"
+    version = "Archive: 1.4"
     githubbranch = "v1.4-branch"
     url = "https://v1-4-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.3"
+    version = "Archive: 1.3"
     githubbranch = "v1.3-branch"
     url = "https://v1-3-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.2"
+    version = "Archive: 1.2"
     githubbranch = "v1.2-branch"
     url = "https://v1-2-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.1"
+    version = "Archive: 1.1"
     githubbranch = "v1.1-branch"
     url = "https://v1-1-branch.kubeflow.org"
   [[params.versions]]
-    version = "v1.0"
+    version = "Archive: 1.0"
     githubbranch = "v1.0-branch"
     url = "https://v1-0-branch.kubeflow.org"
   [[params.versions]]
-    version = "v0.7"
+    version = "Archive: 0.7"
     githubbranch = "v0.7-branch"
     url = "https://v0-7.kubeflow.org"
   [[params.versions]]
-    version = "v0.6"
+    version = "Archive: 0.6"
     githubbranch = "v0.6-branch"
     url = "https://v0-6.kubeflow.org"
   [[params.versions]]
-    version = "v0.5"
+    version = "Archive: 0.5"
     githubbranch = "v0.5-branch"
     url = "https://v0-5.kubeflow.org"
   [[params.versions]]
-    version = "v0.4"
+    version = "Archive: 0.4"
     githubbranch = "v0.4-branch"
     url = "https://v0-4.kubeflow.org"
   [[params.versions]]
-    version = "v0.3"
+    version = "Archive: 0.3"
     githubbranch = "v0.3-branch"
     url = "https://v0-3.kubeflow.org"
 

--- a/config.toml
+++ b/config.toml
@@ -135,7 +135,7 @@ enable = true
 
   # Text label for the version menu in the top bar of the website, depends on the branch:
   #  - master -> "Latest"
-  #  - v1.0-branch -> "Archive: 1.0"
+  #  - v1.0-branch -> "v1.0"
   version_menu = "Latest"
 
   # The major.minor version tag for the version of the docs represented in this
@@ -175,51 +175,51 @@ enable = true
     githubbranch = "master"
     url = "https://www.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.9"
+    version = "v1.9"
     githubbranch = "v1.9-branch"
     url = "https://v1-9-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.8"
+    version = "v1.8"
     githubbranch = "v1.8-branch"
     url = "https://v1-8-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.7"
+    version = "v1.7"
     githubbranch = "v1.7-branch"
     url = "https://v1-7-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.6"
+    version = "v1.6"
     githubbranch = "v1.6-branch"
     url = "https://v1-6-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.5"
+    version = "v1.5"
     githubbranch = "v1.5-branch"
     url = "https://v1-5-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.4"
+    version = "v1.4"
     githubbranch = "v1.4-branch"
     url = "https://v1-4-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.3"
+    version = "v1.3"
     githubbranch = "v1.3-branch"
     url = "https://v1-3-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.2"
+    version = "v1.2"
     githubbranch = "v1.2-branch"
     url = "https://v1-2-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.1"
+    version = "v1.1"
     githubbranch = "v1.1-branch"
     url = "https://v1-1-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 1.0"
+    version = "v1.0"
     githubbranch = "v1.0-branch"
     url = "https://v1-0-branch.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 0.7"
+    version = "v0.7"
     githubbranch = "v0.7-branch"
     url = "https://v0-7.kubeflow.org"
   [[params.versions]]
-    version = "Archive: 0.6"
+    version = "v0.6"
     githubbranch = "v0.6-branch"
     url = "https://v0-6.kubeflow.org"
 

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,33 @@
+<!-- Check the variable that indicates whether this is an archived doc set. If yes, display a banner. -->
+{{- $latest_version_url := .Site.Params.url_latest_version }}
+{{- $current_version := replace .Site.Params.version "v" "" | markdownify }}
+{{- if .Site.Params.archived_version }}
+  <style>
+    .version-banner {
+      padding: 1.5rem;
+      margin: 2rem 0;
+      max-width: 40rem;
+      border-style: solid;
+      border-color: #f0ad4e;
+      background-color: #faf5b6;
+      border-radius: 0.25rem;
+    }
+    .version-banner h3 {
+      margin-top: 0;
+      margin-bottom: 0.6em;
+      font-size: 1.25em;
+    }
+    .version-banner p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  </style>
+  <div class="version-banner">
+    <h3>You are viewing documentation for <strong>Kubeflow {{ $current_version }}</strong></h3>
+    <p>
+      This is a static snapshot from the time of the Kubeflow {{ $current_version }} release.
+      <br>
+      For up-to-date information, see the <a href="{{ $latest_version_url | safeURL }}">latest version</a>.
+    </p>
+  </div>
+{{- end }}


### PR DESCRIPTION
In the top right of the website, we have a "version selector" that lets you view archived versions of the docs from past releases, however, the current presentation is confusing to users.

New users expect that they should browse the site on the 1.9 branch for information about 1.9 (when in reality they should browse the master branch because we are always updating it).

In reality, we treat these historical snapshot versions as "snapshot archives" and don't go back to update them with content from master.

__This PR makes the following changes to the version menu:__

- Renamed the button which you click to expand the menu:
    - For example, in this PR its `"Latest"`, but in the `v1.0-branch` snapshot it would be `"Archive: 1.0"`
- prepended `Archive: ` to each version label
- removes versions older than 0.6 from the dropdown

# Screenshots

## OLD

![Screenshot 2024-09-04 at 17 58 06](https://github.com/user-attachments/assets/ec665e90-e505-44b1-837d-8992dd384e2a)

## NEW

<img width="189" alt="Screenshot 2024-10-15 at 09 00 03" src="https://github.com/user-attachments/assets/e25de653-49f6-4c8c-8c91-96d7e6add81d">

