### PR TITLE
chore(pipelines): Control Flow - remove unsupported banners

### DIFF
--- a/content/en/docs/components/pipelines/user-guides/core-functions/control-flow.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/control-flow.md
@@ -87,8 +87,6 @@ def my_pipeline():
 Branches are mutually exclusive if exactly one will be executed. 
 To enforce this, the KFP SDK compiler requires `dsl.OneOf` consume from tasks within a logically associated group of conditional branches and that one of the branches is a `dsl.Else` branch.
 
-{{% oss-be-unsupported feature_name="`dsl.OneOf`" %}}
-
 For example, the following pipeline uses `dsl.OneOf` to gather outputs from mutually exclusive branches:
 
 ```python
@@ -141,8 +139,6 @@ The context manager takes three arguments:
 - `parallelism` (optional): is the maximum number of concurrent iterations while executing the `dsl.ParallelFor` group
      - note, `parallelism=0` indicates unconstrained parallelism
 
-{{% oss-be-unsupported feature_name="Setting `parallelism`" gh_issue_link=https://github.com/kubeflow/pipelines/issues/8718 %}}
-
 In the following pipeline, `train_model` will train a model for 1, 5, 10, and 25 epochs, with no more than two training tasks running at one time:
 
 ```python
@@ -164,8 +160,6 @@ def my_pipeline():
 ### **dsl.Collected**
 
 Use [`dsl.Collected`][dsl-collected] with `dsl.ParallelFor` to gather outputs from a parallel loop of tasks.
-
-{{% oss-be-unsupported feature_name="`dsl.Collected`" gh_issue_link=https://github.com/kubeflow/pipelines/issues/6161 %}}
 
 #### **Example:** Using `dsl.Collected` as an input to a downstream task
 
@@ -318,8 +312,6 @@ def my_pipeline():
     with dsl.ExitHandler(exit_task=print_status_task):
         fail_op()
 ```
-
-{{% oss-be-unsupported feature_name="Setting `PipelineTaskFinalStatus`" gh_issue_link=https://github.com/kubeflow/pipelines/issues/10917 %}}
 
 #### **Example:** Ignoring upstream task failures
 


### PR DESCRIPTION
Current implemented features on master for pipelines that will be available for 2.6: loop parallelism - https://github.com/kubeflow/pipelines/pull/10798 oneOf - https://github.com/kubeflow/pipelines/pull/11196 dsl.Collected - https://github.com/kubeflow/pipelines/pull/11725 PipelineTaskFinalStatus - https://github.com/kubeflow/pipelines/pull/11953

<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
- [ ] You have included screenshots when changing the website style or adding a new page.


**Description of your changes:**


### Issue

<!--
 If this pull request resolves an open issue, please link the issue in the PR
 description so it will automatically close when the PR is merged.

 See the GitHub documentation for more details and other options:

 https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes: #

<!--Additional Information:-->
### Labels
<!-- Please include labels below by uncommenting them to help us better review PRs -->

<!-- /area central-dashboard -->
<!-- /area katib -->
<!-- /area kserve -->
<!-- /area model-registry -->
<!-- /area notebooks -->
<!-- /area pipelines -->
<!-- /area spark-operator -->
<!-- /area trainer -->
<!-- /area gsoc -->
<!-- /area website -->
<!-- /area community -->
---

