### PR TITLE
website: fix header and announcements

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -453,7 +453,8 @@ nav.foldable-nav {
   }
 
   .navbar-nav {
-    white-space: nowrap;
+    // allow wrapping of navbar links
+    white-space: normal;
 
     .dropdown-toggle {
       white-space: normal;

--- a/config.toml
+++ b/config.toml
@@ -60,24 +60,24 @@ ignoreFiles = []
 # Hugo - Top-level navigation (horizontal)
 ###############################################################################
 [menu]
- [[menu.main]]
-    name = "Kubeflow Summit NA 2025"
-    weight = -1100
-    pre = "<i class='fas fa-bullhorn pr-2 text-danger'></i>"
-    post = "<br><span class='badge badge-danger'>CFP Open</span> <span class='badge badge-light'>Nov 2025</span>"
+  [[menu.main]]
+    name = "Kubeflow Summit"
+    weight = -1000
+    pre = "<i class='fas fa-calendar pr-2' style='color: #FFC107'></i>"
+    post = "<br><span class='badge badge-warning'>Nov 10th, 2025</span> <span class='badge badge-warning'>Atlanta, Georgia</span>"
     url = "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/kubeflow-summit/"
   [[menu.main]]
     name = "Kubeflow Virtual Symposium"
-    weight = -1000
+    weight = -950
     pre = "<i class='fas fa-calendar pr-2' style='color: #FFC107'></i>"
-    post = "<br><span class='badge badge-warning'>July 9th, 2025</span> <span class='badge badge-warning'>Virtual</span> "
+    post = "<br><span class='badge badge-warning'>Jul 9th, 2025</span> <span class='badge badge-warning'>Virtual</span>"
     url = "https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-kubeflow-virtual-planning-symposium-2025/"
-  [[menu.main]]
-    name = "GSoC 2025"
-    weight = -900
-    pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' style='height: 1.22em;'></i>"
-    post = "<br><span class='badge badge-success'>Ongoing</span>"
-    url = "/events/gsoc-2025/"
+#  [[menu.main]]
+#    name = "GSoC 2025"
+#    weight = -900
+#    pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' style='height: 1.22em;'></i>"
+#    post = "<br><span class='badge badge-success'>Ongoing</span>"
+#    url = "/events/gsoc-2025/"
   [[menu.main]]
     name = "Docs"
     weight = -102


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [x] You have included screenshots when changing the website style or adding a new page.

### Description

Partially reverts: https://github.com/kubeflow/website/pull/4136

Currently, after https://github.com/kubeflow/website/pull/4136 the header of the website is broken, it does not wrap correctly and will extend beyond the edge of the screen, causing it to not be possible to see the version or dark/light drop-downs.

This PR:
- reverts the incorrect style update which prevented wrapping of header text on smaller screens
- reduces the width of the announcements text (say "Kubeflow Summit" which is shorter)
- uses the standard format of "date", "location" for the icons below the Kubeflow Summit entry
- comments out the GSOC one, as we can only fit 3 announcements, and GSOC is already underway, so doesn't need a header announcement

#### After this PR:

<img width="1253" alt="Screenshot 2025-06-24 at 09 39 23" src="https://github.com/user-attachments/assets/6431e742-db36-4cbd-8aaf-fe8baefc17ff" />

#### Before this PR:

<img width="1389" alt="Screenshot 2025-06-24 at 09 39 39" src="https://github.com/user-attachments/assets/ec12ffcd-b911-4f51-a242-c1426addb7ed" />

<img width="319" alt="Screenshot 2025-06-24 at 09 38 49" src="https://github.com/user-attachments/assets/95c7a775-fa75-4ee0-a0f0-289599b3387a" />


<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
/area website
<!-- /area community -->
---

