### PR TITLE
fix(trainer): Fix redirect for /components/training/

### DIFF
--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -362,3 +362,4 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/components/training/user-guides/prometheus/             /docs/components/trainer/legacy-v1/user-guides/prometheus/
 /docs/components/training/user-guides/tensorflow/             /docs/components/trainer/legacy-v1/user-guides/tensorflow/
 /docs/components/training/user-guides/xgboost/                /docs/components/trainer/legacy-v1/user-guides/xgboost/
+/docs/components/training/                                    /docs/components/trainer/


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/trainer/issues/2433

This should fix this redirect: https://www.kubeflow.org/docs/components/training

/assign @kubeflow/wg-training-leads @gaocegege 