### PR TITLE
Update `v0.3-branch` Hugo (fix deploy)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,9 @@
   command = "hugo"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.40"
-  NODE_VERSION = "8"
+  HUGO_VERSION = "0.81.0"
+  NODE_VERSION = "10"
 
 [context.production.environment]
-  HUGO_VERSION = "0.40"
-  NODE_VERSION = "8"
+  HUGO_VERSION = "0.81.0"
+  NODE_VERSION = "10"


### PR DESCRIPTION
This is a follow up to https://github.com/kubeflow/website/pull/3847, and is similar to https://github.com/kubeflow/website/pull/3864, except for the `v0.3-branch`.

Unlike the `v0.2-branch` the `v0.3-branch` did sucessfully deploy, but I think it was a fluke, and also needs to have Hugo updated to ensure it works successfully in the future, see the build logs:

- https://app.netlify.com/sites/competent-brattain-de2d6d/deploys/66d9af5ef5f8e600085b1753

This PR updates Hugo/NodeJS to a version that Netlify can actually install.