### PR TITLE
website: add archive banner for 1.9 branch

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -128,25 +128,22 @@ enable = true
   # Google Custom Search Engine ID.
   gcs_engine_id = "007239566369470735695:624rglujm-w"
 
-  # Text label for the version menu in the top bar of the website.
-  version_menu = "Kubeflow Version"
+  # The text label for the version menu in the top bar.
+  version_menu = "v1.9"
 
-  # The major.minor version tag for the version of the docs represented in this
-  # branch of the repository. Used in the "version-banner" partial to display a
-  # version number for this doc set.
-  version = "master"
+  # The version of the docs. This is used in the "version-banner" partial.
+  version = "v1.9"
 
-  # Flag used in the "version-banner" partial to decide whether to display a
-  # banner on every page indicating that this is an archived version of the docs.
-  archived_version = false
+  # If the "version-banner" partial should display at the top of each page.
+  archived_version = true
 
-  # A link to latest version of the docs. Used in the "version-banner" partial to
-  # point people to the main doc site.
-  url_latest_version = "https://kubeflow.org/docs/"
+  # The URL of the latest version of the docs.
+  # Used in the "version-banner" partial.
+  url_latest_version = "https://www.kubeflow.org/docs/"
 
-  # A variable used in various docs to determine URLs for config files etc.
-  # To find occurrences, search the repo for 'params "githubbranch"'.
-  github_branch = "master"
+  # The GitHub branch for the current version of the docs.
+  # Used to generate the "Edit this page" link.
+  github_branch = "v1.9-branch"
 
   # Disable MathJax by default
   # NOTE: enable it per-page with `mathjax: true` in front matter
@@ -154,9 +151,13 @@ enable = true
 
   # These entries appear in the drop-down menu at the top of the website.
   [[params.versions]]
-    version = "master"
+    version = "Latest"
     githubbranch = "master"
-    url = "https://master.kubeflow.org"
+    url = "https://www.kubeflow.org"
+  [[params.versions]]
+    version = "v1.9"
+    githubbranch = "v1.9-branch"
+    url = "https://v1-9-branch.kubeflow.org"
   [[params.versions]]
     version = "v1.8"
     githubbranch = "v1.8-branch"
@@ -193,26 +194,6 @@ enable = true
     version = "v1.0"
     githubbranch = "v1.0-branch"
     url = "https://v1-0-branch.kubeflow.org"
-  [[params.versions]]
-    version = "v0.7"
-    githubbranch = "v0.7-branch"
-    url = "https://v0-7.kubeflow.org"
-  [[params.versions]]
-    version = "v0.6"
-    githubbranch = "v0.6-branch"
-    url = "https://v0-6.kubeflow.org"
-  [[params.versions]]
-    version = "v0.5"
-    githubbranch = "v0.5-branch"
-    url = "https://v0-5.kubeflow.org"
-  [[params.versions]]
-    version = "v0.4"
-    githubbranch = "v0.4-branch"
-    url = "https://v0-4.kubeflow.org"
-  [[params.versions]]
-    version = "v0.3"
-    githubbranch = "v0.3-branch"
-    url = "https://v0-3.kubeflow.org"
 
   # User interface configuration
   [params.ui]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,12 +5,8 @@
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
 
-{{ $outputFormat := partial "outputformat.html" . -}}
-{{ if and hugo.IsProduction (ne $outputFormat "print") -}}
-<meta name="robots" content="index, follow">
-{{ else -}}
-<meta name="robots" content="noindex, nofollow">
-{{ end -}}
+<!-- Prevent search engines from indexing this old site -->
+<meta name="robots" content="noindex">
 
 {{ partialCached "favicons.html" . }}
 <title>

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,33 @@
+<!-- Check the variable that indicates whether this is an archived doc set. If yes, display a banner. -->
+{{- $latest_version_url := .Site.Params.url_latest_version }}
+{{- $current_version := replace .Site.Params.version "v" "" | markdownify }}
+{{- if .Site.Params.archived_version }}
+  <style>
+    .version-banner {
+      padding: 1.5rem;
+      margin: 2rem 0;
+      max-width: 40rem;
+      border-style: solid;
+      border-color: #f0ad4e;
+      background-color: #faf5b6;
+      border-radius: 0.25rem;
+    }
+    .version-banner h3 {
+      margin-top: 0;
+      margin-bottom: 0.6em;
+      font-size: 1.25em;
+    }
+    .version-banner p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  </style>
+  <div class="version-banner">
+    <h3>You are viewing documentation for <strong>Kubeflow {{ $current_version }}</strong></h3>
+    <p>
+      This is a static snapshot from the time of the Kubeflow {{ $current_version }} release.
+      <br>
+      For up-to-date information, see the <a href="{{ $latest_version_url | safeURL }}">latest version</a>.
+    </p>
+  </div>
+{{- end }}


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 


**Description of your changes:**

This PR archives the 1.9 branch in the same way as we have done for all past releases, it adds a warning banner to say please use the latest version by setting `archived_version=true`.

This should be less work in future versions after https://github.com/kubeflow/website/pull/4119 is merged, because we will only need to set `archived_version=true`, not update the template to add the banner.

### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

/area website
