### PR TITLE
docs(spark-operator): fix Helm parameter name for Volcano integration

### DIFF
--- a/content/en/docs/components/spark-operator/user-guide/volcano-integration.md
+++ b/content/en/docs/components/spark-operator/user-guide/volcano-integration.md
@@ -24,7 +24,7 @@ helm repo add spark-operator https://kubeflow.github.io/spark-operator
 helm install my-release spark-operator/spark-operator \
     --namespace spark-operator \
     --set webhook.enable=true \
-    --set batchScheduler.enable=true
+    --set controller.batchScheduler.enable=true
 ```
 
 ## Run Spark Application with Volcano scheduler


### PR DESCRIPTION
### What this PR does  fixes #4212 
Fixes incorrect Helm parameter in `volcano-integration.md`.

### Changes made
- Updated:
  `--set batchScheduler.enable=true`
  ➜
  `--set controller.batchScheduler.enable=true`

### Why this is needed
The previous parameter was incorrect and caused the Volcano batch scheduler
not to be enabled when deploying the Spark Operator with TLS integration.