### PR TITLE
Fix grammar in "Quirks of the process" section on the Contributing page 

### DIFF
--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -205,9 +205,7 @@ GitHub usernames and aliases listed in OWNERS files are case-insensitive.
 
 ### Quirks of the process
 
-There are a number of behaviors we've observed that while _possible_ are discouraged, as they go
-against the intent of this review process. Some of these could be prevented in the future, but this
-is the state of today.
+There are a number of behaviors we’ve observed that, while possible, are discouraged, as they go against the intent of this review process. Some of these could be prevented in the future, but this is the state of things today.
 
 - An **approver**'s `/lgtm` is simultaneously interpreted as an `/approve`
   - While a convenient shortcut for some, it can be surprising that the same command is interpreted


### PR DESCRIPTION
**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [x] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**
This pull request makes two grammatical corrections in the “Quirks of the process” section of the Contributing page to improve clarity and readability:

 **Comma Placement:**
        Before: “There are a number of behaviors we’ve observed that while possible are discouraged…”
        After: “There are a number of behaviors we’ve observed that, while possible, are discouraged…”
        Explanation: Adding commas around “while possible” correctly sets off the clause, clarifying the sentence structure.

**Phrasing Update:**
        Before: “…but this is the state of today.”
        After: “…but this is the state of things today.”
        Explanation: Changing the phrasing to “state of things today” makes the sentence more natural and clear.


<!-- /area website -->

---

![Screenshot from 2025-03-08 18-40-30](https://github.com/user-attachments/assets/3777ab33-58d5-44d8-9433-9a693a8f31b1)