### PR TITLE
gsoc: remove project 9 & update mentors

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2025.md
+++ b/content/en/events/upcoming-events/gsoc-2025.md
@@ -312,39 +312,7 @@ __Skills Required/Preferred:__
 ---
 ---
 
-### Project 9: Kubernetes-native Sidecar Containers for Katib Metrics Collector
-
-__Components:__ Kubeflow Katib
-
-__Possible Mentors:__ [`@Electronic-Waste`](https://github.com/Electronic-Waste),
-  [`@andreyvelich`](https://github.com/andreyvelich)
-
-__Difficulty:__ Medium
-
-__Size:__ 350 hours
-
-__Goals:__
-
-- Integrate Katib Metrics Collectors with Kubernetes Sidecars ([`kubeflow/katib#2181`](https://github.com/kubeflow/katib/issues/2181))
-   - Katib implements Pull-based Metrics Collector as a sidecar container to collect training metrics from the Trials once training is complete. 
-   - However, the Pull-based Metrics Collector has some problems. 
-   - For example, the Trial will fail if the training container is finished before Metrics Collector is started.
-   - After v1.28, Kubernetes add native support for sidecar containers as part of KEP 753, which allows us to launch sidecar containers before the training container. 
-   - In order to address the problems with the Pull-based Metrics Collector, we need to support Kubernetes Sidecar Containers in Katib.
-- Provide some unit tests and e2e tests
-
-__Skills Required/Preferred:__
-
-- Kubernetes
-- Go
-- YAML
-- Python
-
-
----
----
-
-### Project 10: Export Kubeflow Trainer Models to Kubeflow Model Registry
+### Project 9: Export Kubeflow Trainer Models to Kubeflow Model Registry
 
 __Components:__ Kubeflow Trainer, Kubeflow Model Registry
 
@@ -370,7 +338,7 @@ __Skills Required/Preferred:__
 ---
 ---
 
-### Project 11: Support Volcano Scheduler in Kubeflow Trainer
+### Project 10: Support Volcano Scheduler in Kubeflow Trainer
 
 __Components:__ Kubeflow Trainer
 
@@ -395,7 +363,7 @@ __Skills Required/Preferred:__
 ---
 ---
 
-### Project 12: Support Postgres for Kubeflow Pipelines backend
+### Project 11: Support Postgres for Kubeflow Pipelines backend
 
 __Components:__ Kubeflow Pipelines
 

--- a/content/en/events/upcoming-events/gsoc-2025.md
+++ b/content/en/events/upcoming-events/gsoc-2025.md
@@ -342,7 +342,7 @@ __Skills Required/Preferred:__
 
 __Components:__ Kubeflow Trainer
 
-__Possible Mentors:__ [`@Electronic-Waste`](https://github.com/Electronic-Waste)
+__Possible Mentors:__ [`@Electronic-Waste`](https://github.com/Electronic-Waste), [`@rudeigerc`](https://github.com/rudeigerc)
 
 __Difficulty:__ Hard
 

--- a/content/en/events/upcoming-events/gsoc-2025.md
+++ b/content/en/events/upcoming-events/gsoc-2025.md
@@ -314,7 +314,7 @@ __Skills Required/Preferred:__
 
 ### Project 9: Export Kubeflow Trainer Models to Kubeflow Model Registry
 
-__Components:__ Kubeflow Trainer, Kubeflow Model Registry
+__Components:__ Kubeflow Trainer (Training Operator), Kubeflow Model Registry
 
 __Possible Mentors:__ [`@tarilabs`](https://github.com/tarilabs), [`@franciscojavierarceo`](https://github.com/franciscojavierarceo)
 
@@ -340,7 +340,7 @@ __Skills Required/Preferred:__
 
 ### Project 10: Support Volcano Scheduler in Kubeflow Trainer
 
-__Components:__ Kubeflow Trainer
+__Components:__ Kubeflow Trainer (Training Operator)
 
 __Possible Mentors:__ [`@Electronic-Waste`](https://github.com/Electronic-Waste), [`@rudeigerc`](https://github.com/rudeigerc)
 


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [ ] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**

As I discussed with @andreyvelich in the slack, we agreed that WG AutoML/Training should remove project 9 because our effort is limited and can accept at most 3 projects. And I propose to add @rudeigerc as backup mentor for `Support Volcano Scheduler in Kubeflow Trainer`. He has rich experience in scheduling and will surely help us a lot with the project.

So I:

-  Remove project 9
- Add @rudeigerc as mentor for `Support Volcano Scheduler in Kubeflow Trainer`

/cc @kubeflow/kubeflow-steering-committee @kubeflow/wg-training-leads @kubeflow/wg-automl-leads @rudeigerc

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

/area gsoc

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
<!-- /area website -->
<!-- /area community -->
---

