### PR TITLE
trainer: update get-started example of trainer.

### DIFF
--- a/content/en/docs/components/trainer/getting-started.md
+++ b/content/en/docs/components/trainer/getting-started.md
@@ -130,7 +130,7 @@ def train_pytorch():
 After configuring the training function, check the available Kubeflow Training Runtimes:
 
 ```python
-from kubeflow.trainer import TrainerClient, Trainer
+from kubeflow.trainer import TrainerClient, CustomTrainer
 
 for r in TrainerClient().list_runtimes():
     print(f"Runtime: {r.name}")
@@ -147,7 +147,7 @@ Create a TrainJob using the `torch-distributed` Runtime, which scales your train
 
 ```python
 job_id = TrainerClient().train(
-    trainer=Trainer(
+    trainer=CustomTrainer(
         func=train_pytorch,
         num_nodes=4,
         resources_per_node={


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [x] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**

Update the get-started example of trainer according to changes in `train()` API: https://github.com/kubeflow/trainer/pull/2513

- Rename `Trainer` to `CustomTrainer`

/cc @andreyvelich 

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->
/area trainer
<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
<!-- /area website -->
<!-- /area community -->
---

