### PR TITLE
docs: Fix typo in GenAI use-cases docs

### DIFF
--- a/content/en/docs/genai/use-cases.md
+++ b/content/en/docs/genai/use-cases.md
@@ -7,7 +7,9 @@ aliases = ["/genai/use-cases/"]
 
 # Powering GenAI Use Cases with Kubeflow
 
+
 Kubeflow Projects are powering every stage of the GenAI application lifecycle
+
 
 From generating synthetic data to retrieval-augmented generation (RAG), fine-tuning large language models (LLMs), hyperparameter optimization, inference at scale, and evaluation,
 Kubeflow’s modular, Kubernetes-native architecture makes building end-to-end GenAI pipelines both reproducible and production-ready.


### PR DESCRIPTION
This PR fixes a typo in the GenAI use-cases documentation. fixes #4201 

Before:
Kubeflow Projects are powered every stage of GenAI application lifecycle.

After:
Kubeflow Projects are powering every stage of the GenAI application lifecycle.

This makes the sentence grammatically correct.
