### PR TITLE
chore: use OWNERS to set area labels on PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,42 +1,24 @@
 <!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->
 
+### Description of Changes
 
-**Checklist:**
+<!-- Please include a summary of the changes and which issue is fixed. -->
+
+### Related Issues
+
+<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
+     This will automatically close the issue when the PR is merged. -->
+
+Closes: #<issue number>
+
+<!-- If this pull request is RELATED but does NOT resolve an open issue,
+     include it here with the prefix "Related: #<issue number>" -->
+
+Related: #<issue number>
+
+
+### Checklist
+
 - [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
-- [ ] Ensure you follow best practices from our guide. [Contributing](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md). 
-- [ ] You have included screenshots when changing the website style or adding a new page.
-
-
-**Description of your changes:**
-
-
-### Issue
-
-<!--
- If this pull request resolves an open issue, please link the issue in the PR
- description so it will automatically close when the PR is merged.
-
- See the GitHub documentation for more details and other options:
-
- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
--->
-
-Closes: #
-
-<!--Additional Information:-->
-### Labels
-<!-- Please include labels below by uncommenting them to help us better review PRs -->
-
-<!-- /area central-dashboard -->
-<!-- /area katib -->
-<!-- /area kserve -->
-<!-- /area model-registry -->
-<!-- /area notebooks -->
-<!-- /area pipelines -->
-<!-- /area spark-operator -->
-<!-- /area trainer -->
-<!-- /area gsoc -->
-<!-- /area website -->
-<!-- /area community -->
----
-
+- [ ] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
+- [ ] (for big changes) I will post screenshots of the changes in a PR comment

--- a/assets/OWNERS
+++ b/assets/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/website

--- a/content/en/docs/about/OWNERS
+++ b/content/en/docs/about/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/community
+
 approvers:
   - 8bitmp3
   - andreyvelich

--- a/content/en/docs/components/central-dash/OWNERS
+++ b/content/en/docs/components/central-dash/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/central-dashboard
+
 approvers:
   - kimwnasptd
   - thesuperzapper

--- a/content/en/docs/components/katib/OWNERS
+++ b/content/en/docs/components/katib/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/katib
+
 approvers:
   - andreyvelich
   - gaocegege

--- a/content/en/docs/components/model-registry/OWNERS
+++ b/content/en/docs/components/model-registry/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/model-registry
+
 approvers:
   - Al-Pragliola
   - ederign

--- a/content/en/docs/components/notebooks/OWNERS
+++ b/content/en/docs/components/notebooks/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/notebooks
+
 approvers:
   - StefanoFioravanzo
   - elikatsis

--- a/content/en/docs/components/pipelines/OWNERS
+++ b/content/en/docs/components/pipelines/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/pipelines
+
 approvers:
   - chensun
   - rimolive

--- a/content/en/docs/components/spark-operator/OWNERS
+++ b/content/en/docs/components/spark-operator/OWNERS
@@ -1,7 +1,11 @@
+labels:
+  - area/spark-operator
+
 approvers:
   - ChenYi015
   - mwielgus
   - yuchaoran2011
   - vara-bonthu
+
 reviewers:
   - jacobsalway

--- a/content/en/docs/components/trainer/OWNERS
+++ b/content/en/docs/components/trainer/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/trainer
+
 approvers:
   - andreyvelich
   - ChanYiLin

--- a/content/en/docs/distributions/OWNERS
+++ b/content/en/docs/distributions/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/community

--- a/content/en/docs/external-add-ons/OWNERS
+++ b/content/en/docs/external-add-ons/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/community

--- a/content/en/docs/genai/OWNERS
+++ b/content/en/docs/genai/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/community

--- a/content/en/docs/releases/OWNERS
+++ b/content/en/docs/releases/OWNERS
@@ -1,6 +1,10 @@
+labels:
+  - area/community
+
 approvers:
   - thesuperzapper
   - zijianjoy
+
 reviewers:
   - thesuperzapper
   - zijianjoy

--- a/content/en/docs/started/OWNERS
+++ b/content/en/docs/started/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/community
+
 approvers:
   - RFMVasconcelos
   - 8bitmp3

--- a/content/en/events/OWNERS
+++ b/content/en/events/OWNERS
@@ -1,3 +1,6 @@
+labels:
+  - area/community
+
 approvers:
   - akgraner
   - jbottum

--- a/layouts/OWNERS
+++ b/layouts/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/website

--- a/static/OWNERS
+++ b/static/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/website

--- a/themes/OWNERS
+++ b/themes/OWNERS
@@ -1,0 +1,2 @@
+labels:
+  - area/website


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

This PR makes it so that all future PRs will be automatically labeled with the `area/xxxx` labels, based on the files they change.

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

Closes: #<issue number>

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: #<issue number>

### Checklist

- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
