### PR TITLE
trainer: migration guide from training operator to Trainer V2

### DIFF
--- a/.github/workflows/pr_title_check.yaml
+++ b/.github/workflows/pr_title_check.yaml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-
-permissions:
-  pull-requests: write 
-  
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_title_check.yaml
+++ b/.github/workflows/pr_title_check.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+
+permissions:
+  pull-requests: write 
+  
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest

--- a/content/en/docs/components/trainer/operator-guides/migration.md
+++ b/content/en/docs/components/trainer/operator-guides/migration.md
@@ -1,6 +1,6 @@
 +++
-title = "Migrating to Kubeflow Trainer V2"
-description = "How to migrate to the new Kubeflow Trainer V2."
+title = "Migrating to Kubeflow Trainer v2"
+description = "How to migrate from the Training Operator v1"
 weight = 20
 +++
 
@@ -20,26 +20,31 @@ The key features introduced by Kubeflow Trainer are:
 - Custom dataset and model initializer: to streamline assets initialization across distributed
   training nodes and to reduce GPU cost by offloading I/O tasks to CPU workloads.
 
-- Enhanced MPI support: featuring MPI-Operator V2 features with SSH-based optimization to boost
+- Enhanced MPI support: featuring MPI-Operator v2 features with SSH-based optimization to boost
   MPI performance.
 
 ## Migration Paths
 
-Kubeflow Trainer v2 introduces new APIs that replace the older, framework-specific CRDs such as `PyTorchJob`, `TFJob`, and `MPIJob`. These new APIs—`TrainingRuntime`, `TrainJob`, and `ClusterTrainingRuntime`—offer a more flexible and unified interface for defining training jobs across frameworks.
+Kubeflow Trainer v2 introduces new APIs that replace the older, framework-specific CRDs such as
+`PyTorchJob`, `TFJob`, and `MPIJob`. These new APIs - `TrainJob`, `ClusterTrainingRuntime`,
+and `TrainingRuntime` — offer a more flexible and unified interface for defining training
+jobs across frameworks.
 
-This section shows how to migrate an existing PyTorchJob to the new API.
+Please see [the runtime guide](/docs/components/trainer/operator-guides/) to understand the concepts
+of `TrainJob` and `ClusterTrainingRuntime`.
 
-### Migrate PyTorchJob to TrainingRuntime
+### Migrate PyTorchJob to TrainJob
 
-The following example demonstrates how to migrate from a `PyTorchJob` (v1) to a `TrainingRuntime` (v2alpha1),  utilizing the default Torch runtime and overriding it with TrainJob.
+The following example demonstrates how to migrate from `PyTorchJob` to `TrainJob`, utilizing the
+default Torch runtime:
 
-### Old: PyTorchJob (v1)
+#### Old: PyTorchJob (v1)
+
 ```yaml
 apiVersion: kubeflow.org/v1
 kind: PyTorchJob
 metadata:
   name: pytorch-simple
-  namespace: kubeflow
 spec:
   pytorchReplicaSpecs:
     Master:
@@ -50,7 +55,10 @@ spec:
           containers:
             - name: pytorch
               image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
-              command: ["python3", "/opt/pytorch-mnist/mnist.py", "--epochs=1"]
+              command:
+                - "python3"
+                - "/opt/pytorch-mnist/mnist.py"
+                - "--epochs=1"
     Worker:
       replicas: 1
       restartPolicy: OnFailure
@@ -59,46 +67,50 @@ spec:
           containers:
             - name: pytorch
               image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
-              command: ["python3", "/opt/pytorch-mnist/mnist.py", "--epochs=1"]
+              command:
+                - "python3"
+                - "/opt/pytorch-mnist/mnist.py"
+                - "--epochs=1"
 ```
-### New: TrainingRuntime with TrainJob Override (v2alpha1)
+
+#### New: TrainJob (v2)
 
 ```yaml
-apiVersion: trainer.kubeflow.org/v2alpha1
+apiVersion: trainer.kubeflow.org/v1alpha1
 kind: TrainJob
 metadata:
   name: pytorch-simple
-  namespace: kubeflow
 spec:
   runtimeRef:
-    name: torch-distributed  
-  template:
-    spec:
-      containers:
-        - name: trainer
-          image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
-          command: ["torchrun", "/opt/pytorch-mnist/mnist.py", "--epochs=1"]
-          env:
-            - name: MASTER_ADDR
-              value: "pytorch-simple-0"  
-            - name: MASTER_PORT
-              value: "29400"
-      replicas: 2
+    name: torch-distributed
+  trainer:
+    numNodes: 2
+    image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+    command:
+      - "python3"
+      - "/opt/pytorch-mnist/mnist.py"
+      - "--epochs=1"
 ```
 
-### Additional Notes:
+### Kubeflow Trainer Python SDK
 
+Kubeflow Trainer uses Kubeflow Python SDK to allow AI practitioners interact with Kubeflow Trainer
+APIs without dealing with YAMLs or `kubectl`.
 
-- The TrainingRuntime now leverages the default Torch runtime and is overridden with TrainJob to define the training configuration.
-
-- Kubeflow Trainer provides a Python SDK, enabling ML users to programmatically submit TrainJob instances without relying on kubectl, enhancing usability and integration with Kubeflow workflows.
+Check the [Getting Started](/docs/components/trainer/getting-started) guide to learn how
+to scale PyTorch code with `TrainJob` using Python SDK.
 
 ### Additional information
 
