### PR TITLE
website: kubeflow outreach slack link

### DIFF
--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -29,6 +29,7 @@ The following table lists official Kubeflow channels which are hosted on the **C
 | --------------------------------------- | ------------------------------------------------------------------------------ |
 | Announcements                           | [#kubeflow-announcements](https://app.slack.com/client/T08PSQ7BQ/C01EV0FV154)  |
 | Contributors                            | [#kubeflow-contributors](https://app.slack.com/client/T08PSQ7BQ/C0742LBR5BM)   |
+| Outreach                                | [#kubeflow-outreach](https://app.slack.com/client/T08PSQ7BQ/C073N7BMLB1)       |
 | Katib                                   | [#kubeflow-katib](https://app.slack.com/client/T08PSQ7BQ/C073N7AS48P)          |
 | ML experience                           | [#kubeflow-ml-experience](https://app.slack.com/client/T08PSQ7BQ/C08KJBVDH5H)  |
 | Model Registry                          | [#kubeflow-model-registry](https://app.slack.com/client/T08PSQ7BQ/C073N7B6K3R) |


### PR DESCRIPTION
### Description of Changes

Add slack link of `kubeflow-outreach` to the community page. https://www.kubeflow.org/docs/about/community/#slack-channels

Closes: #4199


### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
