### PR TITLE
fix link in section Efficient Neural Architecture Search (ENAS)

### DIFF
--- a/content/en/docs/components/katib/reference/nas-algorithms.md
+++ b/content/en/docs/components/katib/reference/nas-algorithms.md
@@ -11,7 +11,7 @@ This page describes how Neural Architecture Search (NAS) algorithms work in Kati
 The algorithm follows the idea proposed in _Efficient Neural Architecture Search via Parameter Sharing_
 by Hieu Pham, Melody Y. Guan, Barret Zoph, Quoc V. Le and Jeff Dean (https://arxiv.org/abs/1802.03268)
 and _Neural Architecture Search with Reinforcement Learning_ by Barret Zoph and
-Quoc V. Le (https://arxiv.org/abs/1611.01578).
+Quoc V. Le (https://arxiv.org/abs/1611.01578) .
 
 The implementation is based on
 [the GitHub of _Efﬁcient Neural Architecture Search via Parameter Sharing_](https://github.com/melodyguan/enas)


### PR DESCRIPTION
fix link in section Efficient Neural Architecture Search (ENAS) - related to #3811 . Discussed with @hbelmiro 
To resolve this problem:
<img width="783" alt="image" src="https://github.com/user-attachments/assets/65d8aef8-fa79-4c87-8962-5c7c544b8a0e">
