### PR TITLE
fixed the link to the trainer python sdk

### DIFF
--- a/content/en/docs/started/architecture.md
+++ b/content/en/docs/started/architecture.md
@@ -138,7 +138,7 @@ See the following sets of reference documentation:
 - [Pipelines reference docs](/docs/components/pipelines/reference/) for the Kubeflow
   Pipelines API and SDK, including the Kubeflow Pipelines domain-specific
   language (DSL).
-- [Kubeflow Python SDK](https://github.com/kubeflow/training-operator/blob/master/sdk_v2/kubeflow/training/api/training_client.py)
+- [Kubeflow Python SDK](https://github.com/kubeflow/trainer/blob/master/sdk/kubeflow/trainer/api/trainer_client.py)
   to interact with Kubeflow Trainer APIs and to manage TrainJobs.
 - [Katib Python SDK](https://github.com/kubeflow/katib/blob/086093fed72610c227e3ae1b4044f27afa940852/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py)
   to manage Katib hyperparameter tuning Experiments using Python APIs.


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [ ] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**

corrects a link on the website to the python sdk.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
<!-- /area website -->
<!-- /area community -->
---

