### PR TITLE
katib: fixed broken link in Katib overview

### DIFF
--- a/content/en/docs/components/katib/overview.md
+++ b/content/en/docs/components/katib/overview.md
@@ -33,7 +33,7 @@ Katib supports a lot of various AutoML algorithms, such as
 and many more. Additional algorithm support is coming soon.
 
 The [Katib project](https://github.com/kubeflow/katib) is open source.
-The [developer guide](https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md)
+The [developer guide](https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md)
 is a good starting point for developers who want to contribute to the project.
 
 <img src="/docs/components/katib/images/katib-overview.drawio.png"


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

Updated the link to the developer guide in the Katib overview which was previously broken.

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

Closes: [#2582](https://github.com/kubeflow/katib/issues/2582)

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
