### PR TITLE
website: add website folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ resources/
 #
 # vim files
 **/*.swp
+website/


### PR DESCRIPTION
Added `website/` to `.gitignore` to prevent local untracked build folder from appearing after running `hugo serve`.

### Related Issues
Closes: #4226

### Checklist
- [x] You have signed off your commits
- [x] Followed contributing guide
