### PR TITLE
model‑registry: add kubectl apply example for installation (#1071)

### DIFF
--- a/content/en/docs/components/model-registry/installation.md
+++ b/content/en/docs/components/model-registry/installation.md
@@ -26,6 +26,7 @@ Kubeflow Model Registry is available as an opt-in alpha component in Kubeflow Pl
 
 These instructions assume that you've installed Kubeflow from the [manifests](https://github.com/kubeflow/manifests/), if you're using a distribution consult its documentation instead.
 
+
 Clone the `model-registry` repository:
 
 ```sh
@@ -68,6 +69,23 @@ Finally, configure a Model Registry link in the Kubeflow Dashboard:
 ```sh
 kubectl get configmap centraldashboard-config -n kubeflow -o json | jq '.data.links |= (fromjson | .menuLinks += [{"icon": "assignment", "link": "/model-registry/", "text": "Model Registry", "type": "item"}] | tojson)' | kubectl apply -f - -n kubeflow
 ```
+
+### Installing via `kubectl apply`
+
+You can deploy Model Registry directly with a single command:
+
+```sh
+kubectl apply -k https://github.com/kubeflow/model-registry/manifests/kustomize/base?ref=v0.2.16
+```
+### Optional: Istio compatibility
+
+If your cluster uses Istio (and you’ve installed Kubeflow with Istio), enable compatibility:
+
+```sh
+kubectl apply -k \ https://github.com/kubeflow/model-registry/manifests/kustomize/options/istio?ref=v0.2.16
+```
+
+Tip: Adjust ref= to the exact release tag (e.g. v0.2.16) so you’re always pulling in the matching manifests.
 
 ### Standalone installation
 


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**

This adds a “kubectl apply” snippet (and optional Istio compatibility) to the Model Registry installation docs.

Fixes kubeflow/model-registry#1071

### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes:  kubeflow/model-registry#1071

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
<!-- /area website -->
<!-- /area community -->
---

