### PR TITLE
fix: SeaweedFS PoC link in GSoC project

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2025.md
+++ b/content/en/events/upcoming-events/gsoc-2025.md
@@ -87,7 +87,7 @@ To participate in GSoC with Kubeflow, you **must** meet the GSoC [eligibility re
 
 **Possible Projects:**
 
-- Pipelines: productionize the [SeaweedFS PoC](https://github.com/kubeflow/manifests/tree/master/contrib/seaweedfs) as secure minio replacement
+- Pipelines: productionize the [SeaweedFS PoC](https://github.com/kubeflow/manifests/tree/master/experimental/seaweedfs) as secure minio replacement
 - Pipelines: isolate artifacts per namespace/profile/user using only one bucket ([`kubeflow/pipelines#4649`](https://github.com/kubeflow/pipelines/issues/4649))
 - Notebooks/Dashboard: migrate code to kubeflow/dashboard and kubeflow/notebooks ([`kubeflow/kubeflow#7549`](https://github.com/kubeflow/kubeflow/issues/7549))
 - Dashboard: work on the Central Dashboard angular rewrite ([`kubeflow/dashboard#38`](https://github.com/kubeflow/dashboard/issues/38))


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [ ] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
<!-- /area website -->
<!-- /area community -->
---

