### PR TITLE
Website: Github action to verify PR title

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 **Checklist:**
 - [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
 - [ ] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
-- [] You have included screenshots when changing the website style or adding a new page.
+- [ ] You have included screenshots when changing the website style or adding a new page.
 
 
 **Description of your changes:**

--- a/.github/workflows/check_pr_title.yaml
+++ b/.github/workflows/check_pr_title.yaml
@@ -1,0 +1,26 @@
+name: Pull request title
+
+on:
+  pull_request_target:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify-prefix:
+    name: verify component prefix
+    runs-on: ubuntu-latest
+    steps:
+    - uses: deepakputhraya/action-pr-title@master
+      with:
+        regex: '^[-A-Za-z]+: .+'
+        allowed_prefixes: 'central-dashboard,katib,kserve,model-registry,notebooks,pipelines,spark-operator,trainer,gsoc,website,community'
+        prefix_case_sensitive: false
+        verbal_description: 'should match format "{component}: {description}"'
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [ ] You have included screenshots when changing the website style or adding a new page.

**Description of your changes:**

Adds a github action to verify that the PR title matches the format `{component}: {description}`.

I tested this on my fork:

- Passing: https://github.com/pboyd/kubeflow-website/pull/2
- Failing for a missing prefix: https://github.com/pboyd/kubeflow-website/pull/3
- Failing for an unrecognized prefix: https://github.com/pboyd/kubeflow-website/pull/4

### Issue

Closes: #4002