### PR TITLE
website: properly update fontawsome + partial revert #4083

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<div align="center">
-  <img src="./assets/icons/logo.svg" width="320">
-</div>
-
 # Kubeflow Website
 
 <h4 align="center">
@@ -105,8 +101,9 @@ Follow the usual GitHub workflow of forking the repository on GitHub and then cl
 4. Install Docsy dependencies:
 
    ```bash
+   # install the node packages (at the root of the repo)
    # NOTE: ensure you have node 18 installed
-   (cd themes/docsy/ && npm install)
+   npm install
    ```
 
 5. Start your local Hugo server:
@@ -159,6 +156,7 @@ To update referenced docsy commit, run the following command at the root of the 
 # for example, to update docsy to v0.6.0
 # WARNING: updating the docsy version will require you to update our overrides
 #          check under: `layouts/partials` and `assets/scss`
+#          also, we have [[module.mounts]] in `config.toml` that must align with the `config.yaml` from docsy
 git -C themes/docsy fetch --tags
 git -C themes/docsy checkout tags/v0.6.0
 ```

--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,39 @@ disableKinds = ["taxonomy"]
 # deprecated directories
 ignoreFiles = []
 
+# Override module mounts, mainly so that we can update fontawesome.
+# NOTE: this is based on docsy's config.yaml from v0.6.0, and must be updated if the docsy theme ever is.
+#       https://github.com/google/docsy/blob/v0.6.0/config.yaml#L24-L38
+[module]
+
+  [[module.mounts]]
+    source = "assets"
+    target = "assets"
+
+  [[module.mounts]]
+    source = "node_modules/bootstrap"
+    target = "assets/vendor/bootstrap"
+
+  [[module.mounts]]
+    source = "node_modules/@fortawesome/fontawesome-free"
+    target = "assets/vendor/Font-Awesome"
+
+  [[module.mounts]]
+    source = "i18n"
+    target = "i18n"
+
+  [[module.mounts]]
+    source = "layouts"
+    target = "layouts"
+
+  [[module.mounts]]
+    source = "static"
+    target = "static"
+
+  [[module.mounts]]
+    source = "node_modules/@fortawesome/fontawesome-free/webfonts"
+    target = "static/webfonts"
+
 ###############################################################################
 # Hugo - Top-level navigation (horizontal)
 ###############################################################################
@@ -304,5 +337,5 @@ enable = true
     [[params.links.user]]
       name = "Kubeflow Community Calendars"
       url = "/docs/about/community/#kubeflow-community-meetings"
-      icon = "fa fa-calendar"
+      icon = "fa fa-calendar-day"
       desc = "View the Kubeflow Community Calendars!"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,5 @@
 {{ $links := .Site.Params.links }}
 <footer class="bg-dark pt-3 row d-print-none" xmlns="http://www.w3.org/1999/html">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/fontawesome.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/brands.min.css"> 
   <div class="container px-5">
     <div class="row">
       <div class="col-6 col-sm-2 text-xs-center order-sm-2">

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,16 +2,16 @@
   publish = "public"
   # setting baseURL is required for `PAGE.Permalink` to correctly include the full `https://DOMAIN/` prefix
   # which is required for things like `twitter:image` meta tags to work correctly
-  command = "cd themes/docsy && git submodule update -f --init && npm install && cd ../.. && hugo --gc --minify"
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo --gc --minify"
 
 [context.deploy-preview]
   # for deploy previews, the domain will be `https://deploy-preview-PR_NUMBER--competent-brattain-de2d6d.netlify.app/`
   # which can be read from the `DEPLOY_PRIME_URL` environment variable in Netlify
-  command = "cd themes/docsy && git submodule update -f --init && npm install && cd ../.. && hugo --gc --minify --baseURL $DEPLOY_PRIME_URL"
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo --gc --minify --baseURL $DEPLOY_PRIME_URL"
 
 [context.production]
   # for production, the domain will be `https://www.kubeflow.org/`
-  command = "cd themes/docsy && git submodule update -f --init && npm install && cd ../.. && hugo --gc --minify --baseURL https://www.kubeflow.org/"
+  command = "cd themes/docsy && git submodule update -f --init && cd ../.. && hugo --gc --minify --baseURL https://www.kubeflow.org/"
 
 [[context.deploy-preview.plugins]]
 package = "netlify-plugin-checklinks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,10 @@
   "packages": {
     "": {
       "name": "website",
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.7.2",
+        "bootstrap": "^4.6.2"
+      },
       "devDependencies": {
         "autoprefixer": "^10.4.0",
         "netlify-plugin-checklinks": "^4.1.1",
@@ -63,6 +67,14 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@hapi/address": {
@@ -692,6 +704,25 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/bootstrap": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "peerDependencies": {
+        "jquery": "1.9.1 - 3",
+        "popper.js": "^1.16.1"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2931,6 +2962,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3839,6 +3876,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6327,6 +6375,11 @@
         "regenerator-runtime": "^0.14.0"
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA=="
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -6794,6 +6847,12 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
+    },
+    "bootstrap": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "requires": {}
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -8339,6 +8398,12 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
+    "jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9011,6 +9076,12 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "peer": true
     },
     "possible-typed-array-names": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "website",
+  "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.7.2",
+    "bootstrap": "^4.6.2"
+  },
   "devDependencies": {
     "autoprefixer": "^10.4.0",
     "netlify-plugin-checklinks": "^4.1.1",


### PR DESCRIPTION
/area website

This PR fixes the error introduced by https://github.com/kubeflow/website/pull/4083 where fontawsome is loaded multiple times on every page, and has two conflicting versions. This was a serious issue because it affects page load times, but also because the `integrity` arg was not set on the `<link>` which was added to the footer.

It also partially reverts the readme update which put an image above the title of the root readme. This hurts SEO of the repo, because the title needs to be at the top. But it also implies that this is the "kubeflow" repo (when its just the website source). Note, we already have a logo on the [`kubeflow/kubeflow` readme](https://github.com/kubeflow/kubeflow), and it sits below the title.

__WARNING:__ after this PR, everyone will need to stop doing `(cd themes/docsy/ && npm install)` when trying to run a local version of the website. Instead, they must run `npm install` at the root of the repo, as this is now where fontawsome and bootstrap are installed, rather than under the `themes/docsy` folder.

__Screenshot [from preview site](https://deploy-preview-4085--competent-brattain-de2d6d.netlify.app/) showing that the new icons still work after this PR:__

<img width="318" alt="Screenshot 2025-04-12 at 15 18 40" src="https://github.com/user-attachments/assets/9b1ebc6c-e1cf-4085-8aee-ae061b2a70ba" />
