### PR TITLE
website: GSOC 2026 mentor proposals template

### DIFF
--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -217,9 +217,6 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/external-add-ons/kserve/first_isvc_kserve/ https://kserve.github.io/website/latest/get_started/first_isvc/
 /docs/external-add-ons/kserve/migration/         https://kserve.github.io/website/latest/admin/migration/
 
-# GSoC redirects
-/events/2025/gsoc-2025/                 /events/gsoc-2025/
-
 # ===============
 # IMPORTANT NOTE:
 # Catch-all redirects should be added at the end of this file as redirects happen from top to bottom

--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -11,7 +11,7 @@ The Kubeflow Community plans to participate in [**Google Summer of Code 2026**](
 This page aims to help you participate in GSoC 2026 with Kubeflow.
 
 {{% alert title="Note" color="info" %}}
-While Kubeflow participated in [GSoC 2025](/events/2025/gsoc-2025/), we are currently awaiting final confirmation of our participation in GSoC 2026.
+we are currently awaiting final confirmation of our participation in GSoC 2026.
 Google will announce the final list of accepted organizations on **February 18, 2026**.
 {{% /alert %}}
 


### PR DESCRIPTION
### Description of Changes

This initial template with GSOC 2026 information and project proposal template that Kubeflow mentors can submit their project ides. Note the deadline is February 3rd 2026.

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).