### PR TITLE
Docs/pipeline version note

### DIFF
--- a/content/en/docs/components/pipelines/operator-guides/installation/_index.md
+++ b/content/en/docs/components/pipelines/operator-guides/installation/_index.md
@@ -21,7 +21,11 @@ You should be familiar with [Kubernetes](https://kubernetes.io/docs/home/),
      export PIPELINE_VERSION={{% pipelines/latest-version %}}
      kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
      kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
-     kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/dev?ref=$PIPELINE_VERSION"
+     kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/dev?ref=$PIPELINE_VERSION" 
+
+> **Note:** The placeholder `{{% pipelines/latest-version %}}` automatically resolves to the latest Kubeflow Pipelines release (e.g., `2.5.0`).  
+> Users don’t need to manually update this value each time a new release is published.
+
      ```
 
 > 💡 **Troubleshooting**: If you encounter persistent pod crashes (e.g., `proxy-agent`, `workflow-controller`) after applying the default config, you may try using the `platform-agnostic` configuration instead:


### PR DESCRIPTION
docs(pipelines): clarify installation guide with latest-version note fixes #4160 

This PR updates the Kubeflow Pipelines installation guide to clarify the usage of the {{% pipelines/latest-version %}} placeholder.

Adds a note explaining that {{% pipelines/latest-version %}} automatically resolves to the latest release (e.g., 2.5.0).

Users do not need to manually update this value with every new release.

Improves readability and reduces potential confusion for first-time users following the installation instructions.

Related Issues:

Related: #4160

