### PR TITLE
trainer: PlainML policy added in ML Policy docs

### DIFF
--- a/content/en/docs/components/trainer/operator-guides/ml-policy.md
+++ b/content/en/docs/components/trainer/operator-guides/ml-policy.md
@@ -16,12 +16,6 @@ to understand the basics of Kubeflow Trainer Runtimes.
 The `MLPolicy` API defines the ML-specific configuration for the training jobs - for example,
 the number of training nodes (e.g., Pods) to launch, or PyTorch settings.
 
-```YAML
-mlPolicy:
-  numNodes: 3
-  torch:
-    numProcPerNode: gpu
-```
 
 ## Types of MLPolicy
 
@@ -31,14 +25,13 @@ the training job is launched and orchestrated. You can specify one of the suppor
 
 ### PlainML
 
-The `PlainML` policy configures training jobs without a specialized distributed framework. It simply uses the `numNodes` value to set the job’s parallelism (number of pods) and applies any training environment variables to each pod.
+The empty policy configures training jobs without a specialized distributed framework. It simply uses the `numNodes` value to set the job’s parallelism (number of pods) and applies any training environment variables to each pod. For empty policy, the PlainML plugin is activated in the extension framework.
 
 TrainJobs using this policy are launched as standard Kubernetes Jobs. The number of pods (parallelism) and completions is set based on the `numNodes` field in the `Trainer` spec, and environment variables from the TrainJob spec are added to the training containers.
 
 ```YAML
 mlPolicy:
   numNodes: 10
-  plain: {}
 ```
 
 ### Torch
@@ -49,6 +42,13 @@ configures distributed training for PyTorch.
 TrainJobs using this policy are launched via [the `torchrun` CLI](https://docs.pytorch.org/docs/stable/elastic/run.html).
 You can customize `torchrun` options such as `numProcPerNode` to define number of
 processes (e.g. GPUs) to launch per training node.
+
+```YAML
+mlPolicy:
+  numNodes: 3
+  torch:
+    numProcPerNode: gpu
+```
 
 ### MPI
 
@@ -67,4 +67,7 @@ mlPolicy:
   numNodes: 2
   mpi:
     numProcPerNode: 4
+    mpiImplementation: OpenMPI
+    sshAuthMountPath: /home/mpiuser/.ssh
+    runLauncherAsNode: true
 ```


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes
This PR updates the [ML Policy guide](https://www.kubeflow.org/docs/components/trainer/operator-guides/ml-policy/) to include documentation for the PlainML plugin.

<!-- Please include a summary of the changes and which issue is fixed. -->

### Changes

- Added a new PlainML section under "Types of MLPolicy".

- Clarified that this policy applies when no specialized distributed framework (like Torch or MPI) is configured.

- Explained how PlainML utilizes numNodes to configure job parallelism/completions and propagates environment variables to the training containers.

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

Closes:  #[kubeflow/trainer/#2993](https://github.com/kubeflow/trainer/issues/2993)

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: #<issue number>


### Checklist

- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
