### PR TITLE
pipelines: updated KFP component concept page

### DIFF
--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -151,9 +151,9 @@ kfp component build --component-filepattern the_component.py --no-build-image --
 Note that creating and maintaining custom containers can carry a significant maintenance burden. In general, a 1-to-1 relationship between components and containers is not needed or recommended, as AI/ML work is often highly iterative. A best practice is to work with a small set of base images that can support many components. If you need more control over the container build than the `kfp` CLI provides, consider using a container CLI like [docker][docker-cli] or [podman][podman-cli].
 
 
-[pipeline]: /docs/components/concepts/pipeline.md
+[pipeline]: /docs/components/pipelines/concepts/pipeline
 [KFP SDK]: https://kubeflow-pipelines.readthedocs.io
-[artifacts]: /docs/components/concepts/output-artifact.md
+[artifacts]: /docs/components/pipelines/concepts/output-artifact
 [python-sdk-component]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.component
 [yaml-component]: /docs/components/pipelines/reference/component-spec
 [docker-cli]: https://github.com/docker/cli

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -2,66 +2,159 @@
 title = "Component"
 description = "Conceptual overview of components in Kubeflow Pipelines"
 weight = 20
-                    
 +++
 
-A *pipeline component* is self-contained set of code that performs one step in
-the ML workflow (pipeline), such as data preprocessing, data transformation,
-model training, and so on. A component is analogous to a function, in that it
-has a name, parameters, return values, and a body.
 
-## Component code
+A **pipeline component** is the fundamental building block for ML engineers to construct a Kubeflow Pipelines [pipeline][pipeline]. The component structure serves the purpose of packaging a functional unit of code along with its dependencies, so that it can be run as part of a workflow in a Kubernetes-based environement. Components can be combined in a [pipeline][pipeline] that creates a repeatable workflow, with individual components coordinating on inputs and outputs like parameters and [artifacts][artifacts].
 
-The code for each component includes the following:
+A component is similar to a programming function. Indeed, it is most often implemented as a wrapper to a Python function using the [KFP Python SDK][KFP SDK]. However, a KFP component goes further than a simple function, with support for code dependencies, runtime environments, and distributed execution requirements.
 
-* **Client code:** The code that talks to endpoints to submit jobs. For example, 
-  code to talk to the Google Dataproc API to submit a Spark job.
+KFP components are designed to simplify constructing and running ML workflows in a Kubernetes-based environment. Using KFP components engineers can iterate faster, reduce maintenance overhead, and focus more attention on ML work.
 
-* **Runtime code:** The code that does the actual job and usually runs in the 
-  cluster. For example, Spark code that transforms raw data into preprocessed 
-  data.
+## The Why Behind KFP Components
 
-Note the naming convention for client code and runtime code&mdash;for a task 
-named "mytask":
+Running ML code in a Kubernetes-based cluster presents many challenges. Some of the main challenges are:
+- Managing **code dependencies** (Python libraries and versions)
+- Handling **system dependencies** (OS-level packages, GPU drivers, runtime environments)
+- **Building and maintaining container images** and everything around this from container registry support to CVE (Common Vulnerabilities and Exposures) fixes
+- **Deploying supporting resources** like PersistentVolumeClaims and ConfigMaps
+- Handling **inputs and outputs** including metadata, parameters, logs, and artifacts
+- **Ensuring compatibility** across clusters, images, and dependencies
 
-* The `mytask.py` program contains the client code.
-* The `mytask` directory contains all the runtime code.
+KFP components simplify these challenges by enabling ML engineers to:
+- **Stay at the Python level** - where most modern ML work occurs
+- **Iterate quickly** – modify code without creating or rebuilding containers at each step
+- **Focus on ML tasks** - rather than on platform and infrastructure concerns
+- **Work seamlessly with Python IDE tools** – enable debugging, syntax highlighting, type checking, and docstring usage
+- **Move between environments** – transition from local development to distributed execution with minimal changes
 
-## Component definition
+## What Does a Component Consist Of?
 
-A component specification in YAML format describes the component for the
-Kubeflow Pipelines system. A component definition has the following parts:
+A KFP component consist of the following key elements:
+
+### 1. Code
+- Typically a Python function, but can be other code such as a Bash command.
+
+### 2. Dependency Support
+- **Python libraries** - to be installed at runtime
+- **Environment variables** - to be available in the runtime environment
+- **Python package indices** - (for example, private PyPi servers) if needed to support installations
+- **Cluster resources** - to support use of ConfigMaps, Secrets, PersistentVolumeClaims, and more
+- **Runtime dependencies** - to support CPU, memory, and GPU requests and limits
+
+### 3. Base Image
+- Defines the base container runtime environment
+- May include system dependencies and pre-installed Python libraries
+
+### 4. Input/Output (I/O) Specification
+- Individual components cannot share in-memory data with each other, so they use the following concepts to support exchanging information and publishing results:
+  - **Parameters** – for small values
+  - **[Artifacts][artifacts]** - for larger data like model files, processed datasets, and metadata
+
+## Constructing a Component
+
+### 1. Python-Based Components
+The recommended way to define a component is using the `@dsl.component` decorator from the [KFP Python SDK][KFP SDK]. Below are two basic component definition examples:
+```python
+from kfp.dsl import component, Output, Dataset
+
+# hello component
+@component()
+def hello_world(name: str = "World") -> str:
+    print(f"Hello {name}!")
+    return name
+
+# process data component
+@component(
+    base_image="python:3.12-slim-bookworm",
+    packages_to_install=["pandas>=2.2.3"],
+)
+def process_data(output_data: Output[Dataset]):
+    '''Get max from an array'''
+    import pandas as pd
+   # create dataset to write to output
+    data = pd.DataFrame(data=[[1,2,3],[4,5,6]], columns=["a","b","c"])
+    data.to_csv(output_data.path)
+```
+
+Observe that these are wrapped Python functions. The `@component` wrapper helps the KFP Python SDK supply the needed context for running these functions in containers as part of a KFP [pipeline][pipeline].
+
+The `hello_world` component just uses default behavior (run the Python function on the default base image, which is `python:3.9`). The `process_data` component adds layers of customization, by supplying the name of a specific `base_image`, and `packages_to_install`. This component also uses KFP's `Output[Dataset]` class, which takes care of creating a KFP [artifact][artifact] type output.
+
+Note that inputs and outputs are defined as Python function parameters. Also, dependencies can often be installed at runtime, avoiding the need for custom base containers. Python-based components give close access to the Python tools that ML experimenters rely on, like modules and imports, usage information, type hints, and debugging tools.
+
+Provided that dependencies are satisfied in your environment, it is also easy to run Python-based components as simple Python functions, which can be useful for local work. For example, to run `process_data` as a Python function try:
+``` python
+# Provide path as dataset type (as the function expects)
+dataset = Dataset(uri="data.csv")
+# execute the function
+# (writes data to data.csv locally)
+process_data.execute(output_data=dataset)
+# access the underlying function docstring
+print(process_data.python_func.__doc__)
+```
+
+Component usage can get much more complex, as AI/ML use-cases often have demanding code and environment dependencies. For more on Python-based components, see the [component][python-sdk-component] SDK documentation.
+
+
+### 2. YAML-Based Components
+
+The KFP backend uses YAML-based definitions to specify components. While the [KFP Python SDK][KFP SDK] can do this conversion automatically when a Python-based [pipeline][pipeline] is submitted, some use-cases can benefit from the direct YAML-based component approach.
+
+A YAML-based component definition has the following parts:
 
 * **Metadata:** name, description, etc.
-* **Interface:** input/output specifications (name, type, description, default 
-  value, etc).
-* **Implementation:** A specification of how to run the component given a 
-  set of argument values for the component's inputs. The implementation section 
-  also describes how to get the output values from the component once the
-  component has finished running.
+* **Interface:** input/output specifications (name, type, description, default value, etc).
+* **Implementation:** A specification of how to run the component given a set of argument values for the component’s inputs. The implementation section also describes how to get the output values from the component once the component has finished running.
 
-For the complete definition of a component, see the
-[component specification](/docs/components/pipelines/reference/component-spec/).
+YAML-based components support system commands directly. Here is simple YAML-based component example:
+```yaml
+# my_component.yaml file
+name: my-component
+description:
 
-## Containerizing components
+inputs:
+- {name: string prefix, type: String}
+- {name: num, type: Integer}
 
-You must package your component as a 
-[Docker image](https://docs.docker.com/get-started/). Components represent a 
-specific program or entry point inside a container.
+outputs:
 
-Each component in a pipeline executes independently. The components do not run
-in the same process and cannot directly share in-memory data. You must serialize
-(to strings or files) all the data pieces that you pass between the components
-so that the data can travel over the distributed network. You must then
-deserialize the data for use in the downstream component.
+implementation:
+  container:
+    image: python:3.12-slim-bookworm
+    args:
+    - echo
+    - {inputValue: string prefix}
+    - ...
+    - {inputValue: num}
+```
 
-## Next steps
+For the complete definition of a YAML-based component, see the [component specification][yaml-component].
 
-* Read an [overview of Kubeflow Pipelines](/docs/components/pipelines/overview/).
-* Follow the [pipelines quickstart guide](/docs/components/pipelines/getting-started/) 
-  to deploy Kubeflow and run a sample pipeline directly from the Kubeflow 
-  Pipelines UI.
-* Build your own 
-  [component and pipeline](/docs/components/pipelines/legacy-v1/sdk/component-development/).
-* Build a [reusable component](/docs/components/pipelines/legacy-v1/sdk/component-development/) for
-  sharing in multiple pipelines.
+YAML-based components can be loaded for use in the Python SDK alongside Python-based components:
+```python
+from kfp.components import load_component_from_file
+
+my_comp = load_component_from_file("my_component.yaml")
+```
+
+Note that a component loaded from a YAML-based component will not have the same level of Python support that Python-based components do (like executing the function locally).
+
+
+## "Containerize" a Component
+
+The KFP command-line tool contains a build command to help users "containerize" a component. This can be used to create the `Dockerfile`, `runtime-dependencies.txt`, and other supporting files, or even to build the custom image and push it to a registry. In order to use this utility, the `target_image` parameter must be set in the Python-based component definition, which itself is saved in a file.
+```bash
+# build Dockerfile and runtime-dependencies.txt
+kfp component build --component-filepattern the_component.py --no-build-image --platform linux/amd64 .
+```
+Note that creating and maintaining custom containers can carry a significant maintenance burden. In general, a 1-to-1 relationship between components and containers is not needed or recommended, as AI/ML work is often highly iterative. A best practice is to work with a small set of base images that can support many components. If you need more control over the container build than the `kfp` CLI provides, consider using a container CLI like [docker][docker-cli] or [podman][podman-cli].
+
+
+[pipeline]: /docs/components/concepts/pipeline.md
+[KFP SDK]: https://kubeflow-pipelines.readthedocs.io
+[artifacts]: /docs/components/concepts/output-artifact.md
+[python-sdk-component]: https://kubeflow-pipelines.readthedocs.io/en/stable/source/dsl.html#kfp.dsl.component
+[yaml-component]: /docs/components/pipelines/reference/component-spec
+[docker-cli]: https://github.com/docker/cli
+[podman-cli]: https://github.com/containers/podman

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -9,7 +9,7 @@ A **pipeline component** is the fundamental building block for an ML engineer to
 
 A component is similar to a programming function. Indeed, it is most often implemented as a wrapper to a Python function using the [KFP Python SDK][KFP SDK]. However, a KFP component goes further than a simple function, with support for code dependencies, runtime environments, and distributed execution requirements.
 
-KFP components are designed to simplify constructing and running ML workflows in a Kubernetes environment. Using KFP components engineers can iterate faster, reduce maintenance overhead, and focus more attention on ML work.
+KFP components are designed to simplify constructing and running ML workflows in a Kubernetes environment. Using KFP components, engineers can iterate faster, reduce maintenance overhead, and focus more attention on ML work.
 
 ## The Why Behind KFP Components
 
@@ -58,7 +58,7 @@ The recommended way to define a component is using the `@dsl.component` decorato
 ```python
 from kfp.dsl import component, Output, Dataset
 
-# hello component
+# hello world component
 @component()
 def hello_world(name: str = "World") -> str:
     print(f"Hello {name}!")

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -140,6 +140,7 @@ my_comp = load_component_from_file("my_component.yaml")
 
 Note that a component loaded from a YAML-based component will not have the same level of Python support that Python-based components do (like executing the function locally).
 
+<!-- TODO: Briefly discuss graph components, container components, and importer components (see sdk dsl scripts) -->
 
 ## "Containerize" a Component
 

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -81,7 +81,7 @@ Observe that these are wrapped Python functions. The `@component` wrapper helps 
 
 The `hello_world` component just uses the default behavior, which is to run the Python function on the default base image (`python:3.9`). 
 
-The `process_data` component adds layers of customization, by supplying the name of a specific `base_image`, and `packages_to_install`. Note the inclusion of the `import pandas as pd` statement inside the function; since the function will run inside a container (and won't have the script context), all non-builtin Python library dependencies need to be imported within the component function. This component also uses KFP's `Output[Dataset]` class, which takes care of creating a KFP [artifact][artifact] type output. 
+The `process_data` component adds layers of customization, by supplying the name of a specific `base_image`, and `packages_to_install`. Note the inclusion of the `import pandas as pd` statement inside the function; since the function will run inside a container (and won't have the script context), all non-builtin Python library dependencies need to be imported within the component function. This component also uses KFP's `Output[Dataset]` class, which takes care of creating a KFP [artifact][artifacts] type output. 
 
 Note that inputs and outputs are defined as Python function parameters. Also, dependencies can often be installed at runtime, avoiding the need for custom base containers. Python-based components give close access to the Python tools that ML experimenters rely on, like modules and imports, usage information, type hints, and debugging tools.
 
@@ -115,13 +115,13 @@ YAML-based components support system commands directly. In fact, any command (or
 ```yaml
 # my_component.yaml file
 name: my-component
-description:
+description: "Component that outputs \"<string prefix>...<num>\""
 
 inputs:
 - {name: string prefix, type: String}
 - {name: num, type: Integer}
 
-outputs:
+outputs: []
 
 implementation:
   container:

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -79,7 +79,7 @@ def process_data(output_data: Output[Dataset]):
 
 Observe that these are wrapped Python functions. The `@component` wrapper helps the KFP Python SDK supply the needed context for running these functions in containers as part of a KFP [pipeline][pipeline].
 
-The `hello_world` component just uses the default behavior, which is to run the Python function on the default base image (`python:3.9`). 
+The `hello_world` component just uses the default behavior, which is to run the Python function on the default base image (`kfp.dsl.component_factory._DEFAULT_BASE_IMAGE`).
 
 The `process_data` component adds layers of customization, by supplying the name of a specific `base_image`, and `packages_to_install`. Note the inclusion of the `import pandas as pd` statement inside the function; since the function will run inside a container (and won't have the script context), all Python library dependencies need to be imported within the component function. This component also uses KFP's `Output[Dataset]` class, which takes care of creating a KFP [artifact][artifacts] type output. 
 

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -81,7 +81,7 @@ Observe that these are wrapped Python functions. The `@component` wrapper helps 
 
 The `hello_world` component just uses the default behavior, which is to run the Python function on the default base image (`python:3.9`). 
 
-The `process_data` component adds layers of customization, by supplying the name of a specific `base_image`, and `packages_to_install`. Note the inclusion of the `import pandas as pd` statement inside the function; since the function will run inside a container (and won't have the script context), all non-builtin Python library dependencies need to be imported within the component function. This component also uses KFP's `Output[Dataset]` class, which takes care of creating a KFP [artifact][artifacts] type output. 
+The `process_data` component adds layers of customization, by supplying the name of a specific `base_image`, and `packages_to_install`. Note the inclusion of the `import pandas as pd` statement inside the function; since the function will run inside a container (and won't have the script context), all Python library dependencies need to be imported within the component function. This component also uses KFP's `Output[Dataset]` class, which takes care of creating a KFP [artifact][artifacts] type output. 
 
 Note that inputs and outputs are defined as Python function parameters. Also, dependencies can often be installed at runtime, avoiding the need for custom base containers. Python-based components give close access to the Python tools that ML experimenters rely on, like modules and imports, usage information, type hints, and debugging tools.
 

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -43,7 +43,7 @@ A KFP component consist of the following key elements:
 - **Runtime dependencies** - to support CPU, memory, and GPU requests and limits
 
 ### 3. Base Image
-- Defines the base container runtime environment
+- Defines the base container runtime environment (defaults to a generic Python base image)
 - May include system dependencies and pre-installed Python libraries
 
 ### 4. Input/Output (I/O) Specification
@@ -79,10 +79,14 @@ def process_data(output_data: Output[Dataset]):
 
 Observe that these are wrapped Python functions. The `@component` wrapper helps the KFP Python SDK supply the needed context for running these functions in containers as part of a KFP [pipeline][pipeline].
 
-The `hello_world` component just uses default behavior (run the Python function on the default base image, which is `python:3.9`). The `process_data` component adds layers of customization, by supplying the name of a specific `base_image`, and `packages_to_install`. This component also uses KFP's `Output[Dataset]` class, which takes care of creating a KFP [artifact][artifact] type output.
+The `hello_world` component just uses the default behavior, which is to run the Python function on the default base image (`python:3.9`). 
+
+The `process_data` component adds layers of customization, by supplying the name of a specific `base_image`, and `packages_to_install`. Note the inclusion of the `import pandas as pd` statement inside the function; since the function will run inside a container (and won't have the script context), all non-builtin Python library dependencies need to be imported within the component function. This component also uses KFP's `Output[Dataset]` class, which takes care of creating a KFP [artifact][artifact] type output. 
 
 Note that inputs and outputs are defined as Python function parameters. Also, dependencies can often be installed at runtime, avoiding the need for custom base containers. Python-based components give close access to the Python tools that ML experimenters rely on, like modules and imports, usage information, type hints, and debugging tools.
 
+
+#### Run a Component's Python Function
 Provided that dependencies are satisfied in your environment, it is also easy to run Python-based components as simple Python functions, which can be useful for local work. For example, to run `process_data` as a Python function try:
 ``` python
 # Provide path as dataset type (as the function expects)
@@ -94,7 +98,7 @@ process_data.execute(output_data=dataset)
 print(process_data.python_func.__doc__)
 ```
 
-Component usage can get much more complex, as AI/ML use-cases often have demanding code and environment dependencies. For more on Python-based components, see the [component][python-sdk-component] SDK documentation.
+Component usage can get much more complex, as AI/ML use-cases often have demanding code and environment dependencies. For more on creating Python-based components, see the [component][python-sdk-component] SDK documentation.
 
 
 ### 2. YAML-Based Components
@@ -107,7 +111,7 @@ A YAML-based component definition has the following parts:
 * **Interface:** input/output specifications (name, type, description, default value, etc).
 * **Implementation:** A specification of how to run the component given a set of argument values for the component’s inputs. The implementation section also describes how to get the output values from the component once the component has finished running.
 
-YAML-based components support system commands directly. Here is simple YAML-based component example:
+YAML-based components support system commands directly. In fact, any command (or binary) that exists on the base image can be run. Here is simple YAML-based component example:
 ```yaml
 # my_component.yaml file
 name: my-component
@@ -151,8 +155,10 @@ kfp component build --component-filepattern the_component.py --no-build-image --
 ```
 Note that creating and maintaining custom containers can carry a significant maintenance burden. In general, a 1-to-1 relationship between components and containers is not needed or recommended, as AI/ML work is often highly iterative. A best practice is to work with a small set of base images that can support many components. If you need more control over the container build than the `kfp` CLI provides, consider using a container CLI like [docker][docker-cli] or [podman][podman-cli].
 
+
 ## Next steps
 
+* Read the user guides for [Creating Components][Creating Components]
 * Read an [overview of Kubeflow Pipelines](/docs/components/pipelines/overview/).
 * Follow the [pipelines quickstart guide](/docs/components/pipelines/getting-started/) 
   to deploy Kubeflow and run a sample pipeline directly from the Kubeflow 
@@ -170,3 +176,4 @@ Note that creating and maintaining custom containers can carry a significant mai
 [yaml-component]: /docs/components/pipelines/reference/component-spec
 [docker-cli]: https://github.com/docker/cli
 [podman-cli]: https://github.com/containers/podman
+[Creating Components]: /docs/components/pipelines/user-guides/components

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -150,6 +150,17 @@ kfp component build --component-filepattern the_component.py --no-build-image --
 ```
 Note that creating and maintaining custom containers can carry a significant maintenance burden. In general, a 1-to-1 relationship between components and containers is not needed or recommended, as AI/ML work is often highly iterative. A best practice is to work with a small set of base images that can support many components. If you need more control over the container build than the `kfp` CLI provides, consider using a container CLI like [docker][docker-cli] or [podman][podman-cli].
 
+## Next steps
+
+* Read an [overview of Kubeflow Pipelines](/docs/components/pipelines/overview/).
+* Follow the [pipelines quickstart guide](/docs/components/pipelines/getting-started/) 
+  to deploy Kubeflow and run a sample pipeline directly from the Kubeflow 
+  Pipelines UI.
+* Build your own 
+  [component and pipeline](/docs/components/pipelines/legacy-v1/sdk/component-development/).
+* Build a [reusable component](/docs/components/pipelines/legacy-v1/sdk/component-development/) for
+  sharing in multiple pipelines.
+
 
 [pipeline]: /docs/components/pipelines/concepts/pipeline
 [KFP SDK]: https://kubeflow-pipelines.readthedocs.io

--- a/content/en/docs/components/pipelines/concepts/component.md
+++ b/content/en/docs/components/pipelines/concepts/component.md
@@ -5,15 +5,15 @@ weight = 20
 +++
 
 
-A **pipeline component** is the fundamental building block for ML engineers to construct a Kubeflow Pipelines [pipeline][pipeline]. The component structure serves the purpose of packaging a functional unit of code along with its dependencies, so that it can be run as part of a workflow in a Kubernetes-based environement. Components can be combined in a [pipeline][pipeline] that creates a repeatable workflow, with individual components coordinating on inputs and outputs like parameters and [artifacts][artifacts].
+A **pipeline component** is the fundamental building block for an ML engineer to construct a Kubeflow Pipelines [pipeline][pipeline]. The component structure serves the purpose of packaging a functional unit of code along with its dependencies, so that it can be run as part of a workflow in a Kubernetes environement. Components can be combined in a [pipeline][pipeline] that creates a repeatable workflow, with individual components coordinating on inputs and outputs like parameters and [artifacts][artifacts].
 
 A component is similar to a programming function. Indeed, it is most often implemented as a wrapper to a Python function using the [KFP Python SDK][KFP SDK]. However, a KFP component goes further than a simple function, with support for code dependencies, runtime environments, and distributed execution requirements.
 
-KFP components are designed to simplify constructing and running ML workflows in a Kubernetes-based environment. Using KFP components engineers can iterate faster, reduce maintenance overhead, and focus more attention on ML work.
+KFP components are designed to simplify constructing and running ML workflows in a Kubernetes environment. Using KFP components engineers can iterate faster, reduce maintenance overhead, and focus more attention on ML work.
 
 ## The Why Behind KFP Components
 
-Running ML code in a Kubernetes-based cluster presents many challenges. Some of the main challenges are:
+Running ML code in a Kubernetes cluster presents many challenges. Some of the main challenges are:
 - Managing **code dependencies** (Python libraries and versions)
 - Handling **system dependencies** (OS-level packages, GPU drivers, runtime environments)
 - **Building and maintaining container images** and everything around this from container registry support to CVE (Common Vulnerabilities and Exposures) fixes


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

This is a major update to the component concept page for KFP. The old page was confusing and lacked important information for the main KFP users (ML engineers). This update seeks to fix this by treating the "component" from the perspective of an MLE, providing a useful introduction on what a component is, and how to use it in the KFP world.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
<!-- /area website -->
<!-- /area community -->
---

