### PR TITLE
kserve: Fix incorrect link to KServe website

### DIFF
--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -44,7 +44,7 @@ corresponding [AI lifecycle stage](/docs/started/architecture/#kubeflow-projects
     <tbody>
       <tr>
         <td>
-         <a href="https://kserve.github.io/website/master/admin/serverless/serverless">
+         <a href="https://kserve.github.io/website/">
             KServe
           </a>
         </td>


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

<!-- Please include a summary of the changes and which issue is fixed. -->

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

Closes: #<issue number>

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: #<issue number>


### Checklist

- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
