### PR TITLE
website: temporarily remove the DHL logo

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -99,11 +99,12 @@ title = "Kubeflow"
         <img class="adopter-logo show_dark-only" src="/docs/images/logos/aws-dark.svg" alt="AWS Logo">
       </div>
       
-      <!-- DHL (Organization Contact: @juliusvonkohout) -->
+      <!-- DHL (Organization Contact: @juliusvonkohout)
       <div class="px-5 py-4">
         <img class="adopter-logo show_light-only" src="/docs/images/logos/dhl-light.svg" alt="DHL Logo">
         <img class="adopter-logo show_dark-only" src="/docs/images/logos/dhl-dark.svg" alt="DHL Logo">
       </div>
+      -->
 
       <!-- Oracle (Organization Contact: TBA) -->
       <div class="px-5 py-4">


### PR DESCRIPTION
Due to organizational changes I have to temporarily remove the logo. I will follow up with more information.