### PR TITLE
fix(#3940): Add release navigation links to _index.md

### DIFF
--- a/content/en/docs/kubeflow-platform/releases/_index.md
+++ b/content/en/docs/kubeflow-platform/releases/_index.md
@@ -3,3 +3,19 @@ title = "Releases"
 description = "Information about past and future Kubeflow AI reference platform releases"
 weight = 100
 +++
+
+## Kubeflow Releases
+
+- [Kubeflow 1.9](kubeflow-1.9.md)
+- [Kubeflow 1.8](kubeflow-1.8.md)
+- [Kubeflow 1.7](kubeflow-1.7.md)
+- [Kubeflow 1.6](kubeflow-1.6.md)
+- [Kubeflow 1.5](kubeflow-1.5.md)
+- [Kubeflow 1.4](kubeflow-1.4.md)
+- [Kubeflow 1.3](kubeflow-1.3.md)
+- [Kubeflow 1.2](kubeflow-1.2.md)
+- [Kubeflow 1.1](kubeflow-1.1.md)
+- [Kubeflow 1.0](kubeflow-1.0.md)
+- [Kubeflow 0.7](kubeflow-0.7.md)
+- [Kubeflow 0.6](kubeflow-0.6.md)
+

--- a/content/en/docs/kubeflow-platform/releases/_index.md
+++ b/content/en/docs/kubeflow-platform/releases/_index.md
@@ -3,9 +3,9 @@ title = "Releases"
 description = "Information about past and future Kubeflow AI reference platform releases"
 weight = 100
 +++
-
 ## Kubeflow Releases
-
+- [Kubeflow 1.11](kubeflow-1.11.md)
+- [Kubeflow 1.10](kubeflow-1.10.md)
 - [Kubeflow 1.9](kubeflow-1.9.md)
 - [Kubeflow 1.8](kubeflow-1.8.md)
 - [Kubeflow 1.7](kubeflow-1.7.md)
@@ -18,4 +18,3 @@ weight = 100
 - [Kubeflow 1.0](kubeflow-1.0.md)
 - [Kubeflow 0.7](kubeflow-0.7.md)
 - [Kubeflow 0.6](kubeflow-0.6.md)
-


### PR DESCRIPTION
fix(#3940): Add release navigation links to _index.md

- Fixed 'file not found' error in releases directory [attached_file:1]
- Added navigation links for Kubeflow 0.6-1.9 (12 links total)
- Verified diff shows all links added [file:307]

### Description of Changes
Added missing release navigation links to `content/en/docs/kubeflow-platform/releases/_index.md`. 
The releases page was empty (just frontmatter) causing "file not found" errors during versioning.

### Related Issues
Closes: #3940

### Checklist
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment

**Sapthagiri777** (Jaeger CNCF contributor - 3 PRs merged)
