### PR TITLE
gsoc: Update mentors for Kubeflow GSoC 2025

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2025.md
+++ b/content/en/events/upcoming-events/gsoc-2025.md
@@ -221,7 +221,10 @@ __Skills Required/Preferred:__
 
 __Components:__ Kubeflow Spark Operator
 
-__Possible Mentors:__ [`@Shekharrajak`](https://github.com/Shekharrajak), [`@yuchaoran2011`](https://github.com/yuchaoran2011), [`@andreyvelich`](https://github.com/andreyvelich)
+__Possible Mentors:__ [`@Shekharrajak`](https://github.com/Shekharrajak),
+  [`@lresende`](https://github.com/lresende),
+  [`@yuchaoran2011`](https://github.com/yuchaoran2011),
+  [`@andreyvelich`](https://github.com/andreyvelich)
 
 __Difficulty:__ Hard
 
@@ -286,7 +289,9 @@ __Skills Required/Preferred:__
 
 __Components:__ Kubeflow Trainer (Training Operator)
 
-__Possible Mentors:__ [`@andreyvelich`](https://github.com/andreyvelich)
+__Possible Mentors:__ [`@Electronic-Waste`](https://github.com/Electronic-Waste),
+  [`@XshubhamX`](https://github.com/XshubhamX),
+  [`@andreyvelich`](https://github.com/andreyvelich)
 
 __Difficulty:__ Hard
 
@@ -311,7 +316,8 @@ __Skills Required/Preferred:__
 
 __Components:__ Kubeflow Katib
 
-__Possible Mentors:__ [`@andreyvelich`](https://github.com/andreyvelich), [`@Electronic-Waste`](https://github.com/Electronic-Waste)
+__Possible Mentors:__ [`@Electronic-Waste`](https://github.com/Electronic-Waste),
+  [`@andreyvelich`](https://github.com/andreyvelich)
 
 __Difficulty:__ Medium
 


### PR DESCRIPTION
/area gsoc

I updated mentors for GSoC 2025 as follows:
1. Adding @lresende to the Spark Operator + BPG integrations.
2. Adding @XshubhamX to the Kubeflow Trainer + TF and JAX Runtimes support

/assign @kubeflow/wg-training-leads @lresende @Shekharrajak @yuchaoran2011 @Electronic-Waste 