### PR TITLE
model-registry: add (graduation) badges

### DIFF
--- a/content/en/docs/components/model-registry/_index.md
+++ b/content/en/docs/components/model-registry/_index.md
@@ -3,3 +3,7 @@ title = "Kubeflow Model Registry"
 description = "Documentation for Kubeflow Model Registry"
 weight = 50
 +++
+
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry?ref=badge_shield&issueType=license)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9937/badge)](https://www.bestpractices.dev/projects/9937)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubeflow/model-registry/badge)](https://scorecard.dev/viewer/?uri=github.com/kubeflow/model-registry)

--- a/content/en/docs/components/model-registry/getting-started.md
+++ b/content/en/docs/components/model-registry/getting-started.md
@@ -4,6 +4,10 @@ description = "Getting started with Model Registry using examples"
 weight = 20
 +++
 
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry?ref=badge_shield&issueType=license)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9937/badge)](https://www.bestpractices.dev/projects/9937)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubeflow/model-registry/badge)](https://scorecard.dev/viewer/?uri=github.com/kubeflow/model-registry)
+
 This guide shows how to get started with Model Registry and run a few examples using the
 command line or Python clients.
 

--- a/content/en/docs/components/model-registry/installation.md
+++ b/content/en/docs/components/model-registry/installation.md
@@ -4,6 +4,10 @@ description = "How to set up Model Registry"
 weight = 30
 +++
 
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry?ref=badge_shield&issueType=license)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9937/badge)](https://www.bestpractices.dev/projects/9937)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubeflow/model-registry/badge)](https://scorecard.dev/viewer/?uri=github.com/kubeflow/model-registry)
+
 This section details how to set up and configure Model Registry on your Kubernetes cluster with Kubeflow.
 
 ## Prerequisites

--- a/content/en/docs/components/model-registry/overview.md
+++ b/content/en/docs/components/model-registry/overview.md
@@ -4,6 +4,10 @@ description = "An overview for Kubeflow Model Registry"
 weight = 10
 +++
 
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry?ref=badge_shield&issueType=license)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9937/badge)](https://www.bestpractices.dev/projects/9937)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubeflow/model-registry/badge)](https://scorecard.dev/viewer/?uri=github.com/kubeflow/model-registry)
+
 {{% alpha-status feedbacklink="https://github.com/kubeflow/model-registry/issues/new/choose" %}}
 
 ## What is Model Registry?

--- a/content/en/docs/components/model-registry/reference/_index.md
+++ b/content/en/docs/components/model-registry/reference/_index.md
@@ -3,3 +3,7 @@ title = "Reference"
 description = "Reference docs for Kubeflow Model Registry"
 weight = 100
 +++
+
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkubeflow%2Fmodel-registry?ref=badge_shield&issueType=license)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9937/badge)](https://www.bestpractices.dev/projects/9937)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubeflow/model-registry/badge)](https://scorecard.dev/viewer/?uri=github.com/kubeflow/model-registry)


### PR DESCRIPTION
### Description of Changes

as part of the due diligences for raising the Graduation document to the TOC, as the Model Registry WG we implemented a number of badge(s). It has been suggested to highlight these also on the website, according to this PR.

<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->



<!-- Please include a summary of the changes and which issue is fixed. -->

### Related Issues

none


### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment
