### PR TITLE
Restructure events section, and add GSoC 2025 page

### DIFF
--- a/assets/icons/gsoc.svg
+++ b/assets/icons/gsoc.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" version="1.1" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+ <g id="Logo" transform="matrix(20.358 0 0 20.358 -36.441 -7.1252)">
+  <path class="starOuter" d="m10.68 21.82 3.68 3.68 3.69-3.68h5.2v-5.21l3.69-3.68-3.69-3.69v-5.24h-5.25l-3.64-3.65-2.89 2.89-0.79 0.76h-5.21v5.24l-3.68 3.69 3.68 3.68v5.21z" fill="#f9ab00"/>
+  <path class="starCenter" d="m21.63 12.93a7.27 7.27 0 1 1-7.27-7.27 7.26 7.26 0 0 1 7.27 7.25z" fill="#e37400"/>
+  <path class="starGlyphs" transform="rotate(-74.901,14.413,12.739)" d="m10.974 12.229h6.88v1.02h-6.88z" fill="#fff"/>
+  <path class="starGlyphs" d="m11.85 10.39 0.76 0.68-1.5 1.68 1.5 1.67-0.76 0.68-2.11-2.36zm5.03-0.01 2.12 2.35-2.11 2.35-0.76-0.68 1.5-1.67-1.5-1.67z" fill="#fff"/>
+ </g>
+</svg>

--- a/config.toml
+++ b/config.toml
@@ -34,6 +34,12 @@ ignoreFiles = []
     post = "<br><span class='badge badge-warning'>April 1st, 2025</span> <span class='badge badge-warning'>London, England</span> "
     url = "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/kubeflow-summit/"
   [[menu.main]]
+    name = "GSoC 2025"
+    weight = -900
+    pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' style='height: 1.22em;'></i>"
+      post = "<br><span class='badge badge-info'>Coming Soon</span>"
+    url = "/events/gsoc-2025/"
+  [[menu.main]]
     name = "Docs"
     weight = -102
     pre = "<i class='fas fa-book pr-2'></i>"

