### PR TITLE
trainer: update getting-started.md to reflect API changes

### DIFF
--- a/content/en/docs/components/trainer/getting-started.md
+++ b/content/en/docs/components/trainer/getting-started.md
@@ -24,7 +24,7 @@ pip install git+https://github.com/kubeflow/trainer.git@master#subdirectory=sdk
 
 ## Getting Started with PyTorch
 
-Before creating a Kubeflow TrainJob, defines the training function that handles end-to-end model
+Before creating a Kubeflow TrainJob, define the training function that handles end-to-end model
 training. Each PyTorch node will execute this function within the configured distributed environment.
 Typically, this function includes steps to download the dataset, initialize the model, and train it.
 
@@ -156,24 +156,24 @@ job_id = TrainerClient().train(
             "gpu": 1, # Comment this line if you don't have GPUs.
         },
     ),
-    runtime_ref="torch-distributed",
+    runtime=TrainerClient().get_runtime("torch-distributed"),
 )
 ```
 
-You can check the components of the TrainJob and the number of devices each PyTorch node is using:
+You can check the steps of the TrainJob and the number of devices each PyTorch node is using:
 
 ```python
-for c in TrainerClient().get_job(name=job_id).components:
-    print(f"Component: {c.name}, Status: {c.status}, Devices: {c.device} x {c.device_count}")
+for s in TrainerClient().get_job(name=job_id).steps:
+    print(f"Step: {s.name}, Status: {s.status}, Devices: {s.device} x {s.device_count}")
 ```
 
 The output:
 
 ```python
-Component: trainer-node-0, Status: Succeeded, Devices: gpu x 1
-Component: trainer-node-1, Status: Succeeded, Devices: gpu x 1
-Component: trainer-node-2, Status: Succeeded, Devices: gpu x 1
-Component: trainer-node-3, Status: Succeeded, Devices: gpu x 1
+Step: node-0, Status: Succeeded, Devices: gpu x 1
+Step: node-1, Status: Succeeded, Devices: gpu x 1
+Step: node-2, Status: Succeeded, Devices: gpu x 1
+Step: node-3, Status: Succeeded, Devices: gpu x 1
 ```
 
 Finally, you can check the training logs from the master node:
@@ -181,7 +181,7 @@ Finally, you can check the training logs from the master node:
 ```python
 logs = TrainerClient().get_job_logs(name=job_id)
 
-print(logs["trainer-node-0"])
+print(logs["node-0"])
 ```
 
 Since training was run on 4 GPUs, each PyTorch node processes 60,000 / 4 = 15,000 images


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [ ] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**

The getting-started page for Kubeflow Trainer requires updates to reflect the following API changes:
- The `TrainerClient().train` function now takes a `runtime` instead of a `runtime_ref`.
- A `TrainJob` no longer has the `components` attribute. The `steps` attribute is now used instead.
- `Step` names are prefixed with `node-` instead of `trainer-node-`.

A minor spelling change (`defines` to `define`) was also updated in this PR.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
/area trainer
<!-- /area gsoc -->
/area website
<!-- /area community -->
---

