### PR TITLE
Fix outdated 'url' key to 'link' in ConfigMap example

### DIFF
--- a/content/en/docs/components/central-dash/customize.md
+++ b/content/en/docs/components/central-dash/customize.md
@@ -35,7 +35,7 @@ Each element of `externalLinks` is a JSON object with the following fields:
 - `type`: must be set to `"item"`
 - `iframe`: must be set to `false`
 - `text`: the text to display for the link
-- `url`: the URL to open when the link is clicked
+- `link`: the URL to open when the link is clicked
 - `icon`: an [iron-icon](https://www.webcomponents.org/element/@polymer/iron-icons/demo/demo/index.html) name to display for the link.
     - Note, you must exclude the `icons:` prefix
     - For example, to use `icons:launch` you would set `"launch"`
@@ -62,7 +62,7 @@ data:
           "type": "item",
           "iframe": false,
           "text": "Kubeflow Website",
-          "url": "https://www.kubeflow.org/",
+          "link": "https://www.kubeflow.org/",
           "icon": "launch"
         }
       ],


### PR DESCRIPTION
### Summary
Fixed outdated key in the `externalLinks` section of the ConfigMap example. 
Fixes #3803 

### Changes
- Replaced `url` with `link` in the `externalLinks` section of the ConfigMap example.
- The change applies to two instances of the `url` key.

### Example
#### Before
```
"externalLinks": [
        {
          "type": "item",
          "iframe": false,
          "text": "Kubeflow Website",
          "url": "https://www.kubeflow.org/",
          "icon": "launch"
        }
```

#### After
```
"externalLinks": [
        {
          "type": "item",
          "iframe": false,
          "text": "Kubeflow Website",
          "link": "https://www.kubeflow.org/",
          "icon": "launch"
        }
```