### PR TITLE
trainer: Update kubeflow sdk reference

### DIFF
--- a/content/en/docs/components/trainer/getting-started.md
+++ b/content/en/docs/components/trainer/getting-started.md
@@ -19,7 +19,7 @@ Kubeflow Trainer.
 Install the latest Kubeflow Python SDK version directly from the source repository:
 
 ```bash
-pip install git+https://github.com/kubeflow/sdk.git@main#subdirectory=python
+pip install git+https://github.com/kubeflow/sdk.git@main
 ```
 
 ## Getting Started with PyTorch

--- a/content/en/docs/components/trainer/user-guides/pytorch.md
+++ b/content/en/docs/components/trainer/user-guides/pytorch.md
@@ -238,4 +238,4 @@ print(TrainerClient().get_job_logs(name=job_id)["node-0"])
 - Check out [the PyTorch MNIST example](https://github.com/kubeflow/trainer/blob/master/examples/pytorch/image-classification/mnist.ipynb).
 - Follow [the PyTorch fine-tuning example](https://github.com/kubeflow/trainer/blob/master/examples/pytorch/question-answering/fine-tune-distilbert.ipynb)
   using the pre-trained DistilBERT model.
-- Learn more about `TrainerClient()` APIs [in the Kubeflow SDK](https://github.com/kubeflow/sdk/blob/main/python/kubeflow/trainer/api/trainer_client.py).
+- Learn more about `TrainerClient()` APIs [in the Kubeflow SDK](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/api/trainer_client.py).

--- a/content/en/docs/started/architecture.md
+++ b/content/en/docs/started/architecture.md
@@ -139,7 +139,7 @@ See the following sets of reference documentation:
 - [Pipelines reference docs](/docs/components/pipelines/reference/) for the Kubeflow
   Pipelines API and SDK, including the Kubeflow Pipelines domain-specific
   language (DSL).
-- [Kubeflow Python SDK](https://github.com/kubeflow/sdk/blob/main/python/kubeflow/trainer/api/trainer_client.py)
+- [Kubeflow Python SDK](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/api/trainer_client.py)
   to interact with Kubeflow Trainer APIs and to manage TrainJobs.
 - [Katib Python SDK](https://github.com/kubeflow/katib/blob/086093fed72610c227e3ae1b4044f27afa940852/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py)
   to manage Katib hyperparameter tuning Experiments using Python APIs.


### PR DESCRIPTION
Since we've moved `pyproject.toml` to root in https://github.com/kubeflow/sdk/pull/61, I updated its references on the website

/assign @andreyvelich