### PR TITLE
website: remove unmaintained gcp distribution

### DIFF
--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -204,21 +204,6 @@ The following table lists distributions which are <em>maintained</em> by their r
       </tr>
       <tr>
         <td>
-          Google Cloud
-        </td>
-        <td>
-          {{< kf-version-notice >}}{{% gke/latest-version %}}{{< /kf-version-notice >}}
-          <sup><a href="https://googlecloudplatform.github.io/kubeflow-gke-docs/docs/changelog/">[release notes]</a></sup>
-        </td>
-        <td>
-          Google Kubernetes Engine (GKE)
-        </td>
-        <td>
-          <a href="https://googlecloudplatform.github.io/kubeflow-gke-docs">Website</a>
-        </td>
-      </tr>
-      <tr>
-        <td>
           Microsoft Azure
         </td>
         <td>


### PR DESCRIPTION
@andreyvelich @franciscojavierarceo @james-jwu @chensun @zijianjoy

We are close to releasing Kubeflow 1.11.0 so the GCP distribution is outdated then by 2-3 years and 8 or so releases. 
We still suppport GCP in kubeflow/manifests.