### PR TITLE
add Model Registry line in KF 1.9 release

### DIFF
--- a/content/en/docs/releases/kubeflow-1.9.md
+++ b/content/en/docs/releases/kubeflow-1.9.md
@@ -85,6 +85,16 @@ weight = 95
         </td>
       </tr>
       <!-- ======================= -->
+      <!-- Data Working Group -->
+      <!-- ======================= -->
+      <tr>
+        <td rowspan="1" class="align-middle">Data Working Group</td>
+        <td>Model Registry</td>
+        <td>
+          <a href="https://github.com/kubeflow/model-registry/releases/tag/v0.2.1-alpha">v0.2.1</a>
+        </td>
+      </tr>
+      <!-- ======================= -->
       <!-- Notebooks Working Group -->
       <!-- ======================= -->
       <tr>


### PR DESCRIPTION
similarly to Katib (which for KF 1.9 is v0.17.0)
in this website table doesn't list the "version policy" for alpha/beta/stable, but list only the designated version, which in the case of KF Model Registry is v0.2.1.

For completeness, at the time of writing, the
"KF vesioning policy" in the case of Model Registry is Alpha, as reported in:
- as highlighted in the website, https://www.kubeflow.org/docs/components/model-registry/overview/#:~:text=Alpha,of%20the%20feature. 
- and on the Model Registry Python client readme, https://github.com/kubeflow/model-registry/blob/7990b69b9c545cc97f1aa5281ceeabd501be35c7/clients/python/README.md?plain=1#L10-L14

---

Add a secion for the "Data Working Group" / "Model Registry"

Since at the time of writing all sections in the currently existing table are alphabetically sorted, this section is introduced between "AutoML" and "Notebook".

If we intend this table differently, happy to move it as the last section.

--- 

@rimolive , @andreyvelich , wdyt? Happy to hear feedback and adapt (or close) as needed!