### PR TITLE
community: ensure manifests description is vendor-neutral

### DIFF
--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -339,9 +339,8 @@ The following table lists distributions which are <em>maintained</em> by their r
 
 ### Kubeflow Manifests
 
-The Kubeflow manifests are a collection of community maintained manifests to install Kubeflow in popular Kubernetes clusters such as Kind (locally), Minikube (locally), Rancher, EKS, AKS, GKE.
-They are aggregated by the Manifests Working Group and are intended to be
-used by users with Kubernetes knowledge and as the base of packaged distributions.
+The Kubeflow Manifests are community maintained kustomize manifests which are tested to deploy a minimum-viable Kubeflow Platform on **[Kind](https://kind.sigs.k8s.io/)** clusters.
+They are aggregated by the Manifests Working Group, and are intended to be used as the base of packaged distributions and by those with Kubernetes knowledge.
 
 Kubeflow Manifests contain all Kubeflow Components, Kubeflow Central Dashboard, and other Kubeflow
 applications that comprise the **Kubeflow Platform**. This installation is helpful when you want to


### PR DESCRIPTION
Related: https://github.com/kubeflow/website/pull/4028
Related: https://github.com/kubeflow/website/pull/4014

/area community

## What this PR does

This PR proposes an update to the manifests introduction paragraph that clarifies what the manifests actually are.

See [diff](https://github.com/kubeflow/website/pull/4071/files) for the current proposal.

## Motivation

@kubeflow/kubeflow-steering-committee I am deeply concerned about a recent change to the manifests description that was merged without wider discussion with the community.

In PR https://github.com/kubeflow/website/pull/4028 (about 30 days ago), the manifests description was updated to the following:

> The Kubeflow manifests are a collection of community maintained manifests to install Kubeflow in popular Kubernetes clusters such as Kind (locally), Minikube (locally), Rancher, EKS, AKS, GKE. They are aggregated by the Manifests Working Group and are intended to be used by users with Kubernetes knowledge and as the base of packaged distributions.

This wording is misleading, as the manifests are currently only tested to deploy a minimum-viable Kubeflow Platform on Kind, with no guarantees for other platforms.

It's also important to note that the [Manifests WG charter](https://github.com/kubeflow/community/blob/master/wg-manifests/charter.md#out-of-scope) explicitly prohibits the inclusion of (kubernetes) distribution-specific manifests, so even mentioning specific distributions verges on violating the charter.



