### PR TITLE
website: update main branch archive banner

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -172,24 +172,33 @@ enable = true
   # Google Custom Search Engine ID.
   gcs_engine_id = "007239566369470735695:624rglujm-w"
 
-  # Text label for the version menu in the top bar of the website.
+  # The text label for the version menu in the top bar.
+  # The value depends on the branch:
+  #  - `master` -> "Version"
+  #  - `v1.0-branch` -> "v1.0"
   version_menu = "Version"
 
-  # The major.minor version tag for the version of the docs represented in this
-  # branch of the repository. Used in the "version-banner" partial to display a
-  # version number for this doc set.
-  version = "master"
+  # The version of the docs. This is used in the "version-banner" partial.
+  # The value depends on the branch:
+  #  - `master` -> "REPLACE_WITH_VERSION_ON_ARCHIVE"
+  #  - `v1.0-branch` -> "v1.0"
+  version = "REPLACE_WITH_VERSION_ON_ARCHIVE"
 
-  # Flag used in the "version-banner" partial to decide whether to display a
-  # banner on every page indicating that this is an archived version of the docs.
+  # If the "version-banner" partial should display at the top of each page.
+  # The value depends on the branch:
+  #  - `master` -> false
+  #  - `v*-branch` -> true
   archived_version = false
 
-  # A link to latest version of the docs. Used in the "version-banner" partial to
-  # point people to the main doc site.
-  url_latest_version = "https://kubeflow.org/docs/"
+  # The URL of the latest version of the docs.
+  # Used in the "version-banner" partial.
+  url_latest_version = "https://www.kubeflow.org/docs/"
 
-  # A variable used in various docs to determine URLs for config files etc.
-  # To find occurrences, search the repo for 'params "githubbranch"'.
+  # The GitHub branch for the current version of the docs.
+  # Used to generate the "Edit this page" link.
+  # The value depends on the branch:
+  #  - `master` -> "master"
+  #  - `v1.0-branch` -> "v1.0-branch"
   github_branch = "master"
 
   # Disable MathJax by default
@@ -255,26 +264,6 @@ enable = true
     version = "v1.0"
     githubbranch = "v1.0-branch"
     url = "https://v1-0-branch.kubeflow.org"
-  [[params.versions]]
-    version = "v0.7"
-    githubbranch = "v0.7-branch"
-    url = "https://v0-7.kubeflow.org"
-  [[params.versions]]
-    version = "v0.6"
-    githubbranch = "v0.6-branch"
-    url = "https://v0-6.kubeflow.org"
-  [[params.versions]]
-    version = "v0.5"
-    githubbranch = "v0.5-branch"
-    url = "https://v0-5.kubeflow.org"
-  [[params.versions]]
-    version = "v0.4"
-    githubbranch = "v0.4-branch"
-    url = "https://v0-4.kubeflow.org"
-  [[params.versions]]
-    version = "v0.3"
-    githubbranch = "v0.3-branch"
-    url = "https://v0-3.kubeflow.org"
 
   # User interface configuration
   [params.ui]

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,33 @@
+<!-- Check the variable that indicates whether this is an archived doc set. If yes, display a banner. -->
+{{- $latest_version_url := .Site.Params.url_latest_version }}
+{{- $current_version := replace .Site.Params.version "v" "" | markdownify }}
+{{- if .Site.Params.archived_version }}
+  <style>
+    .version-banner {
+      padding: 1.5rem;
+      margin: 2rem 0;
+      max-width: 40rem;
+      border-style: solid;
+      border-color: #f0ad4e;
+      background-color: #faf5b6;
+      border-radius: 0.25rem;
+    }
+    .version-banner h3 {
+      margin-top: 0;
+      margin-bottom: 0.6em;
+      font-size: 1.25em;
+    }
+    .version-banner p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  </style>
+  <div class="version-banner">
+    <h3>You are viewing documentation for <strong>Kubeflow {{ $current_version }}</strong></h3>
+    <p>
+      This is a static snapshot from the time of the Kubeflow {{ $current_version }} release.
+      <br>
+      For up-to-date information, see the <a href="{{ $latest_version_url | safeURL }}">latest version</a>.
+    </p>
+  </div>
+{{- end }}


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 

**Description of your changes:**

This PR updates the archive banner text so when `archived_version=true` it's more clear that the branch is archived.

___NOTE:__ this PR only updates the templates so that when we next fork off the `main` branch to a `v1.11-branch` it is easy to just set `archived_version=true`_

___NOTE 2:__ this is not a new change, it has already been done to all the old branches, but this means its less work for future versions._

<!--Additional Information:-->
### Labels

/area website

