### PR TITLE
website: update the link from training-operator to trainer

### DIFF
--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -141,8 +141,8 @@ corresponding [ML lifecycle stage](/docs/started/architecture/#kubeflow-componen
           Model Training and LLMs Fine-Tuning
         </td>
         <td>
-          <a href="https://github.com/kubeflow/training-operator">
-            <code>kubeflow/training-operator</code>
+          <a href="https://github.com/kubeflow/trainer">
+            <code>kubeflow/trainer</code>
           </a>
         </td>
       </tr>


### PR DESCRIPTION
kubeflow training-operator repo is renamed to [trainer](https://github.com/kubeflow/trainer) now, so update the link accordingly 