### PR TITLE
Webiste: Adjust contributor progression guidelines to foster community growth

### DIFF
--- a/content/en/docs/about/membership.md
+++ b/content/en/docs/about/membership.md
@@ -94,7 +94,7 @@ Acceptance of code contributions requires at least one approver in addition to t
 
 The following apply to the part of codebase for which one would be a reviewer in an [OWNERS](/docs/about/contributing/#owners) file.
 
-- member for at least 3 months
+- Demonstrated consistent contributions for at least 2 to 3 months since their first contribution
 - Primary reviewer for at least 5 PRs to the codebase
 - Reviewed or merged at least 15 substantial PRs to the codebase
 - Knowledgeable about the codebase


### PR DESCRIPTION

**Checklist:**
- [ x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [x] You have included screenshots when changing the website style or adding a new page.

**Description of your changes:**
A minor variation to the requirements of the Kubeflow membership agreement. 

The suggestion is to start the reviewer vetting period from the first contribution rather than from membership.

### Issue
As being owner and contributor of the Model registry component and part of the community what I observed is

- The current process from new member to committer takes too long (7-12 months) in the best-case scenario.
- There are artificial time constraints between stages that may be unnecessary.
- IMO, it is not balanced towards fairness and community growth.
- We should be placing the importance of observing contributions over time not artificially keeping someone out. 
- I do hope this encourages more active participation from new contributors, and recognize them quickly.
- IMO, there is not much difference between the reviewer and member as both can do this task; it is more on the approver to trust the reviewer; time is not giving any trust, anyway, I did not make any changes there.
- full disclaimer, I do have many associates who are trying to earn their stripes and mentioned to me that this is a concern.

</area website>
