### PR TITLE
Training: Update example to run PyTorchJob with torchrun

### DIFF
--- a/content/en/docs/components/katib/installation.md
+++ b/content/en/docs/components/katib/installation.md
@@ -26,10 +26,10 @@ using manifests or package distributions. Kubeflow platform includes Katib.
 
 You can install Katib as a standalone component.
 
-Run the following command to install the stable release of Katib control plane: `v0.16.0`
+Run the following command to install the stable release of Katib control plane: `v0.17.0`
 
 ```shell
-kubectl apply -k "github.com/kubeflow/katib.git/manifests/v1beta1/installs/katib-standalone?ref=v0.16.0"
+kubectl apply -k "github.com/kubeflow/katib.git/manifests/v1beta1/installs/katib-standalone?ref=v0.17.0"
 ```
 
 Run the following command to install the latest changes of Katib control plane:

--- a/content/en/docs/components/training/installation.md
+++ b/content/en/docs/components/training/installation.md
@@ -28,10 +28,10 @@ using manifests or package distributions. The Kubeflow platform includes the Tra
 
 You can install the Training Operator as a standalone component.
 
-Run the following command to install the stable release of the Training Operator control plane: `v1.7.0`
+Run the following command to install the stable release of the Training Operator control plane: `v1.8.1`
 
 ```shell
-kubectl apply -k "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=v1.7.0"
+kubectl apply -k "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=v1.8.1"
 ```
 
 Run the following command to install the latest changes of Training Operator control plane:


### PR DESCRIPTION
I updated PyTorchJob getting started example to make it run with `torchrun.

/assign @kubeflow/wg-training-leads @kuizhiqing 
/hold until this merged https://github.com/kubeflow/training-operator/pull/2276