### PR TITLE
trainer: Fix the version in installation guide

### DIFF
--- a/content/en/docs/components/trainer/operator-guides/installation.md
+++ b/content/en/docs/components/trainer/operator-guides/installation.md
@@ -30,7 +30,7 @@ kind create cluster # or minikube start
 Run the following command to deploy a released version of Kubeflow Trainer controller manager:
 
 ```bash
-VERSION=v2.0.0
+export VERSION=v2.0.0
 kubectl apply --server-side -k "https://github.com/kubeflow/trainer.git/manifests/overlays/manager?ref=${VERSION}"
 ```
 


### PR DESCRIPTION
We should appropriately set the `VERSION` env during installation.
We noticed that in some shell environment, it won't get saved without `export`

/cc @kubeflow/wg-training-leads @astefanutti @raravena80