### PR TITLE
Improve `archived_version` banner for `v0.3-branch`

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,27 +1,7 @@
 approvers:
-  - abhi-g
-  - aronchick
-  - ewilderj
-  - jlewi
-  - kunmingg
-  - lluunn
-  - nickchase
-  - pdmack
-  - richardsliu
-  - sarahmaddox
-  - texasmichelle
-  - willingc
-reviewers:
-  - abhi-g
-  - aronchick
-  - ewilderj
-  - inc0
-  - jlewi
-  - kunmingg
-  - lluunn
-  - nickchase
-  - pdmack
-  - richardsliu
-  - sarahmaddox
-  - texasmichelle
-  - willingc
+  - andreyvelich
+  - james-jwu
+  - jbottum
+  - johnugeorge
+  - terrytangyuan
+  - zijianjoy

--- a/themes/kf/layouts/partials/version-banner.html
+++ b/themes/kf/layouts/partials/version-banner.html
@@ -1,22 +1,33 @@
-<!-- Check the variable that indicates whether this is an archived doc set.
-  If yes, display a banner. -->
-{{ if .Site.Params.archived_version }}
-  {{ $latest := .Site.Params.url_latest_version }}
-  <div style="font-weight: $font-weight-medium;
-              background: $gray-100;
-              color: inherit;
-              border-radius: 0;
-              margin: 2rem;
-              padding: 1.5rem;
-              padding-bottom: 0.5rem;
-              border-style: solid;
-              border-width: medium;
-              border-color: #000000;">
-    {{ with .Site.Params.version }}<p>Version {{ . | markdownify }} of the
-      documentation is no longer actively maintained. The site that you are
-      currently viewing is an archived snapshot. For up-to-date documentation,
-      see the 
-      <a href="{{ $latest | safeURL }}" target="_blank">latest version</a>.</p>
-    {{ end }}
+<!-- Check the variable that indicates whether this is an archived doc set. If yes, display a banner. -->
+{{- $latest_version_url := .Site.Params.url_latest_version }}
+{{- $current_version := replace .Site.Params.version "v" "" | markdownify }}
+{{- if .Site.Params.archived_version }}
+  <style>
+    .version-banner {
+      padding: 1.5rem;
+      margin: 2rem 0;
+      max-width: 40rem;
+      border-style: solid;
+      border-color: #f0ad4e;
+      background-color: #faf5b6;
+      border-radius: 0.25rem;
+    }
+    .version-banner h3 {
+      margin-top: 0;
+      margin-bottom: 0.6em;
+      font-size: 1.25em;
+    }
+    .version-banner p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  </style>
+  <div class="version-banner">
+    <h3>You are viewing documentation for <strong>Kubeflow {{ $current_version }}</strong></h3>
+    <p>
+      This is a static snapshot from the time of the Kubeflow {{ $current_version }} release.
+      <br>
+      For up-to-date information, see the <a href="{{ $latest_version_url | safeURL }}">latest version</a>.
+    </p>
   </div>
-{{ end }}
+{{- end }}


### PR DESCRIPTION
This is a follow up to https://github.com/kubeflow/website/pull/3847

This PR makes the following changes:

1. Uses the same "archived_version" banner styling as the newer branches
1. Updates the OWNERS file of this very old branch to align with [the current `OWNERS` in `master`](https://github.com/kubeflow/website/blob/89d8f792625e6c95fad4774570358ecd773830e7/OWNERS) to make it easier to approve PRs in the future without GitHub admin overrides.