### PR TITLE
pipelines: adding maxRetries option to s3 config examples

### DIFF
--- a/content/en/docs/components/pipelines/operator-guides/configure-object-store.md
+++ b/content/en/docs/components/pipelines/operator-guides/configure-object-store.md
@@ -186,6 +186,7 @@ data:
         disableSSL: false
         region: us-east-2
         forcePathStyle: true
+        maxRetries: 5
         credentials:
           fromEnv: false
           secretRef:
@@ -217,6 +218,7 @@ data:
         disableSSL: false
         region: us-east-2
         forcePathStyle: true
+        maxRetries: 5
         credentials:
           fromEnv: true
 kind: ConfigMap
@@ -330,6 +332,7 @@ s3:
     disableSSL: true
     region: minio
     forcePathStyle: true
+    maxRetries: 5
     credentials:
       fromEnv: false
       secretRef:


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

Updating Object Store Configuration with `maxRetries` example, so that in case someone want to override the default value, they have an example to refer to

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
