### PR TITLE
Update training operator installation to use SSA

### DIFF
--- a/content/en/docs/components/training/installation.md
+++ b/content/en/docs/components/training/installation.md
@@ -31,13 +31,13 @@ You can install the Training Operator as a standalone component.
 Run the following command to install the stable release of the Training Operator control plane: `v1.8.1`
 
 ```shell
-kubectl apply -k "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=v1.8.1"
+kubectl apply --server-side -k "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=v1.8.1"
 ```
 
 Run the following command to install the latest changes of Training Operator control plane:
 
 ```shell
-kubectl apply -k "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=master"
+kubectl apply --server-side -k "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=master"
 ```
 
 After installing it, you can verify that Training Operator controller is running as follows:


### PR DESCRIPTION
Latest version of the training operator will require to use server side apply to install its CRDs, as their sizes have increased beyond what client-side apply can handled.

See https://github.com/kubeflow/training-operator/pull/2332#discussion_r1860620021 for more details.

/cc @tenzen-y @andreyvelich 