### PR TITLE
model-registry: better link to issue selector screen

### DIFF
--- a/content/en/docs/components/model-registry/getting-started.md
+++ b/content/en/docs/components/model-registry/getting-started.md
@@ -189,4 +189,4 @@ For detailed instructions on using the Model Registry UI, refer to the [Model Re
   - [Model Registry working group](https://www.kubeflow.org/docs/about/community/#kubeflow-community-meetings)
   - [GitHub repository](https://github.com/kubeflow/model-registry)
 - Share your feedback:
-  - [File an issue](https://github.com/kubeflow/model-registry/issues)
+  - [File an issue](https://github.com/kubeflow/model-registry/issues/new/choose)

--- a/content/en/docs/components/model-registry/overview.md
+++ b/content/en/docs/components/model-registry/overview.md
@@ -4,7 +4,7 @@ description = "An overview for Kubeflow Model Registry"
 weight = 10
 +++
 
-{{% alpha-status feedbacklink="https://github.com/kubeflow/model-registry" %}}
+{{% alpha-status feedbacklink="https://github.com/kubeflow/model-registry/issues/new/choose" %}}
 
 ## What is Model Registry?
 


### PR DESCRIPTION
Guide the Reader to the correct issue-selector screen on the repo

@varodrig @andreyvelich @milosjava
@rareddy @rimolive 


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
<!-- /area website -->
<!-- /area community -->
---

