### PR TITLE
trainer: Add GPU passthrough documentation for local execution mode

### DIFF
--- a/content/en/docs/components/trainer/user-guides/local-execution-mode/overview.md
+++ b/content/en/docs/components/trainer/user-guides/local-execution-mode/overview.md
@@ -53,6 +53,7 @@ Run distributed TrainJobs using Podman, a daemonless container engine with enhan
 | **Setup** | No additional software | Docker Desktop/Engine | Podman installation |
 | **Isolation** | Virtual environments | Full container isolation | Full container isolation |
 | **Multi-node** | Not supported | Supported | Supported |
+| **NVIDIAGPU Support** | Not supported | Linux/Windows (WSL2) | Linux/Windows (WSL2) |
 | **Root Required** | No | Docker group or root | Rootless supported |
 | **Startup Time** | Fast (seconds) | Medium (container start) | Medium (container start) |
 | **Best For** | Quick prototyping | General use, wide ecosystem | Security, Linux servers |


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

<!-- Please include a summary of the changes and which issue is fixed. -->
Adds GPU passthrough documentation for Docker and Podman local execution backends:

  - **docker.md**: New "GPU Training" section with prerequisites (NVIDIA Container Toolkit), code example using `resources_per_node={"gpu": "1"}`, and troubleshooting
  - **podman.md**: New "GPU Training" section with CDI-specific prerequisites, code example, and troubleshooting (including CDI device issues)
  - **overview.md**: Added "NVIDIA GPU Support" row to backend comparison table

Documents platform support (Linux, Windows via WSL2) and notes macOS limitation.

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->


Related: kubeflow/sdk#219

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment
