### PR TITLE
gsoc: Update GSoC 2025 status to Application Closed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -70,7 +70,7 @@ ignoreFiles = []
     name = "GSoC 2025"
     weight = -900
     pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' style='height: 1.22em;'></i>"
-      post = "<br><span class='badge badge-info'>Coming Soon</span>"
+      post = "<br><span class='badge badge-info'>Application Closed</span>"
     url = "/events/gsoc-2025/"
   [[menu.main]]
     name = "Docs"


### PR DESCRIPTION
**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] You have included screenshots when changing the website style or adding a new page.

**Description of your changes:**
Updated the GSoC 2025 status in the navigation menu from "Coming Soon" to "Application Closed" to reflect the current application status.

![image](https://github.com/user-attachments/assets/5c5bea8b-fe48-486a-b32c-edfe2d90d6f6)

### Issue
Closes: # (no specific issue)

### Labels
/area gsoc
/area website