### PR TITLE
Update of the support page

### DIFF
--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -87,7 +87,7 @@ Below is a table of organizations that contribute to Kubeflow and offer commerci
 | Other Providers        | ...                                                            |
 
 <a id="cloud-support"></a>
-If you are using the a managed offer from a cloud provider for Kubeflow, then the cloud
+If you are using a managed offer from a cloud provider for Kubeflow, then the cloud
 provider may be able to help you diagnose and solve a problem.
 
 ## Getting Involved

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -6,6 +6,7 @@ weight = 80
 
 This page describes the Kubeflow resources and support options available when you encounter a problem, have a question, or want to make a suggestion about Kubeflow.
 
+<a id="application-status"></a>
 ## Component Status
 
 When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple components. Note that component versioning is independent from Kubeflow versioning. Each component should meet certain criteria regarding stability, upgradability, logging, monitoring, and security (such as adherence to PodSecurity standards, network policies, and integration tests for authentication and authorization).
@@ -16,6 +17,7 @@ Application status indicators for Kubeflow:
 * **Beta**: The application is progressing toward meeting all criteria.
 * **Alpha**: The application is in early development or integration stages.
 
+<a id="levels-of-support"></a>
 ## Levels of Support
 
 The following table describes the level of support that you can expect based on the status of an application:
@@ -73,6 +75,7 @@ usYou can ask questions and make suggestions in the following places:
   * [Examples](https://github.com/kubeflow/examples/issues)
   * [Website](https://github.com/kubeflow/website/issues)
 
+<a id="provider-support"></a>
 ## Support from Providers in the Kubeflow Ecosystem
 
 Below is a table of organizations that contribute to Kubeflow and offer commercial support:
@@ -85,6 +88,7 @@ Below is a table of organizations that contribute to Kubeflow and offer commerci
 | Red Hat                | [Red Hat](https://...)                                         |
 | Other Providers        | ...                                                            |
 
+<a id="cloud-support"></a>
 If you are using the a managed offer from a cloud provider for Kubeflow, then the cloud
 provider may be able to help you diagnose and solve a problem.
 

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -62,16 +62,15 @@ You can ask questions and make suggestions in the following places:
     Each Kubeflow component has its own issue tracker within the [Kubeflow
     organization on GitHub](https://github.com/kubeflow). To get you started,
     here are the primary issue trackers:
-
+  * [Kubeflow Spark Operator](https://github.com/kubeflow/spark-operator/issues)
   * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/issues)
-  * [Katib AutoML](https://github.com/kubeflow/katib/issues)
-  * [Trainer](https://github.com/kubeflow/trainer/issues)
-  * [Notebooks](https://github.com/kubeflow/notebooks/issues)
-  * [Dashboard](https://github.com/kubeflow/dashboard/issues)
-  * [Kserve](https://github.com/kserve/kserve/issues)
-  * [Platform / Manifests](https://github.com/kubeflow/manifests/issues)
-  * [Examples](https://github.com/kubeflow/examples/issues)
-  * [Website](https://github.com/kubeflow/website/issues)
+  * [Kubeflow Katib](https://github.com/kubeflow/katib/issues)
+  * [Kubeflow Trainer](https://github.com/kubeflow/trainer/issues)
+  * [Kubeflow Notebooks](https://github.com/kubeflow/notebooks/issues)
+  * [Kubeflow Dashboard](https://github.com/kubeflow/dashboard/issues)
+  * [Kubeflow Kserve](https://github.com/kserve/kserve/issues)
+  * [Kubeflow Platform / Manifests](https://github.com/kubeflow/manifests/issues)
+  * [Kubeflow Website](https://github.com/kubeflow/website/issues)
 
 <a id="provider-support"></a>
 ## Support from commercial providers in the Kubeflow Ecosystem

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -9,7 +9,7 @@ This page describes the Kubeflow resources and support options available when yo
 <a id="application-status"></a>
 ## Component Status
 
-When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple components. Note that component versioning is independent from Kubeflow versioning. Each component should meet certain [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md) regarding stability, upgradability, logging, monitoring, and security (PodSecurityStandards restricted, network policies, and integration tests for authentication and authorization).
+When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple projects. Note that project versioning is independent from Kubeflow Platform version. Each project should meet certain [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md) regarding stability, upgradability, logging, monitoring, and security (PodSecurityStandards restricted, network policies, and integration tests for authentication and authorization).
 
 Component status indicators:
 

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -97,6 +97,7 @@ You can participate in Kubeflow by contributing funding, code, documentation, us
 ## Stay Updated
 
 Keep up with Kubeflow news:
+* The [community page](https://www.kubeflow.org/docs/about/community/) with Slack channels, regular meetings and other guidelines.
 * The [Kubeflow Blog](https://blog.kubeflow.org/) for release announcements, events, and tutorials.
 * [Kubeflow on Twitter](https://twitter.com/kubeflow) for technical tips.
 * Release notes for detailed updates on each Kubeflow application.

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -9,6 +9,7 @@ This page describes the Kubeflow resources and support options available when yo
 <a id="application-status"></a>
 ## Component Status
 
+Please make youself familiar with the [structure of Kubeflow](https://www.kubeflow.org/docs/started/introduction/#what-is-kubeflow) first. 
 When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple projects. Note that project versioning is independent from Kubeflow Platform version. Each project should meet certain [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md) regarding stability, upgradability, logging, monitoring, and security (PodSecurityStandards restricted, network policies, and integration tests for authentication and authorization).
 
 Component status indicators:

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -76,6 +76,7 @@ You can ask questions and make suggestions in the following places:
 <a id="provider-support"></a>
 ## Support from commercial providers in the Kubeflow Ecosystem
 
+We want to promote commercial companies and idividuals that contribute back to the open source project.
 Below is a table of organizations that contribute to Kubeflow and offer commercial support:
 
 | Provider               | Support Link                                                   |

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -19,8 +19,8 @@ Component status indicators:
 <a id="levels-of-support"></a>
 ## Levels of Support
 
-- The Kubeflow community offers best-effort support for stable components.
-- You can also consider requesting  support from a commercial company or freelancer listed below.
+1. The Kubeflow community offers best-effort support for stable components.
+2. You can also consider requesting  support from a commercial company or freelancer listed below.
 
 <a id="community-support"></a>
 ## Support from the Kubeflow community

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -4,90 +4,28 @@ description = "Where to get support for Kubeflow"
 weight = 80
 +++
 
-This page describes the Kubeflow resources and support options that you can
-explore when you encounter a problem, have a question, or want to make a
-suggestion about Kubeflow.
+This page describes the Kubeflow resources and support options available when you encounter a problem, have a question, or want to make a suggestion about Kubeflow.
 
-<a id="application-status"></a>
-## Application status
+## Component Status
 
-Starting from the release of Kubeflow v1.0, the Kubeflow community
-attributes *stable status* to those applications and components that
-meet a defined level of stability, supportability, and upgradability.
-
-When you deploy Kubeflow to a Kubernetes cluster, your deployment includes a
-number of applications. Application versioning is independent of Kubeflow
-versioning. An application moves to version 1.0 when the application meets
-certain [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md)
-in terms of stability, upgradability, and the provision of services such as
-logging and monitoring.
-
-When an application moves to version 1.0, the Kubeflow community will
-decide whether to mark that version of the application as *stable* in the next
-major or minor release of Kubeflow.
+When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple components. Note that component versioning is independent from Kubeflow versioning. Each component should meet certain criteria regarding stability, upgradability, logging, monitoring, and security (such as adherence to PodSecurity standards, network policies, and integration tests for authentication and authorization).
 
 Application status indicators for Kubeflow:
 
-* **Stable** means that the application complies with the
-  [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md)
-  to reach application version 1.0, and that the Kubeflow community has deemed
-  the application stable for this release of Kubeflow.
-* **Beta** means that the application is working towards a version 1.0 release
-  and its maintainers have communicated a timeline for satisfying the criteria
-  for the stable status.
-* **Alpha** means that the application is in the early phases of
-  development and/or integration into Kubeflow.
+* **Stable**: The application complies with most of the criteria and is considered stable for this release.
+* **Beta**: The application is progressing toward meeting all criteria.
+* **Alpha**: The application is in early development or integration stages.
 
-<a id="levels-of-support"></a>
-## Levels of support
+## Levels of Support
 
 The following table describes the level of support that you can expect based on the status of an application:
 
-<div class="table-responsive">
-  <table class="table table-bordered">
-    <thead class="thead-light">
-      <tr>
-        <th>Application status</th>
-        <th>Level of support</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Stable</td>
-        <td>The Kubeflow community offers <i>best-effort support</i> for stable
-          applications. See the section on 
-          <a href="#community-support">community support</a> below for a
-          definition of best-effort support and the community channels where you 
-          can report and discuss the problem. You can also consider requesting 
-          support from a 
-          <a href="#provider-support">Kubeflow community provider</a> or from 
-          your <a href="#cloud-support">cloud provider</a>.
-        </td>
-      </tr>
-      <tr>
-        <td>Beta</td>
-        <td>The Kubeflow community offers <i>best-effort support</i> for beta
-          applications. See the section on 
-          <a href="#community-support">community support</a> below for a
-          definition of best-effort support and the community channels where you 
-          can report and discuss the problem. 
-        </td>
-      </tr>
-      <tr>
-        <td>Alpha</td>
-        <td>The response differs per application in alpha status, depending on
-          the size of the community for that application and the current level
-          of active development of the application.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+The Kubeflow community offers best-effort support for stable components. See the section on community support below for a definition of best-effort support and the community channels where you can report and discuss the problem. You can also consider requesting  support from a commercial company or freelancer listed below.
 
 <a id="community-support"></a>
 ## Support from the Kubeflow community
 
 Kubeflow has an active and helpful community of users and contributors. 
-
 The Kubeflow community offers support on a best-effort basis for stable and beta
 applications.
 **Best-effort support** means that there's no formal agreement or
@@ -99,21 +37,22 @@ to helping you diagnose and address the problem if all the following are true:
   example, the Kubeflow community may not be able to help if the problem is 
   caused by a specific network configuration within your organization.
 * Community members can reproduce the problem.
-* The reporter of the problem can help with further diagnosis and 
-  troubleshooting.
+* The reporter can assist with troubleshooting.
 
-You can ask questions and make suggestions in the following places:
+usYou can ask questions and make suggestions in the following places:
 
 * **Slack** for online chat and messaging. See details of Kubeflow's 
-  [Slack workspace and channels](/docs/about/community/#kubeflow-slack-channels).
+  [Slack workspace and channels](/docs/about/community/#kubeflow-slack).
+* **Github discussions** TODO
 * **Kubeflow discuss** for email-based group discussion. Join the
   [kubeflow-discuss](/docs/about/community/#kubeflow-mailing-list)
   group.
 * **Kubeflow documentation** for overviews and how-to guides. In particular,
   refer to the following documents when troubleshooting a problem:
 
-  * [Kubeflow installation and setup](/docs/started/installing-kubeflow/)
+  * [Kubeflow installation and setup](/docs/started/getting-started/)
   * [Kubeflow components](/docs/components/)
+  * [Further setup and troubleshooting](/docs/other-guides/)
 
 * **Kubeflow issue trackers** for known issues, questions, and feature requests.
   Search the open issues to see if someone else has already logged the problem 
@@ -124,104 +63,38 @@ You can ask questions and make suggestions in the following places:
     organization on GitHub](https://github.com/kubeflow). To get you started,
     here are the primary issue trackers:
 
-  * [Kubeflow core](https://github.com/kubeflow/kubeflow/issues)
-  * [kfctl command-line tool](https://github.com/kubeflow/kfctl/issues)
-  * [Kustomize manifests](https://github.com/kubeflow/manifests/issues)
+  * [Platform / Manifests](https://github.com/kubeflow/manifests/issues)
   * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/issues)
   * [Katib AutoML](https://github.com/kubeflow/katib/issues)
-  * [Metadata](https://github.com/kubeflow/metadata/issues)
-  * [Fairing notebook SDK](https://github.com/kubeflow/fairing/issues)
-  * [Kubeflow Training (TFJob, PyTorchJob, MXJob, XGBoostJob)](https://github.com/kubeflow/training-operator/issues)
-  * [KFServing](https://github.com/kubeflow/kfserving/issues)
+  * [Trainer](https://github.com/kubeflow/training-operator/issues)
+  * [Notebooks](https://github.com/kubeflow/notebooks/issues)
+  * [Dashboard](https://github.com/kubeflow/dashboard/issues)
+  * [Kserve](https://github.com/kserve/kserve/issues)
   * [Examples](https://github.com/kubeflow/examples/issues)
-  * [Documentation](https://github.com/kubeflow/website/issues)
+  * [Website](https://github.com/kubeflow/website/issues)
 
-<a id="provider-support"></a>
-## Support from providers in the Kubeflow ecosystem
+## Support from Providers in the Kubeflow Ecosystem
 
-The following organizations offer advice and support for Kubeflow deployments:
+Below is a table of organizations that contribute to Kubeflow and offer commercial support:
 
-<div class="table-responsive">
-  <table class="table table-bordered">
-    <thead class="thead-light">
-      <tr>
-        <th>Organization</th>
-        <th>Points of contact</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a href="https://www.arrikto.com">Arrikto</a></td>
-        <td><a href="mailto:sales@arrikto.com">sales@arrikto.com</a></td>
-      </tr>
-      <tr>
-        <td><a href="https://www.ubuntu.com">Canonical</a></td>
-        <td><a href="https://ubuntu.com/kubeflow#get-in-touch">Get in touch</a></td>
-      </tr>
-      <tr>
-        <td><a href="https://www.pattersonconsultingtn.com/">Patterson Consulting</a></td>
-        <td> 
-        <a href="http://www.pattersonconsultingtn.com/offerings/managed_kubeflow.html">Managed Kubeflow</a></td>
-      </tr>
-      <tr>
-        <td><a href="https://www.seldon.io/">Seldon</a></td>
-        <td> 
-        <a href="https://github.com/SeldonIO/seldon-core/issues">Issue 
-        tracker</a></td>
-      </tr>    
-    </tbody>
-  </table>
-</div>
+| Provider               | Support Link                                                   |
+|------------------------|----------------------------------------------------------------|
+| Canonical              | [Ubuntu Kubeflow](https://ubuntu.com/kubeflow#get-in-touch)    |
+| Aranui Solutions       | [Aranui Solutions](https://...)                                |
+| Freelance/Consulting   | Julius von Kohout on the Slack channel                         |
+| Red Hat                | [Red Hat](https://...)                                         |
+| Other Providers        | ...                                                            |
 
-<a id="cloud-support"></a>
-## Support from a cloud or platform provider
-
-If you're using the services of a cloud provider to host Kubeflow, the cloud
+If you are using the a managed offer from a cloud provider for Kubeflow, then the cloud
 provider may be able to help you diagnose and solve a problem.
 
-Consult the support page for the cloud service or platform that you're using:
+## Getting Involved
 
-* [Amazon Web Services (AWS)](https://aws.amazon.com/contact-us/)
-* [Canonical Ubuntu](https://ubuntu.com/kubeflow#get-in-touch)
-* [Google Cloud Platform (GCP)](https://cloud.google.com/support-hub/)
-* [IBM Cloud](https://www.ibm.com/cloud/support)
-* [Microsoft Azure](https://azure.microsoft.com/en-au/support/options/)
-* [Red Hat OpenShift](https://help.openshift.com/)
+You can participate in Kubeflow by contributing code, documentation, or by joining community meetings. For more information, see the [Kubeflow Community page](/docs/about/community/).
 
-## Other places to ask questions
-
-You can also try searching for answers or asking a question on Stack Overflow. 
-See the [questions tagged with
-“kubeflow”](https://stackoverflow.com/questions/tagged/kubeflow).
-
-## Getting involved in the Kubeflow community
-
-You can get involved with Kubeflow in many ways. For example, you can
-contribute to the Kubeflow code or documentation. You can join the community
-meetings to talk to maintainers about a specific topic. See the
-[Kubeflow community page](/docs/about/community/) for further information.
-
-## Following the news
+## Stay Updated
 
 Keep up with Kubeflow news:
-
-* The [Kubeflow blog](https://blog.kubeflow.org/) is the primary channel for
-  announcement of new releases, events, and technical walkthroughs.
-* Follow [Kubeflow on Twitter](https://twitter.com/kubeflow) for shared
-  technical tips.
-* The release notes give details of the latest updates for each Kubeflow 
-  application.
-
-    Each Kubeflow application has its own repository within the [Kubeflow
-    organization on GitHub](https://github.com/kubeflow). Some of the 
-    applications publish release notes. To get you started,
-    here are the release notes for the primary applications:
-
-  * [Kubeflow core](https://github.com/kubeflow/kubeflow/releases)
-  * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/releases)
-  * [Katib AutoML](https://github.com/kubeflow/katib/releases)
-  * [Metadata](https://github.com/kubeflow/metadata/releases)
-  * [Fairing notebook SDK](https://github.com/kubeflow/fairing/releases)
-  * [Kubeflow Training Operator](https://github.com/kubeflow/training-operator/releases)
-  * [KFServing](https://github.com/kubeflow/kfserving/releases)
-  
+* The [Kubeflow Blog](https://blog.kubeflow.org/) for release announcements, events, and tutorials.
+* [Kubeflow on Twitter](https://twitter.com/kubeflow) for technical tips.
+* Release notes for detailed updates on each Kubeflow application.  

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -9,13 +9,13 @@ This page describes the Kubeflow resources and support options available when yo
 <a id="application-status"></a>
 ## Component Status
 
-When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple components. Note that component versioning is independent from Kubeflow versioning. Each component should meet certain [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md) regarding stability, upgradability, logging, monitoring, and security (such as adherence to PodSecurity standards restricted, network policies, and integration tests for authentication and authorization).
+When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple components. Note that component versioning is independent from Kubeflow versioning. Each component should meet certain [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md) regarding stability, upgradability, logging, monitoring, and security (PodSecurityStandards restricted, network policies, and integration tests for authentication and authorization).
 
 Component status indicators:
 
 * **Stable**: The application complies with most of the criteria and is considered stable for this release.
-* **Beta**: The application is progressing toward meeting all criteria.
-* **Alpha**: The application is in early development or integration stages.
+* **Beta**: The application is progressing towards meeting most criteria.
+* **Alpha**: The application is in an early development or integration stage.
 
 <a id="levels-of-support"></a>
 ## Levels of Support
@@ -44,7 +44,7 @@ to helping you diagnose and address the problem if all of the following requirem
 You can ask questions and make suggestions in the following places:
 
 * **Slack** for online chat and messaging, see [Slack workspace and channels](/docs/about/community/#kubeflow-slack-channels).
-* **Github discussions** per repository, e.g. [here](https://github.com/kubeflow/manifests/discussions)
+* **GitHub discussions** per repository, e.g. [here](https://github.com/kubeflow/manifests/discussions)
 * **Kubeflow discuss** for email-based group discussion. Join the
   [kubeflow-discuss](/docs/about/community/#kubeflow-mailing-list)
   group.
@@ -92,11 +92,11 @@ provider may be able to help you diagnose and solve a problem.
 
 ## Getting Involved
 
-You can participate in Kubeflow by contributing funding, code, documentation, usecases or by joining community meetings. For more information, see the [Kubeflow Community page](/docs/about/community/).
+You can participate in Kubeflow by contributing funding, code, documentation, use cases or by joining community meetings. For more information, see the [Kubeflow Community page](/docs/about/community/).
 
 ## Stay Updated
 
 Keep up with Kubeflow news:
 * The [Kubeflow Blog](https://blog.kubeflow.org/) for release announcements, events, and tutorials.
 * [Kubeflow on Twitter](https://twitter.com/kubeflow) for technical tips.
-* Release notes for detailed updates on each Kubeflow application.  
+* Release notes for detailed updates on each Kubeflow application.

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -65,7 +65,7 @@ You can ask questions and make suggestions in the following places:
 
   * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/issues)
   * [Katib AutoML](https://github.com/kubeflow/katib/issues)
-  * [Trainer](https://github.com/kubeflow/training-operator/issues)
+  * [Trainer](https://github.com/kubeflow/trainer/issues)
   * [Notebooks](https://github.com/kubeflow/notebooks/issues)
   * [Dashboard](https://github.com/kubeflow/dashboard/issues)
   * [Kserve](https://github.com/kserve/kserve/issues)

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -20,7 +20,7 @@ Component status indicators:
 ## Levels of Support
 
 1. The Kubeflow community offers best-effort support for stable components.
-2. You can also consider requesting  support from a commercial company or freelancer listed below.
+2. You can also request commercial support from a company or freelancer listed below.
 
 <a id="community-support"></a>
 ## Support from the Kubeflow community
@@ -91,7 +91,7 @@ provider may be able to help you diagnose and solve a problem.
 
 ## Getting Involved
 
-You can participate in Kubeflow by contributing code, documentation, or by joining community meetings. For more information, see the [Kubeflow Community page](/docs/about/community/).
+You can participate in Kubeflow by contributing funding, code, documentation, usecases or by joining community meetings. For more information, see the [Kubeflow Community page](/docs/about/community/).
 
 ## Stay Updated
 

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -12,6 +12,7 @@ This page describes the Kubeflow resources and support options available when yo
 When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple components. Note that component versioning is independent from Kubeflow versioning. Each component should meet certain [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md) regarding stability, upgradability, logging, monitoring, and security (such as adherence to PodSecurity standards restricted, network policies, and integration tests for authentication and authorization).
 
 Component status indicators:
+
 * **Stable**: The application complies with most of the criteria and is considered stable for this release.
 * **Beta**: The application is progressing toward meeting all criteria.
 * **Alpha**: The application is in early development or integration stages.
@@ -28,6 +29,7 @@ Component status indicators:
 Kubeflow has an active and helpful community of users and contributors. 
 The Kubeflow community offers support on a best-effort basis for stable and beta
 applications. If you need commercial support, please check the sections below.
+
 **Best-effort support** means that there's no formal agreement or
 commitment to solve a problem but the community appreciates the
 importance of addressing the problem as soon as possible. The community commits
@@ -42,22 +44,21 @@ to helping you diagnose and address the problem if all of the following requirem
 You can ask questions and make suggestions in the following places:
 
 * **Slack** for online chat and messaging, see [Slack workspace and channels](/docs/about/community/#kubeflow-slack-channels).
-* **Github discussions** TODO
+* **Github discussions** per repository, e.g. [here](https://github.com/kubeflow/manifests/discussions)
 * **Kubeflow discuss** for email-based group discussion. Join the
   [kubeflow-discuss](/docs/about/community/#kubeflow-mailing-list)
   group.
 * **Kubeflow documentation** for overviews and how-to guides. In particular,
   refer to the following documents when troubleshooting a problem:
-
   * [Kubeflow installation and setup](/docs/started/installing-kubeflow/)
   * [Kubeflow components](/docs/components/)
 
 * **Kubeflow issue trackers** for known issues, questions, and feature requests.
   Search the open issues to see if someone else has already logged the problem 
-  that you're encountering and learn about any workarounds to date. If no one
+  that you are encountering and learn about any workarounds. If no one
   has logged your problem, create a new issue to describe the problem.
 
-    Each Kubeflow application has its own issue tracker within the [Kubeflow
+    Each Kubeflow component has its own issue tracker within the [Kubeflow
     organization on GitHub](https://github.com/kubeflow). To get you started,
     here are the primary issue trackers:
 

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -29,11 +29,11 @@ The Kubeflow community offers best-effort support for stable components. See the
 
 Kubeflow has an active and helpful community of users and contributors. 
 The Kubeflow community offers support on a best-effort basis for stable and beta
-applications.
+applications. If you need commercial support, please check the sections below.
 **Best-effort support** means that there's no formal agreement or
 commitment to solve a problem but the community appreciates the
 importance of addressing the problem as soon as possible. The community commits
-to helping you diagnose and address the problem if all the following are true:
+to helping you diagnose and address the problem if all of the following requirements are satisfied:
 
 * The cause falls within the technical framework that Kubeflow controls. For
   example, the Kubeflow community may not be able to help if the problem is 
@@ -53,7 +53,6 @@ You can ask questions and make suggestions in the following places:
 
   * [Kubeflow installation and setup](/docs/started/installing-kubeflow/)
   * [Kubeflow components](/docs/components/)
-  * [Further setup and troubleshooting](/docs/other-guides/)
 
 * **Kubeflow issue trackers** for known issues, questions, and feature requests.
   Search the open issues to see if someone else has already logged the problem 

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -78,13 +78,13 @@ You can ask questions and make suggestions in the following places:
 We want to promote commercial companies and idividuals that contribute back to the open source project.
 Below is a table of organizations that contribute to Kubeflow and offer commercial support:
 
-| Provider                      | Support Link                                                                                                                    |
-|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| Aranui Solutions              | [Aranui Solutions](https://www.aranui.solutions/services)                                                                       |
-| Canonical                     | [Ubuntu Kubeflow](https://ubuntu.com/kubeflow#get-in-touch)                                                                     |
-| Freelancer Julius von Kohout  | [LinkedIn](https://de.linkedin.com/in/juliusvonkohout/), Slack: Julius von Kohout, [GitHub](https://github.com/juliusvonkohout) |
-| Red Hat                       | [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai)                                        |
-| Other Providers               | Please reach out to the KSC with enough proof of contributions to the Kubeflow open source peoject                              |
+| Provider                      | Support Link                                                                                                                                                   |
+|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Aranui Solutions              | [Aranui Solutions](https://www.aranui.solutions/services)                                                                                                      |
+| Canonical                     | [Ubuntu Kubeflow](https://ubuntu.com/kubeflow#get-in-touch)                                                                                                    |
+| Freelancer Julius von Kohout  | [LinkedIn](https://de.linkedin.com/in/juliusvonkohout/), [Slack](https://cloud-native.slack.com/team/U06LW431SJF), [GitHub](https://github.com/juliusvonkohout) |
+| Red Hat                       | [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai)                                                                       |
+| Other Providers               | Please reach out to the KSC with enough proof of contributions to the Kubeflow open source peoject                                                             |
 
 <a id="cloud-support"></a>
 If you are using a managed offer from a cloud provider for Kubeflow, then the cloud

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -9,10 +9,9 @@ This page describes the Kubeflow resources and support options available when yo
 <a id="application-status"></a>
 ## Component Status
 
-When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple components. Note that component versioning is independent from Kubeflow versioning. Each component should meet certain criteria regarding stability, upgradability, logging, monitoring, and security (such as adherence to PodSecurity standards, network policies, and integration tests for authentication and authorization).
+When you deploy Kubeflow to a Kubernetes cluster, your deployment includes multiple components. Note that component versioning is independent from Kubeflow versioning. Each component should meet certain [criteria](https://github.com/kubeflow/community/blob/master/guidelines/application_requirements.md) regarding stability, upgradability, logging, monitoring, and security (such as adherence to PodSecurity standards restricted, network policies, and integration tests for authentication and authorization).
 
-Application status indicators for Kubeflow:
-
+Component status indicators:
 * **Stable**: The application complies with most of the criteria and is considered stable for this release.
 * **Beta**: The application is progressing toward meeting all criteria.
 * **Alpha**: The application is in early development or integration stages.
@@ -20,9 +19,8 @@ Application status indicators for Kubeflow:
 <a id="levels-of-support"></a>
 ## Levels of Support
 
-The following table describes the level of support that you can expect based on the status of an application:
-
-The Kubeflow community offers best-effort support for stable components. See the section on community support below for a definition of best-effort support and the community channels where you can report and discuss the problem. You can also consider requesting  support from a commercial company or freelancer listed below.
+- The Kubeflow community offers best-effort support for stable components.
+- You can also consider requesting  support from a commercial company or freelancer listed below.
 
 <a id="community-support"></a>
 ## Support from the Kubeflow community

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -41,10 +41,9 @@ to helping you diagnose and address the problem if all the following are true:
 * Community members can reproduce the problem.
 * The reporter can assist with troubleshooting.
 
-usYou can ask questions and make suggestions in the following places:
+You can ask questions and make suggestions in the following places:
 
-* **Slack** for online chat and messaging. See details of Kubeflow's 
-  [Slack workspace and channels](/docs/about/community/#kubeflow-slack).
+* **Slack** for online chat and messaging, see [Slack workspace and channels](/docs/about/community/#kubeflow-slack-channels).
 * **Github discussions** TODO
 * **Kubeflow discuss** for email-based group discussion. Join the
   [kubeflow-discuss](/docs/about/community/#kubeflow-mailing-list)
@@ -52,7 +51,7 @@ usYou can ask questions and make suggestions in the following places:
 * **Kubeflow documentation** for overviews and how-to guides. In particular,
   refer to the following documents when troubleshooting a problem:
 
-  * [Kubeflow installation and setup](/docs/started/getting-started/)
+  * [Kubeflow installation and setup](/docs/started/installing-kubeflow/)
   * [Kubeflow components](/docs/components/)
   * [Further setup and troubleshooting](/docs/other-guides/)
 
@@ -65,18 +64,18 @@ usYou can ask questions and make suggestions in the following places:
     organization on GitHub](https://github.com/kubeflow). To get you started,
     here are the primary issue trackers:
 
-  * [Platform / Manifests](https://github.com/kubeflow/manifests/issues)
   * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/issues)
   * [Katib AutoML](https://github.com/kubeflow/katib/issues)
   * [Trainer](https://github.com/kubeflow/training-operator/issues)
   * [Notebooks](https://github.com/kubeflow/notebooks/issues)
   * [Dashboard](https://github.com/kubeflow/dashboard/issues)
   * [Kserve](https://github.com/kserve/kserve/issues)
+  * [Platform / Manifests](https://github.com/kubeflow/manifests/issues)
   * [Examples](https://github.com/kubeflow/examples/issues)
   * [Website](https://github.com/kubeflow/website/issues)
 
 <a id="provider-support"></a>
-## Support from Providers in the Kubeflow Ecosystem
+## Support from commercial providers in the Kubeflow Ecosystem
 
 Below is a table of organizations that contribute to Kubeflow and offer commercial support:
 

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -67,6 +67,7 @@ You can ask questions and make suggestions in the following places:
   * [Kubeflow Katib](https://github.com/kubeflow/katib/issues)
   * [Kubeflow Trainer](https://github.com/kubeflow/trainer/issues)
   * [Kubeflow Notebooks](https://github.com/kubeflow/notebooks/issues)
+  * [Kubeflow Model Registry](https://github.com/kubeflow/model-registry/issues)
   * [Kubeflow Dashboard](https://github.com/kubeflow/dashboard/issues)
   * [Kubeflow Kserve](https://github.com/kserve/kserve/issues)
   * [Kubeflow Platform / Manifests](https://github.com/kubeflow/manifests/issues)

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -20,14 +20,14 @@ Component status indicators:
 <a id="levels-of-support"></a>
 ## Levels of Support
 
-1. The Kubeflow community offers best-effort support for stable components.
+1. The Kubeflow community provides best-effort support for stable components.
 2. You can also request commercial support from a company or freelancer listed below.
 
 <a id="community-support"></a>
 ## Support from the Kubeflow community
 
 Kubeflow has an active and helpful community of users and contributors. 
-The Kubeflow community offers support on a best-effort basis for stable and beta
+The Kubeflow community provides support on a best-effort basis for stable and beta
 applications. If you need commercial support, please check the sections below.
 
 **Best-effort support** means that there's no formal agreement or
@@ -78,13 +78,13 @@ You can ask questions and make suggestions in the following places:
 We want to promote commercial companies and idividuals that contribute back to the open source project.
 Below is a table of organizations that contribute to Kubeflow and offer commercial support:
 
-| Provider               | Support Link                                                   |
-|------------------------|----------------------------------------------------------------|
-| Canonical              | [Ubuntu Kubeflow](https://ubuntu.com/kubeflow#get-in-touch)    |
-| Aranui Solutions       | [Aranui Solutions](https://...)                                |
-| Freelance/Consulting   | Julius von Kohout on the Slack channel                         |
-| Red Hat                | [Red Hat](https://...)                                         |
-| Other Providers        | ...                                                            |
+| Provider                      | Support Link                                                                                                                    |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| Aranui Solutions              | [Aranui Solutions](https://www.aranui.solutions/services)                                                                       |
+| Canonical                     | [Ubuntu Kubeflow](https://ubuntu.com/kubeflow#get-in-touch)                                                                     |
+| Freelancer Julius von Kohout  | [LinkedIn](https://de.linkedin.com/in/juliusvonkohout/), Slack: Julius von Kohout, [GitHub](https://github.com/juliusvonkohout) |
+| Red Hat                       | [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai)                                        |
+| Other Providers               | Please reach out to the KSC with enough proof of contributions to the Kubeflow open source peoject                              |
 
 <a id="cloud-support"></a>
 If you are using a managed offer from a cloud provider for Kubeflow, then the cloud

--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -78,13 +78,13 @@ You can ask questions and make suggestions in the following places:
 We want to promote commercial companies and idividuals that contribute back to the open source project.
 Below is a table of organizations that contribute to Kubeflow and offer commercial support:
 
-| Provider                      | Support Link                                                                                                                                                   |
-|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Aranui Solutions              | [Aranui Solutions](https://www.aranui.solutions/services)                                                                                                      |
-| Canonical                     | [Ubuntu Kubeflow](https://ubuntu.com/kubeflow#get-in-touch)                                                                                                    |
+| Provider                      | Support Link                                                                                                                                                    |
+|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Aranui Solutions              | [Aranui Solutions](https://www.aranui.solutions/services)                                                                                                       |
+| Canonical                     | [Ubuntu Kubeflow](https://ubuntu.com/kubeflow#get-in-touch)                                                                                                     |
 | Freelancer Julius von Kohout  | [LinkedIn](https://de.linkedin.com/in/juliusvonkohout/), [Slack](https://cloud-native.slack.com/team/U06LW431SJF), [GitHub](https://github.com/juliusvonkohout) |
-| Red Hat                       | [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai)                                                                       |
-| Other Providers               | Please reach out to the KSC with enough proof of contributions to the Kubeflow open source peoject                                                             |
+| Red Hat                       | [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai)                                                                        |
+| Other Providers               | Please reach out to the Kubeflow Steering Committee with proof of significant contributions to the Kubeflow open source project                                 |
 
 <a id="cloud-support"></a>
 If you are using a managed offer from a cloud provider for Kubeflow, then the cloud


### PR DESCRIPTION
The goal is to improve the status quo. It also removes some bankrupt companies or companies that are not actively involved with Kubeflow anymore.

Here is a screenshot
![image](https://github.com/user-attachments/assets/145705a2-74a0-4778-8657-797b1c0c35f5)


<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)