### PR TITLE
trainer: Add Kueue cross-reference to Job Scheduling documentation

### DIFF
--- a/content/en/docs/components/trainer/operator-guides/job-scheduling/kueue.md
+++ b/content/en/docs/components/trainer/operator-guides/job-scheduling/kueue.md
@@ -1,0 +1,7 @@
++++
+title = "Kueue"
+description = "Configure job queueing and resource management with Kueue"
+manualLink = "https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/"
+icon = "fa-solid fa-arrow-up-right-from-square"
+weight = 40
++++

--- a/content/en/docs/components/trainer/operator-guides/job-scheduling/overview.md
+++ b/content/en/docs/components/trainer/operator-guides/job-scheduling/overview.md
@@ -28,3 +28,4 @@ supported plugins.
 
 - Learn how to enable gang scheduling with the [Coscheduling plugin](/docs/components/trainer/operator-guides/job-scheduling/coscheduling).
 - Learn how to configure advanced scheduling with [Volcano Scheduler](/docs/components/trainer/operator-guides/job-scheduling/volcano).
+- Learn how to configure job queueing and resource management with [Kueue](/docs/components/trainer/operator-guides/job-scheduling/kueue).


### PR DESCRIPTION
### Description of Changes

This PR adds a cross-reference to the Kueue TrainJob documentation in the Kubeflow Trainer Job Scheduling guide. 

**Changes include:**
- Created a new `kueue.md` page in the Job Scheduling section that redirects to the Kueue documentation at https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/
- Updated the `overview.md` page to include a link to Kueue in the "Next Steps" section
- Follows the same pattern as the Community Guides (external redirect with `manualLink` and icon)

This completes the second task of issue #2919, which required cross-referencing the Kueue TrainJob documentation from the Kubeflow website. The first task (adding documentation to the Kueue website) was already completed.

### Related Issues

Closes: [#2919](https://github.com/kubeflow/trainer/issues/2919)