### PR TITLE
[Pipelines] Specify KFP SDK version where new caching flag will be available

### DIFF
--- a/content/en/docs/components/pipelines/user-guides/core-functions/caching.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/caching.md
@@ -54,7 +54,7 @@ from kfp.client import Client
 client = Client()
 client.create_run_from_pipeline_func(
     hello_pipeline,
-    enable_caching=True,  # overrides the above disableing of caching
+    enable_caching=True,  # overrides the above disabling of caching
 )
 ```
 

--- a/content/en/docs/components/pipelines/user-guides/core-functions/caching.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/caching.md
@@ -58,6 +58,10 @@ client.create_run_from_pipeline_func(
 )
 ```
 
+## Upcoming caching enhancement
+
+Once it is released, KFP SDK v2.10.0 will provide the following caching enhancement:
+
 The `--disable-execution-caching-by-default` flag disables caching for all pipeline tasks by default.
 
 Example:


### PR DESCRIPTION
As the changes introduced in https://github.com/kubeflow/pipelines/pull/11222 are in master but not in KFP 2.9.0 SDK, modify the _Use Caching_ page to specify when then new caching flag will be available