-- Trainer v2 does not use individual CRDs per framework. Instead, it abstracts functionality into a unified runtime specification.
-- You can use the `Kubeflow Python SDK` to generate and submit Trainer v2 workloads programmatically.
-- Initializer and multi-node coordination logic is managed by the system, reducing overhead on the training container.
-- Support for specifying `managedBy` fields and runtime API versions (via `runtimeRef.version`) is under consideration.
+- Kubeflow Trainer v2 does not use separate CRDs for each framework. Instead, it implements all
+  functionality within a single `TrainJob` CRD.
+- AI practitioners should use the Kubeflow Python SDK to convert their model training code into a
+  `TrainJob`.
+- Platform administrators can leverage the `ClusterTrainingRuntime` and `TrainingRuntime` CRDs
+  to configure reusable blueprints that enable AI practitioners to create `TrainJobs`.
+- For a detailed overview of Kubeflow Trainer v2, please see
+  [the announcement blog post](https://blog.kubeflow.org/trainer/intro/).
 
-You can find detailed proposals and discussion [in the Kubeflow Trainer GitHub repository](https://github.com/kubeflow/trainer/tree/master/docs/proposals/2170-kubeflow-trainer-v2).
+## Next Steps
 
+- Learn about [the Kubeflow Trainer runtimes](docs/components/trainer/operator-guides/runtime)

--- a/content/en/docs/components/trainer/operator-guides/migration.md
+++ b/content/en/docs/components/trainer/operator-guides/migration.md
@@ -23,6 +23,89 @@ The key features introduced by Kubeflow Trainer are:
 - Enhanced MPI support: featuring MPI-Operator V2 features with SSH-based optimization to boost
   MPI performance.
 
-## Migration Paths
+## Migration paths
 
-TODO (andreyvelich): Add docs for migration.
+Kubeflow Trainer v2 introduces new APIs that replace the older, framework-specific CRDs such as `PyTorchJob`, `TFJob`, and `MPIJob`. These new APIs—`TrainingRuntime`, `TrainJob`, and `ClusterTrainingRuntime`—offer a more flexible and unified interface for defining training jobs across frameworks.
+
+This section shows how to migrate an existing PyTorch job to the new API.
+
+### Migrate PyTorchJob to TrainingRuntime
+
+The following example demonstrates how to migrate from a `PyTorchJob` (v1) to a `TrainingRuntime` (v2alpha1).
+
+### Old: PyTorchJob (v1)
+```yaml
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: pytorch-simple
+  namespace: kubeflow
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+              command: ["python3", "/opt/pytorch-mnist/mnist.py", "--epochs=1"]
+    Worker:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+              command: ["python3", "/opt/pytorch-mnist/mnist.py", "--epochs=1"]
+```
+### New: TrainingRuntime (v2alpha1)
+```yaml
+apiVersion: trainer.kubeflow.org/v2alpha1
+kind: TrainingRuntime
+metadata:
+  name: torch-distributed-multi-node
+spec:
+  mpiPolicy:
+    numNodes: 2
+  template:
+    spec:
+      replicatedJobs:
+        - name: node
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              containers:
+                - name: trainer
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+                  env:
+                    - name: MASTER_ADDR
+                      value: "pytorch-node-0-0.pytorch"
+                    - name: MASTER_PORT
+                      value: "29400"
+                  command: ["torchrun", "train.py"]
+```
+The new `TrainingRuntime` CRD allows you to define reusable templates and use MPI-based distributed training with greater flexibility. The `replicatedJobs` and `mpiPolicy` fields replace framework-specific roles like `Master` and `Worker`.
+
+### Version compatibility table
+
+The following table lists compatibility between Kubeflow Trainer versions, supported APIs, and minimum Kubernetes versions:
+
+| Trainer version | API version | CRDs introduced                                | Minimum Kubernetes version | Notes                        |
+|-----------------|-------------|-------------------------------------------------|-----------------------------|-------------------------------|
+| v1.4–v1.8       | v1          | `PyTorchJob`, `TFJob`, `MPIJob`, etc.          | 1.23+                       | Training Operator style       |
+| v1.9+           | v2alpha1    | `TrainingRuntime`, `TrainJob`, `ClusterTrainingRuntime` | 1.31.3+                     | Trainer v2 (breaking changes) |
+
+### Additional information
+
+- Trainer v2 does not use individual CRDs per framework. Instead, it abstracts functionality into a unified runtime specification.
+- You can use the `Kubeflow Python SDK` to generate and submit Trainer v2 workloads programmatically.
+- Initializer and multi-node coordination logic is managed by the system, reducing overhead on the training container.
+- Support for specifying `managedBy` fields and runtime API versions (via `runtimeRef.version`) is under consideration.
+
+You can find detailed proposals and discussion [in the Kubeflow Trainer GitHub repository](https://github.com/kubeflow/trainer/tree/master/docs/proposals).
+


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [x] You have signed off your commits! ([sign-off guide](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits))
- [x] Ensure you follow best practices from our guide. [Contributing]https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md)
- [ ] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**

This PR adds a new migration guide under the Kubeflow Trainer documentation.

It provides users with a clear migration path from the legacy Training Operator (v1) APIs (e.g., PyTorchJob) to the new unified Trainer V2 APIs (e.g., TrainingRuntime). The guide includes:

- A side-by-side example of migrating a PyTorchJob to TrainingRuntime.
- A compatibility table for Trainer versions, CRDs, and Kubernetes requirements.
- Notes on key changes, deprecations, and architectural improvements in Trainer V2.

This contribution addresses the request in [kubeflow/trainer#2412 [(comment)]](https://github.com/kubeflow/trainer/issues/2412#issuecomment-3054291878)


