### PR TITLE
trainer: Add Helm chart installation instructions for data cache

### DIFF
--- a/content/en/docs/components/trainer/user-guides/data-cache.md
+++ b/content/en/docs/components/trainer/user-guides/data-cache.md
@@ -80,21 +80,8 @@ helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
     --version ${VERSION#v}
 ```
 
-The following Helm values are available for configuring data cache:
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `dataCache.enabled` | Enable data cache resources (ClusterTrainingRuntime, RBAC) | `false` |
-| `dataCache.lws.install` | Install LeaderWorkerSet as a dependency | `true` |
-| `dataCache.lws.fullnameOverride` | Override LeaderWorkerSet release name | `lws` |
-| `dataCache.image.registry` | Data cache image registry | `ghcr.io` |
-| `dataCache.image.repository` | Data cache image repository | `kubeflow/trainer/data-cache` |
-| `dataCache.image.tag` | Data cache image tag | `latest` |
-| `dataCache.initializerImage.registry` | Dataset initializer image registry | `ghcr.io` |
-| `dataCache.initializerImage.repository` | Dataset initializer image repository | `kubeflow/trainer/dataset-initializer` |
-| `dataCache.initializerImage.tag` | Dataset initializer image tag | `latest` |
-| `dataCache.targetNamespace` | Namespace for ServiceAccount and RoleBinding | `default` |
-| `dataCache.serviceAccount.name` | ServiceAccount name for cache initializer | `kubeflow-trainer-cache-initializer` |
+For the available Helm values to configure data cache, see the
+[kubeflow-trainer Helm chart documentation](https://github.com/kubeflow/trainer/tree/master/charts/kubeflow-trainer).
 
 {{% alert title="Note" color="info" %}}
 
@@ -104,10 +91,10 @@ in your cluster.
 
 {{% /alert %}}
 
-{{% alert title="Note" color="info" %}}
+{{% alert title="Warning" color="warning" %}}
 
-The above command will install RBAC in the `default` namespace. If you want to create TrainJobs
-in other Kubernetes namespace, run this:
+Helm charts don't install RBAC in the user namespace. You have to deploy RBAC separately
+in each namespace where you want to create TrainJobs:
 
 ```bash
 kubectl apply  --server-side -n <NAMESPACE> -k "https://github.com/kubeflow/trainer.git/manifests/overlays/data-cache/namespace-rbac"


### PR DESCRIPTION
### Description of Changes

Add Helm chart installation guide to the data-cache user guide documentation. This includes:
- Helm installation command with `dataCache.enabled=true`
- Table of available Helm configuration values for data cache
- Note about automatic LeaderWorkerSet installation when enabled

### Related Issues

Closes: #4280 
Related: kubeflow/trainer#3080

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment