### PR TITLE
gsoc: add proposal guide to 2025 page

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2025.md
+++ b/content/en/events/upcoming-events/gsoc-2025.md
@@ -76,7 +76,10 @@ To participate in GSoC with Kubeflow, you **must** meet the GSoC [eligibility re
 4. Review the [project ideas](#project-ideas) to decide which ones you are interested in:
    - You may wish to attend the next [community meeting](/docs/about/community/#kubeflow-community-calendar) for the group that is leading your chosen project.
    - **NOTE:** while we recommend you submit a proposal based on the project ideas, you can also submit a proposal with your own idea.
-5. Submit a proposal through the [GSoC website](https://summerofcode.withgoogle.com/) between **March 24th** and **April 8th**.
+5. Submit a proposal through the [GSoC website](https://summerofcode.withgoogle.com/) between **March 24th** and **April 8th**:
+   - Please see [these guidelines](https://google.github.io/gsocguides/student/writing-a-proposal) on how to write a good proposal.
+   - Kubeflow requests that you use [this template](https://github.com/kubeflow/community/tree/master/proposals/gsoc) for your proposal. 
+   - You will need to submit PDF version of your proposal on GSoC website before April 8th, 2025. 
 6. Wait for the results to be announced on **May 8th**.
 
 ## Project Ideas


### PR DESCRIPTION
/area gsoc

Replaces https://github.com/kubeflow/website/pull/4060

This is a quick update to link to the proposal template added to `kubeflow/community` in https://github.com/kubeflow/community/pull/843.

It should fix the failing builds because it has the head of master as its base.