### PR TITLE
website: new shortcut for community content

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -84,10 +84,10 @@ ignoreFiles = []
     pre = "<i class='fas fa-book pr-2'></i>"
     url = "/docs/"
   [[menu.main]]
-    name = "Events"
+    name = "Community"
     weight = -101
-    pre = "<i class='fas fa-calendar pr-2'></i>"
-    url = "/events/"
+    pre = "<i class='fas fa-users pr-2'></i>"
+    url = "/docs/about/community/"
   [[menu.main]]
     name = "Blog"
     weight = -100


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

Replaces the "event" named tab with "community", along with replacing the icon

Following image shows the header after the update,
<img width="701" height="56" alt="Screenshot 2025-12-21 at 2 09 36 AM" src="https://github.com/user-attachments/assets/f24d850e-c412-4872-86d7-d48110feadea" />

### Related Issues
Closes: #4251

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment
