### PR TITLE
trainer: Add deprecation warning to Training Operator v1 docs

### DIFF
--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -363,3 +363,4 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/components/training/user-guides/tensorflow/             /docs/components/trainer/legacy-v1/user-guides/tensorflow/
 /docs/components/training/user-guides/xgboost/                /docs/components/trainer/legacy-v1/user-guides/xgboost/
 /docs/components/training/                                    /docs/components/trainer/
+/docs/components/training/user-guides/pytorch/                /docs/components/trainer/legacy-v1/user-guides/pytorch/

--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -364,3 +364,5 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/components/training/user-guides/xgboost/                /docs/components/trainer/legacy-v1/user-guides/xgboost/
 /docs/components/training/                                    /docs/components/trainer/
 /docs/components/training/user-guides/pytorch/                /docs/components/trainer/legacy-v1/user-guides/pytorch/
+/docs/components/training/overview/                           /docs/components/trainer/legacy-v1/overview/
+/docs/components/training/getting-started/                    /docs/components/trainer/legacy-v1/getting-started/

--- a/content/en/docs/components/trainer/legacy-v1/_index.md
+++ b/content/en/docs/components/trainer/legacy-v1/_index.md
@@ -8,5 +8,5 @@ weight = 999
 This page is about **Kubeflow Training Operator V1**, for the latest information check
 [the Kubeflow Trainer V2 documentation](/docs/components/trainer).
 
-Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration)
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
 {{% /alert %}}

--- a/content/en/docs/components/trainer/legacy-v1/explanation/_index.md
+++ b/content/en/docs/components/trainer/legacy-v1/explanation/_index.md
@@ -3,3 +3,10 @@ title = "Explanation"
 description = "Explanation for Training Operator Features"
 weight = 60
 +++
+
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}

--- a/content/en/docs/components/trainer/legacy-v1/explanation/fine-tuning.md
+++ b/content/en/docs/components/trainer/legacy-v1/explanation/fine-tuning.md
@@ -4,10 +4,11 @@ description = "Why the Training Operator needs the fine-tuning API"
 weight = 10
 +++
 
-{{% alert title="Warning" color="warning" %}}
-This feature is in **alpha** stage and the Kubeflow community is looking for your feedback. Please
-share your experience using the [#kubeflow-training Slack channel](/docs/about/community/#kubeflow-slack-channels)
-or [Kubeflow Training Operator GitHib](https://github.com/kubeflow/training-operator/issues/new).
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
 {{% /alert %}}
 
 This page explains how the [Training Operator fine-tuning API](/docs/components/trainer/legacy-v1/user-guides/fine-tuning)

--- a/content/en/docs/components/trainer/legacy-v1/getting-started.md
+++ b/content/en/docs/components/trainer/legacy-v1/getting-started.md
@@ -4,6 +4,13 @@ description = "Get started with the Training Operator"
 weight = 30
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This guide describes how to get started with the Training Operator and run a few simple examples.
 
 ## Prerequisites

--- a/content/en/docs/components/trainer/legacy-v1/installation.md
+++ b/content/en/docs/components/trainer/legacy-v1/installation.md
@@ -4,6 +4,13 @@ description = "How to install the Training Operator"
 weight = 20
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This guide describes how to install the Training Operator on your Kubernetes cluster.
 The Training Operator is a lightweight Kubernetes controller that orchestrates the
 appropriate Kubernetes workloads to perform distributed ML training and fine-tuning.

--- a/content/en/docs/components/trainer/legacy-v1/overview.md
+++ b/content/en/docs/components/trainer/legacy-v1/overview.md
@@ -4,7 +4,12 @@ description = "An overview of the Training Operator"
 weight = 10
 +++
 
-{{% stable-status %}}
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
 
 ## What is the Training Operator
 

--- a/content/en/docs/components/trainer/legacy-v1/reference/_index.md
+++ b/content/en/docs/components/trainer/legacy-v1/reference/_index.md
@@ -3,3 +3,10 @@ title = "Reference"
 description = "Reference docs for the Training Operator"
 weight = 50
 +++
+
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}

--- a/content/en/docs/components/trainer/legacy-v1/reference/architecture.md
+++ b/content/en/docs/components/trainer/legacy-v1/reference/architecture.md
@@ -4,7 +4,12 @@ description = "The Training Operator Architecture"
 weight = 10
 +++
 
-{{% stable-status %}}
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
 
 ## What is the Training Operator Architecture?
 

--- a/content/en/docs/components/trainer/legacy-v1/reference/distributed-training.md
+++ b/content/en/docs/components/trainer/legacy-v1/reference/distributed-training.md
@@ -4,6 +4,13 @@ description = "How the Training Operator performs distributed training on Kubern
 weight = 10
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This page shows different distributed strategies that can be used by the Training Operator.
 
 ## Distributed Training for PyTorch

--- a/content/en/docs/components/trainer/legacy-v1/reference/fine-tuning.md
+++ b/content/en/docs/components/trainer/legacy-v1/reference/fine-tuning.md
@@ -4,6 +4,13 @@ description = "How Training Operator performs fine-tuning on Kubernetes"
 weight = 10
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This page shows how Training Operator implements the
 [API to fine-tune LLMs](/docs/components/trainer/legacy-v1/user-guides/fine-tuning).
 

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/_index.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/_index.md
@@ -3,3 +3,10 @@ title = "User Guides"
 description = "User guides for Training Operator"
 weight = 40
 +++
+
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/fine-tuning.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/fine-tuning.md
@@ -4,10 +4,11 @@ description = "Overview of the LLM fine-tuning API in the Training Operator"
 weight = 10
 +++
 
-{{% alert title="Warning" color="warning" %}}
-This feature is in **alpha** stage and the Kubeflow community is looking for your feedback. Please
-share your experience using the [#kubeflow-training Slack channel](https://cloud-native.slack.com/archives/C0742LDFZ4K)
-or the [Kubeflow Training Operator GitHub](https://github.com/kubeflow/training-operator/issues/new).
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
 {{% /alert %}}
 
 This page describes how to use a [`train` API from the Training Python SDK](https://github.com/kubeflow/training-operator/blob/release-1.9/sdk/python/kubeflow/training/api/training_client.py#L95)

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/jax.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/jax.md
@@ -4,6 +4,13 @@ description = "Using JAXJob to train a model with JAX"
 weight = 60
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This page describes `JAXJob` for training a machine learning model with [JAX](https://jax.readthedocs.io/en/latest/).
 
 The `JAXJob` is a Kubernetes

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/job-scheduling.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/job-scheduling.md
@@ -4,6 +4,13 @@ description = "How to schedule a job with gang-scheduling"
 weight = 70
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This guide describes how to use [Kueue](https://kueue.sigs.k8s.io/),
 [Volcano Scheduler](https://github.com/volcano-sh/volcano) and
 [Scheduler Plugins with coscheduling](https://github.com/kubernetes-sigs/scheduler-plugins/blob/2502825c671063af5b2aa78a1d34b24917f2def4/pkg/coscheduling/README.md)

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/paddle.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/paddle.md
@@ -4,6 +4,13 @@ description = "Using PaddleJob to train a model with PaddlePaddle"
 weight = 30
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This page describes the `PaddleJob` for training a machine learning model with [PaddlePaddle](https://www.paddlepaddle.org.cn/).
 
 The `PaddleJob` is a Kubernetes

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/prometheus.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/prometheus.md
@@ -4,6 +4,13 @@ description = "Prometheus Metrics for the Training Operator"
 weight = 70
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This guide explains how to monitor Kubeflow training jobs using Prometheus metrics. The Training Operator exposes these metrics, providing essential insights into the status of distributed machine learning workloads.
 
 {{< note >}}
@@ -11,14 +18,17 @@ Metrics are only generated in response to specific events. For example, job crea
 {{< /note >}}
 
 ## Prometheus Metrics for Training Operator
+
 The Training Operator includes a built-in `/metrics` endpoint exposes Prometheus metrics. This feature is enabled by default and requires no additional configuration for basic use.
 
 ### Configuring Metrics Port
-By default, metrics are exposed on port 8080 and can be scraped from any IP address. 
 
-If you want to change the default port for metrics exporting and limit which IP address can scrape the metrics, simply add the `metrics-bind-address` argument. 
+By default, metrics are exposed on port 8080 and can be scraped from any IP address.
+
+If you want to change the default port for metrics exporting and limit which IP address can scrape the metrics, simply add the `metrics-bind-address` argument.
 
 **For example**:
+
 ```yaml
 # deployment.yaml for the Training Operator
 spec:
@@ -33,21 +43,23 @@ spec:
             name: webhook-server
             protocol: TCP
         args:
-        - "--metrics-bind-address=192.168.1.100:8082" 
+        - "--metrics-bind-address=192.168.1.100:8082"
 ```
 
 **Explanation:**
 
 `--metrics-bind-address=192.168.1.100:8082` specifies that metrics are now available on **port 8082**, restricted to the IP address **192.168.1.100**. Alternatively, you can bind the metrics to all interfaces by using **0.0.0.0:8082**.
 
-
 ### Accessing the Metrics
+
 The method to access these metrics may vary depending on your Kubernetes setup and environment. For example, use the following command for local environments:
+
 ```
 kubectl port-forward -n kubeflow deployment/training-operator 8080:8080
 ```
 
 Then you'll see metrics in this format via `http://localhost:8080/metrics`:
+
 ```
 # HELP training_operator_jobs_created_total Counts number of jobs created
 # TYPE training_operator_jobs_created_total counter
@@ -56,17 +68,16 @@ training_operator_jobs_created_total{framework="tensorflow",job_namespace="kubef
 
 ## List of Job Metrics
 
-| Metric name                          |  Description                     | Labels                                           |
-|------------------------------------|---------|--------------------------|------------------------------------------------------|
-| `training_operator_jobs_created_total`   |  Total number of jobs created       | `namespace`, `framework`                 |
-| `training_operator_jobs_deleted_total`   |  Total number of jobs deleted       | `namespace`, `framework`                 |
-| `training_operator_jobs_successful_total` |  Total number of successful jobs   |  `namespace`, `framework`                 |
-| `training_operator_jobs_failed_total`    |  Total number of failed jobs       |  `namespace`, `framework` |
-| `training_operator_jobs_restarted_total` |  Total number of restarted jobs   |  `namespace`, `framework`|
+| Metric name                               | Description                     | Labels                   |
+| ----------------------------------------- | ------------------------------- | ------------------------ |
+| `training_operator_jobs_created_total`    | Total number of jobs created    | `namespace`, `framework` |
+| `training_operator_jobs_deleted_total`    | Total number of jobs deleted    | `namespace`, `framework` |
+| `training_operator_jobs_successful_total` | Total number of successful jobs | `namespace`, `framework` |
+| `training_operator_jobs_failed_total`     | Total number of failed jobs     | `namespace`, `framework` |
+| `training_operator_jobs_restarted_total`  | Total number of restarted jobs  | `namespace`, `framework` |
 
 Labels information can be interpreted as follows:
-| Label name                          |  Description                     | 
+| Label name | Description |
 |------------------------------------|---------|--------------------------|
-| `namespace`   | The Kubernetes namespace where the job is running        |
-| `framework` | The machine learning framework used (e.g. TensorFlow,PyTorch)     | 
-
+| `namespace` | The Kubernetes namespace where the job is running |
+| `framework` | The machine learning framework used (e.g. TensorFlow,PyTorch) |

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/pytorch.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/pytorch.md
@@ -4,6 +4,13 @@ description = "Using PyTorchJob to train a model with PyTorch"
 weight = 20
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This page describes `PyTorchJob` for training a machine learning model with [PyTorch](https://pytorch.org/).
 
 The `PyTorchJob` is a Kubernetes

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/tensorflow.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/tensorflow.md
@@ -4,6 +4,13 @@ description = "Using TFJob to train a model with TensorFlow"
 weight = 10
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This page describes `TFJob` for training a machine learning model with [TensorFlow](https://www.tensorflow.org/).
 
 ## What is TFJob?

--- a/content/en/docs/components/trainer/legacy-v1/user-guides/xgboost.md
+++ b/content/en/docs/components/trainer/legacy-v1/user-guides/xgboost.md
@@ -4,6 +4,13 @@ description = "Using XGBoostJob to train a model with XGBoost"
 weight = 50
 +++
 
+{{% alert title="Old Version" color="warning" %}}
+This page is about **Kubeflow Training Operator V1**, for the latest information check
+[the Kubeflow Trainer V2 documentation](/docs/components/trainer).
+
+Follow [this guide for migrating to Kubeflow Trainer V2](/docs/components/trainer/operator-guides/migration).
+{{% /alert %}}
+
 This page describes the `XGBoostJob` for training a machine learning model with [XGBoost](https://github.com/dmlc/xgboost).
 
 `XGBoostJob` is a Kubernetes


### PR DESCRIPTION
We forgot to add deprecation message to all Training Operator v1 docs.

Also, I fixed the PyTorch guide redirect.

/assign @kubeflow/wg-training-leads @astefanutti @Electronic-Waste @deepanker13 @varodrig @rimolive @hbelmiro @thesuperzapper 