### PR TITLE
website: fix Alpha, Beta tooltip box (missing space)

### DIFF
--- a/layouts/shortcodes/alpha-status.html
+++ b/layouts/shortcodes/alpha-status.html
@@ -3,6 +3,6 @@
   This Kubeflow component has <b>alpha</b> status with limited support. See the
   <a href="/docs/started/support/#application-status">Kubeflow versioning policies</a>.
   The Kubeflow team is interested in your {{ if .Get "feedbacklink"}} {{ with .Get "feedbacklink" }} 
-  <a href="{{ . | safeURL }}">feedback</a></h4>{{ end }} {{ else }}feedback{{ end }}
+  <a href="{{ . | safeURL }}">feedback </a></h4>{{ end }} {{ else }}feedback {{ end }}
   about the usability of the feature.
 </div>

--- a/layouts/shortcodes/beta-status.html
+++ b/layouts/shortcodes/beta-status.html
@@ -3,7 +3,7 @@
   This Kubeflow component has <b>beta</b> status. See the
   <a href="/docs/started/support/#application-status">Kubeflow versioning policies</a>.
   The Kubeflow team is interested in your {{ if .Get "feedbacklink"}} {{ with .Get "feedbacklink" }} 
-  <a href="{{ . | safeURL }}">feedback</a></h4>{{ end }} {{ else }}feedback{{ end }}
+  <a href="{{ . | safeURL }}">feedback </a></h4>{{ end }} {{ else }}feedback {{ end }}
   about the usability of the feature.
 </div>
   


### PR DESCRIPTION
🔬 the spaces in the if/then/else does not count towards the necessary space in the rendered text 

@varodrig @andreyvelich @thesuperzapper @rimolive @hbelmiro 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [x] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**

## Before (today on kubeflow.org):

<img width="1283" alt="Screenshot 2025-05-04 at 14 20 55" src="https://github.com/user-attachments/assets/bd0ecd6d-5f77-4a49-9984-ec05a38c961d" />

## After (this PR):

<img width="1272" alt="Screenshot 2025-05-04 at 14 21 16" src="https://github.com/user-attachments/assets/fd187726-ebc3-44a8-9969-1e603121daed" />

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels

/area website

<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->

<!-- /area community -->
---

