### PR TITLE
Update announcement to KubeCon Europe 2026 - Fixes #4239

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -61,11 +61,11 @@ ignoreFiles = []
 ###############################################################################
 [menu]
   [[menu.main]]
-    name = "Kubeflow Summit"
-    weight = -1000
+    name = "Kubeflow Europe 2026"
+    weight = -950
     pre = "<i class='fas fa-calendar pr-2' style='color: #FFC107'></i>"
-    post = "<br><span class='badge badge-warning'>Nov 10th, 2025</span> <span class='badge badge-warning'>Atlanta, Georgia</span>"
-    url = "https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/kubeflow-summit/"
+    post = "<br><span class='badge badge-warning'>Mar 31-Apr 3, 2026</span> <span class='badge badge-warning'>Paris, France</span>"
+    url = "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/cloud-native-ai-kubeflow-day/"
   
 #  [[menu.main]]
 #    name = "GSoC 2025"
@@ -225,9 +225,9 @@ enable = true
   # The announcement label text (displayed in bold, e.g., "Announcement:")
   text = "Announcement: "
   # The clickable link text
-  link_text = "Join us at KubeCon Europe 2026 - Cloud Native AI & Kubeflow Day!"
+  link_text = "Check out Kubeflow Unified SDK Survey!"
   # The URL for the announcement link
-  url = "https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/cloud-native-ai-kubeflow-day/"
+  url = "https://docs.google.com/forms/d/e/1FAIpQLSet_IAFQzMMDWolzFt5LI9lhzqOOStjIGHxgYqKBnVcRtDfrw/viewform?usp=dialog"
   # Optional icon/emoji (e.g., "✨") - displayed before and after the announcement
   icon = "✨"
 


### PR DESCRIPTION
 Update homepage announcement to KubeCon Europe 2026

### Description of Changes

Updated the website header announcement banner to promote the upcoming KubeCon Europe 2026 event, replacing the previous survey announcement.

### Related Issues

Closes: #4239

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
