### PR TITLE
clarified new-member instructions

### DIFF
--- a/content/en/docs/about/membership.md
+++ b/content/en/docs/about/membership.md
@@ -49,6 +49,8 @@ Members are *[continuously active]* contributors in the community. They can have
   - Make sure that the list of contributions included is representative of your work on the project.
 - Have your sponsoring reviewers reply confirmation of sponsorship
 - Once your sponsors have responded, your request will be reviewed by the Kubeflow team. Any missing information will be requested
+- After your PR is merged, you will get an email (to your GitHub-associated email address) inviting you to the Kubeflow GitHub org. Follow the instructions to accept your membership.
+- To confirm that the membership acceptance process has completed, you can search for your GitHub username at https://github.com/orgs/kubeflow/people.
 
 ### Responsibilities
 


### PR DESCRIPTION
This clarifies the new member instructions to help new members know what needs to happen after their PR is merged. 

Note: this is related to a companion PR on the internal-acls repo, which has already merged. https://github.com/kubeflow/internal-acls/pull/737
