### PR TITLE
use local image for e2e tests

### DIFF
--- a/content/en/docs/components/spark-operator/developer-guide.md
+++ b/content/en/docs/components/spark-operator/developer-guide.md
@@ -180,7 +180,7 @@ make kind-create-cluster
 make docker-build IMAGE_TAG=local
 
 # Load docker image to kind cluster
-make kind-load-image
+make kind-load-image IMAGE_TAG=local
 
 # Run e2e tests
 make e2e-test


### PR DESCRIPTION
Update Spark operator documentation to use `local` image tag when running E2E tests. Without this, tests fail like so:


```
  2025-01-28T22:49:45Z	INFO	Deployment is not ready: spark-operator/spark-operator-controller. 0 out of 1 expected pods are ready
  2025-01-28T22:49:47Z	INFO	Deployment is not ready: spark-operator/spark-operator-controller. 0 out of 1 expected pods are ready
  2025-01-28T22:49:49Z	INFO	Deployment is not ready: spark-operator/spark-operator-controller. 0 out of 1 expected pods are ready
```

This is done in CI already. Just need to reflect it in the docs too.
https://github.com/kubeflow/spark-operator/blob/ad30d15bbb127b83a08cb203fec24d0dcb2530a9/.github/workflows/integration.yaml#L229-L231