### PR TITLE
Update `v0.2-branch` Hugo (fix deploy)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,9 @@
   command = "hugo"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.40"
-  NODE_VERSION = "8"
+  HUGO_VERSION = "0.81.0"
+  NODE_VERSION = "10"
 
 [context.production.environment]
-  HUGO_VERSION = "0.40"
-  NODE_VERSION = "8"
+  HUGO_VERSION = "0.81.0"
+  NODE_VERSION = "10"


### PR DESCRIPTION
The updates from https://github.com/kubeflow/website/pull/3848 being merged don't seem to have succeeded to deploy, see the build logs: 

- https://app.netlify.com/sites/competent-brattain-de2d6d/deploys/66d9af5ed1fb2d0008676d2b

I am pretty sure it's because that extremely old version of Hugo (from before semantic versioning) can't be installed, so I am updating it to version `0.81.0`, the same as the one used on the `v0.4-branch` which should fix it.