### PR TITLE
website: Added workflow to run GitHub Actions with `/ok-to-test`

### DIFF
--- a/.github/workflows/pr_commands.yaml
+++ b/.github/workflows/pr_commands.yaml
@@ -1,0 +1,100 @@
+name: PR Commands
+on:
+  issue_comment:
+    types:
+      - created
+env:
+  DEFAULT_BRANCH: master
+jobs:
+  process-command:
+    runs-on: ubuntu-latest
+    # Fail early if the command is not recognized
+    if: contains(github.event.comment.body, '/ok-to-test')
+    outputs:
+      PR_SHA: ${{ steps.fetch-pr-sha.outputs.PR_SHA }}
+    steps:
+      - name: Checkout Main Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
+      - name: Check if the author is a member or Owner
+        id: check-condition
+        run: |
+          if [[ "${{ github.event.comment.author_association }}" == "MEMBER" || "${{ github.event.comment.author_association }}" == "OWNER" ]]; then
+            echo "condition_met=true" >> $GITHUB_ENV
+          else
+            echo "User does not have permission to trigger this command."
+            echo "condition_met=false" >> $GITHUB_ENV
+          fi
+
+      - name: Leave a Comment on Precondition Fail
+        if: env.condition_met == 'false'
+        env:
+          message: 🚫 This command cannot be processed. Only organization members or owners can use the commands.
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+          gh issue comment ${{ github.event.issue.number }} --repo "${{ github.repository }}" --body "${{ env.message }}"
+          echo ${message}
+          exit 1
+
+      - name: Check if comment is on a pull request
+        id: check-pr
+        run: |
+          if [[ -z "${{ github.event.issue.pull_request }}" ]]; then
+            echo "Comment is not on a pull request."
+            exit 1
+          fi
+          echo "PR_URL=${{ github.event.issue.pull_request.url }}" >> $GITHUB_ENV
+
+      - name: Fetch pull request sha
+        id: fetch-pr-sha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL="${PR_URL}"
+          PR_DATA=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github.v3+json" "$PR_URL")
+          PR_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
+          echo "PR_SHA=$PR_SHA" >> $GITHUB_OUTPUT
+
+  # Add other commands as separate jobs
+  approve:
+    runs-on: ubuntu-latest
+    needs: process-command
+    if: contains(github.event.comment.body, '/ok-to-test')
+    steps:
+      - name: Checkout Main Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
+      - name: Approve Runs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_SHA: ${{ needs.process-command.outputs.PR_SHA }}
+        run: |
+          runs=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs?head_sha=${{ env.PR_SHA }}" | \
+            jq -r '.workflow_runs[] | select(.conclusion == "action_required") | .id')
+        
+          if [[ -z "$runs" ]]; then
+            echo "No workflow runs found for the given head SHA."
+            exit 1
+          fi
+
+          echo "Found workflow runs requiring approval: $runs"
+          # Approve each workflow run
+          for run_id in $runs; do
+            curl -X POST -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/runs/$run_id/approve"
+            echo "Approved workflow run: $run_id"
+          done
+          msg="Approvals successfully granted for pending runs."
+          echo "output_msg=${msg}" >> $GITHUB_ENV
+
+      - name: Leave a Comment
+        env:
+          message: ${{ env.output_msg }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+          gh issue comment ${{ github.event.issue.number }} --repo "${{ github.repository }}" --body "${{ env.message }}"


### PR DESCRIPTION
**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [x] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**
Currently, the `/ok-to-test` command doesn't trigger GitHub Actions. This PR adds that ability.
The workflow that this PR adds was copied from https://github.com/kubeflow/pipelines/blob/master/.github/workflows/pr-commands.yml.

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
/area website
<!-- /area community -->
---

