### PR TITLE
fix: inconsistent deploy documentation pns references

### DIFF
--- a/content/en/docs/components/pipelines/legacy-v1/installation/localcluster-deployment.md
+++ b/content/en/docs/components/pipelines/legacy-v1/installation/localcluster-deployment.md
@@ -348,11 +348,6 @@ To further debug and diagnose cluster problems, use `kubectl cluster-info dump`.
 The installation process for Kubeflow Pipelines is the same for all three
 environments covered in this guide: kind, K3s, Docker-desktop, and K3ai.
 
-**Note**: Process Namespace Sharing (PNS) is not mature in Argo yet - for more
-information go to [Argo
-Executors](https://argoproj.github.io/argo-workflows/workflow-executors/) and reference
-"pns executors" in any issue you may come across when using PNS.
-
 1. To deploy the Kubeflow Pipelines, run the following commands:
 
     ```shell
@@ -399,7 +394,7 @@ Below are the steps to remove Kubeflow Pipelines on kind, K3s, or K3ai:
 
   ```shell
   export PIPELINE_VERSION={{% pipelines/latest-version %}}
-  kubectl delete -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=$PIPELINE_VERSION"
+  kubectl delete -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic?ref=$PIPELINE_VERSION"
   kubectl delete -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
   ```
 
@@ -407,6 +402,6 @@ Below are the steps to remove Kubeflow Pipelines on kind, K3s, or K3ai:
   file system, run the following commands:
 
   ```shell
-  kubectl delete -k manifests/kustomize/env/platform-agnostic-pns
+  kubectl delete -k manifests/kustomize/env/platform-agnostic
   kubectl delete -k manifests/kustomize/cluster-scoped-resources
   ```


### PR DESCRIPTION
[Documentation](https://www.kubeflow.org/docs/components/pipelines/legacy-v1/installation/localcluster-deployment/#deploying-kubeflow-pipelines) for deploying KFP standalone locally has the following two inconsistencies around pns.
1. The install step installs the `platform-agnostic` manifest, which is based on the emissary executor.
```kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic?ref=$PIPELINE_VERSION"```
However, the uninstall step uninstalls the `platform-agnostic-pns` executor.
```kubectl delete -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-pns?ref=$PIPELINE_VERSION"```

(**Why are we uninstalling a different version from what was installed???**)

2. There is a note that "Process Namespace Sharing (PNS) is not mature in Argo yet", which is outdated, as pns is actually deprecated in Argo.

I'm sure both of these are left over from when pns was a thing. This needs to be fixed for 2 reasons:
1. Having the `apply` step use `platform-agnostic`, and the `delete` step use `platform-agnostic-pns` is confusing at best, and may also lead to some resources not being cleaned up.
2. Argo Workflows has deprecated pns ([see here](https://argo-workflows.readthedocs.io/en/release-3.5/workflow-executors/#process-namespace-sharing-pns)), and it is removed altogether in 3.4. It probably doesn't need to be mentioned anymore on the current install page.