### PR TITLE
trainer: Change label for deprecated runtimes

### DIFF
--- a/content/en/docs/components/trainer/operator-guides/runtime.md
+++ b/content/en/docs/components/trainer/operator-guides/runtime.md
@@ -168,7 +168,7 @@ These measures are taken to inform users about runtime deprecation:
 - Add the following label to the deprecated runtime:
 
   ```yaml
-  trainer.kubeflow.org/deprecated: "true"
+  trainer.kubeflow.org/support: "deprecated"
   ```
 
 - Document the deprecation as **a breaking change** in Kubeflow Trainer release notes.


### PR DESCRIPTION
As we discussed here, we agreed on the `trainer.kubeflow.org/support: deprecated` label to the Kubeflow Trainer deprecated runtimes: https://github.com/kubeflow/trainer/pull/2791/files#r2307816311

/cc @kubeflow/kubeflow-trainer-team @astefanutti 