### PR TITLE
Add Swagger Spec for Model Registry UI (issue #1207)

### DIFF
--- a/content/en/docs/components/model-registry/reference/ui-rest-api.md
+++ b/content/en/docs/components/model-registry/reference/ui-rest-api.md
@@ -1,0 +1,20 @@
+---
+title: "Model Registry UI REST API"
+description: "This page contains the OpenAPI (Swagger) specification for the Model Registry UI APIs."
+weight: 30
+---
+
+## Overview
+
+This page provides the REST API specification for the **Model Registry UI**, used to manage model registry settings and configurations from the frontend.
+
+The API spec follows the OpenAPI 3.0 standard. It defines endpoints related to:
+- Managing UI-based settings for model registry
+- Fetching and updating configuration
+- Handling frontend-specific operations
+
+## Swagger/OpenAPI Reference
+
+You can explore the full API using the Swagger YAML here:
+
+[Raw Swagger YAML for Model Registry UI](https://raw.githubusercontent.com/kubeflow/model-registry/main/clients/ui/api/openapi/mod-arch.yaml)

--- a/content/en/docs/components/model-registry/reference/ui-rest-api.md
+++ b/content/en/docs/components/model-registry/reference/ui-rest-api.md
@@ -18,3 +18,4 @@ The API spec follows the OpenAPI 3.0 standard. It defines endpoints related to:
 You can explore the full API using the Swagger YAML here:
 
 [Raw Swagger YAML for Model Registry UI](https://raw.githubusercontent.com/kubeflow/model-registry/main/clients/ui/api/openapi/mod-arch.yaml)
+


### PR DESCRIPTION
### Summary

This PR adds the Swagger/OpenAPI specification for the Model Registry UI to the Kubeflow website under:

`content/en/docs/components/model-registry/reference/ui-rest-api.md`

It provides users with a dedicated documentation page for the UI-facing endpoints defined in `mod-arch.yaml` from the model-registry repo.

### Details

- Adds a new Markdown file (`ui-rest-api.md`) under `model-registry/reference`
- Links to the raw Swagger YAML file:  
  https://raw.githubusercontent.com/kubeflow/model-registry/main/clients/ui/api/openapi/mod-arch.yaml
- Structured to match the style of the existing main REST API doc
- Resolves part of [kubeflow/model-registry#1207](https://github.com/kubeflow/model-registry/issues/1207)

### Next Steps

Once this is published to the website, the README in `model-registry` will link to this page to replace the broken Swagger link.

Once this page is published to the website, the temporary link in the model-registry README pointing to the raw YAML will be removed and replaced with a proper internal doc reference.