--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -78,7 +78,7 @@ The following list shows available Kubeflow community meetings with the correspo
 | Kubeflow Spark Operator call    | [Google Doc](https://bit.ly/3VGzP4n)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xXuM6gALgBG8vDZHFCNxce) |
 | KServe call                     | [Google Doc](https://bit.ly/3NlKFb3)                 |                                                                                              |
 
-### Kubeflow Community Calendar |
+### Kubeflow Community Calendar
 
 This is an aggregated view of the Kubeflow community calendar and should be displayed in your
 device's timezone.

--- a/content/en/docs/images/logos/gsoc.svg
+++ b/content/en/docs/images/logos/gsoc.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" version="1.1" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+ <g id="Logo" transform="matrix(20.358 0 0 20.358 -36.441 -7.1252)">
+  <path class="starOuter" d="m10.68 21.82 3.68 3.68 3.69-3.68h5.2v-5.21l3.69-3.68-3.69-3.69v-5.24h-5.25l-3.64-3.65-2.89 2.89-0.79 0.76h-5.21v5.24l-3.68 3.69 3.68 3.68v5.21z" fill="#f9ab00"/>
+  <path class="starCenter" d="m21.63 12.93a7.27 7.27 0 1 1-7.27-7.27 7.26 7.26 0 0 1 7.27 7.25z" fill="#e37400"/>
+  <path class="starGlyphs" transform="rotate(-74.901,14.413,12.739)" d="m10.974 12.229h6.88v1.02h-6.88z" fill="#fff"/>
+  <path class="starGlyphs" d="m11.85 10.39 0.76 0.68-1.5 1.68 1.5 1.67-0.76 0.68-2.11-2.36zm5.03-0.01 2.12 2.35-2.11 2.35-0.76-0.68 1.5-1.67-1.5-1.67z" fill="#fff"/>
+ </g>
+</svg>

--- a/content/en/events/docs.md
+++ b/content/en/events/docs.md
@@ -1,7 +1,0 @@
-+++
-title = "Documentation"
-description = "Return to Kubeflow documentation"
-weight = 1
-manualLink = "/docs/about/"
-icon = "fa-solid fa-arrow-up-right-from-square"
-+++

--- a/content/en/events/past-events/2023/_index.md
+++ b/content/en/events/past-events/2023/_index.md
@@ -1,0 +1,4 @@
++++
+title = "2023"
+description = "Events from 2023"
++++

--- a/content/en/events/past-events/2023/kubeflow-summit-2023.md
+++ b/content/en/events/past-events/2023/kubeflow-summit-2023.md
@@ -1,6 +1,13 @@
 +++
 title = "Kubeflow Summit 2023"
 description = "October 6th, 2023 - Irving, TX, USA - Virtual Attendance Available"
+icon = "fa-solid fa-calendar-day"
+
+#
+# NOTE: to avoid 404 when we move events to the "/past-events/", 
+#       we explicitly set the URL here so it doesn't change
+#
+url = "/events/kubeflow-summit-2023/"
 +++
 
 ---

--- a/content/en/events/past-events/2023/watch--kubeflow-summit-2023.md
+++ b/content/en/events/past-events/2023/watch--kubeflow-summit-2023.md
@@ -1,0 +1,6 @@
++++
+title = "Watch: Kubeflow Summit 2023"
+
+manualLink = "https://www.youtube.com/playlist?list=PL2gwy7BdKoGdrkYIWGeAdKi9ntfxq8FYt"
+icon = "fa-brands fa-youtube"
++++

--- a/content/en/events/past-events/2024/_index.md
+++ b/content/en/events/past-events/2024/_index.md
@@ -1,0 +1,4 @@
++++
+title = "2024"
+description = "Events from 2024"
++++

--- a/content/en/events/past-events/2024/gsoc-2024.md
+++ b/content/en/events/past-events/2024/gsoc-2024.md
@@ -1,6 +1,13 @@
 +++
 title = "Google Summer of Code 2024"
 description = "Google Summer of Code 2024"
+icon = "fa-solid fa-calendar-day"
+
+#
+# NOTE: to avoid 404 when we move events to the "/past-events/", 
+#       we explicitly set the URL here so it doesn't change
+#
+url = "/events/gsoc-2024/"
 +++
 
 ---

--- a/content/en/events/past-events/2024/watch--kubeflow-summit-2024.md
+++ b/content/en/events/past-events/2024/watch--kubeflow-summit-2024.md
@@ -1,0 +1,6 @@
++++
+title = "Watch: Kubeflow Summit 2024"
+
+manualLink = "https://www.youtube.com/playlist?list=PLj6h78yzYM2Nk-8Zyjaefz9yFJ-NxC-qn"
+icon = "fa-brands fa-youtube"
++++

--- a/content/en/events/past-events/2024/watch--kubernetes-ai-day-2024.md
+++ b/content/en/events/past-events/2024/watch--kubernetes-ai-day-2024.md
@@ -1,0 +1,6 @@
++++
+title = "Watch: Cloud Native & Kubernetes AI Day 2024"
+
+manualLink = "https://www.youtube.com/playlist?list=PLj6h78yzYM2Mvqk_mNejD7kbe3tldxxsr"
+icon = "fa-brands fa-youtube"
++++

--- a/content/en/events/past-events/_index.md
+++ b/content/en/events/past-events/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Past Events"
+description = "Past Kubeflow events"
+weight = 200
++++

--- a/content/en/events/upcoming-events/_index.md
+++ b/content/en/events/upcoming-events/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Future Events"
+description = "Future Kubeflow events"
+weight = 100
++++

--- a/content/en/events/upcoming-events/gsoc-2025.md
+++ b/content/en/events/upcoming-events/gsoc-2025.md
@@ -1,0 +1,73 @@
++++
+title = "Google Summer of Code 2025"
+description = "Google Summer of Code 2025"
+icon = "fa-regular fa-calendar-day"
+
+#
+# NOTE: to avoid 404 when we move events to the "/past-events/", 
+#       we explicitly set the URL here so it doesn't change
+#
+url = "/events/gsoc-2025/"
++++
+
+---
+
+The Kubeflow Community plans to participate in [**Google Summer of Code 2025**](https://summerofcode.withgoogle.com/). 
+This page aims to help you participate in GSoC 2025 with Kubeflow.
+
+## What is GSoC?
+
+Google Summer of Code (GSoC) is a global program that offers students [stipends](https://developers.google.com/open-source/gsoc/help/student-stipends) for working on open-source projects during the summer.
+
+For more information, see the [GSoC FAQ](https://developers.google.com/open-source/gsoc/faq) and watch the video below:
+
+<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;"><iframe src="https://www.youtube.com/embed/93oj6b7d3VI?rel=0" style="top: 0; left: 0; width: 100%; height: 100%; position: absolute; border: 0;" allowfullscreen scrolling="no" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share;"></iframe></div>
+
+## How can I participate?
+
+Thank you for your interest in participating in GSoC with Kubeflow!
+
+Please carefully read the following information to learn how to participate in GSoC with Kubeflow.
+
+### Key Dates
+
+Here are the key dates for GSoC 2025, the [full timeline](https://developers.google.com/open-source/gsoc/timeline) is available on the GSoC website:
+
+| Event                            | Date                 |
+|----------------------------------|----------------------|
+| __Applications Open__            | March 24 @ 18:00 UTC |
+| __Applications Deadline__        | April 8 @ 18:00 UTC  |
+| __Accepted Proposals Announced__ | May 8                |
+| __Community Bonding__            | May 8 - June 1       |
+| __Coding Begins__                | June 2               |
+| __Midterm Evaluations__          | July 14 - 18         |
+| __Coding Ends__                  | September 1          |
+| __Final Evaluations__            | September 1 - 8      |
+
+### Eligibility
+
+To participate in GSoC with Kubeflow, you __must__ meet the GSoC [eligibility requirements](https://developers.google.com/open-source/gsoc/faq#what_are_the_eligibility_requirements_for_participation):
+
+- Be at least 18 years old at time of registration.
+- Be a student or an [open source beginner](https://developers.google.com/open-source/gsoc/faq#how_do_i_know_if_i_am_considered_a_beginner_in_open_source_development).
+- Be eligible to work in their country of residence during duration of program.
+- Be a resident of a country not currently embargoed by the United States.
+
+### Steps
+
+1. Sign up as a student on the [GSoC website](https://summerofcode.withgoogle.com/).
+2. Join the [Kubeflow Slack](/docs/about/community/#kubeflow-slack-channels):
+    - ___NOTE:__ please __do not__ reach out privately to mentors, instead, start a thread in the [`#kubeflow-gsoc-participants`](https://cloud-native.slack.com/archives/C0742LBR5BM) channel so others can see the response._
+3. Learn about Kubeflow:
+    - Read the [Introduction to Kubeflow](/docs/started/introduction/)
+    - Review the [Architecture Overview](/docs/started/architecture/)
+    - Consider [trying out Kubeflow](/docs/started/installing-kubeflow/) (not required, can be challenging)
+4. Review the [project ideas](#project-ideas-for-2025-gsoc) to decide which ones you are interested in:
+    - You may wish to attend the next [community meeting](/docs/about/community/#kubeflow-community-calendar) for the group that is leading your chosen project.
+    - ___NOTE:__ while we recommend you submit a proposal based on the project ideas, you can also submit a proposal with your own idea._
+5. Submit a proposal through the [GSoC website](https://summerofcode.withgoogle.com/) between __March 24th__ and __April 8th__.
+6. Wait for the results to be announced on __May 8th__.
+
+## Project Ideas for 2025 GSoC
+
+Coming soon!

--- a/content/en/events/upcoming-events/kubeflow-summit-2025.md
+++ b/content/en/events/upcoming-events/kubeflow-summit-2025.md
@@ -1,0 +1,6 @@
++++
+title = "Kubeflow Summit 2025"
+
+manualLink = "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/kubeflow-summit/"
+icon = "fa-solid fa-arrow-up-right-from-square"
++++


### PR DESCRIPTION
closes https://github.com/kubeflow/website/issues/3614

This PR updates the events section of the website in the following ways:

1. Adds youtube links to recordings of past summits
2. adds a new GSoC 2025 page, to reduce the number of people contacting potential mentors
3. splits the events page into "future events" and "past events"

It also adds a GSoC banner to the top of all pages, similar to our existing summit banner.