### PR TITLE
trainer: Flux policy user-guide

### DIFF
--- a/content/en/docs/components/trainer/user-guides/flux.md
+++ b/content/en/docs/components/trainer/user-guides/flux.md
@@ -27,7 +27,7 @@ demanding distributed jobs. The Kubeflow Trainer can be deployed with a Flux Pol
 
 ## Flux Policy Example: LAMMPS
 
-This example demonstrates how to use the **Flux Framework** policy for the Kubeflow Trainer to run distributed HPC workloads. Flux is a next-generation high-performance computing (HPC) scheduler that provides sophisticated resource management in Kubernetes. For more about Flux and its context for Kubeflow Trainer, see [KEP-2841](https://github.com/kubeflow/trainer/tree/master/docs/proposals/2841-flux-hpc).
+This example demonstrates how to use the **Flux Framework** policy for the Kubeflow Trainer to run distributed HPC workloads. 
 
 The Flux plugin automatically handles:
 - Cluster discovery and broker configuration.
@@ -38,18 +38,7 @@ The Flux plugin automatically handles:
 The example here will show you how to run the [LAMMPS](https://www.lammps.org/) Molecular Dynamic Simulator.  The design here emulates the [Flux Operator](https://flux-framework.org/flux-operator/), and you can learn more about Flux Framework and associated projects [here](https://flux-framework.org/). Do you have a question?
 We are part of the High Performance Software Foundation ([HPSF](https://hpsf.io/)) and we hope that you reach out to us with questions or feature requests (The GitHub [flux-framework](https://github.com/flux-framework/) organization works well).
 
-### Prerequisites
-
-1. **Kubeflow Trainer** installed in your cluster.
-2. **JobSet** operator installed (dependency of the Trainer).
-
 ## Quick Start
-
-You'll need to first install the Kubeflow Trainer.
-
-```bash
-kubectl apply --server-side -k "https://github.com/kubeflow/trainer.git/manifests/overlays/manager?ref=master"
-```
 
 This LAMMPS example assumes two small nodes. You can retrieve and alter the LAMMPS manifest to increase the problem size if you have more than that. Apply the `ClusterTrainingRuntime` and the `TrainJob`:
 
@@ -64,22 +53,69 @@ If you get error messages about the webhook, you need to wait a little longer.
 Watch for the pods to be created, and wait for them to be `Running`.
 
 ```bash
-kubectl get pods -w
+kubectl get pods --watch
 ```
+```console
+NAME                         READY   STATUS     RESTARTS   AGE
+lammps-flux-node-0-0-w5pwc   0/1     Init:0/1   0          4s
+lammps-flux-node-0-1-gxkqp   0/1     Init:0/1   0          4s
+lammps-flux-node-0-0-w5pwc   0/1     Init:0/1   0          17s
+lammps-flux-node-0-1-gxkqp   0/1     Init:0/1   0          17s
+lammps-flux-node-0-0-w5pwc   0/1     PodInitializing   0          32s
+lammps-flux-node-0-1-gxkqp   0/1     PodInitializing   0          32s
+lammps-flux-node-0-0-w5pwc   1/1     Running           0          3m38s
+lammps-flux-node-0-1-gxkqp   1/1     Running           0          3m46s
+```
+
+The times above may vary depending on the image you use.
 
 ### 2. Check Logs
 
-You'll see the InitContainer, and then PodInitializing is usually a container pulling.
 To see the Flux broker initialization and the output of the LAMMPS job, check the logs of the lead broker (pod index `0-0`):
 
 ```bash
 kubectl logs lammps-flux-node-0-0-mvjsf -c node -f
+```
+```console
+...
+Performance: 0.036 ns/day, 663.320 hours/ns, 4.188 timesteps/s
+93.0% CPU use with 8 MPI tasks x 1 OpenMP threads
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Pair    | 11.542     | 13.167     | 14.846     |  27.5 | 55.14
+Neigh   | 0.26428    | 0.2649     | 0.26568    |   0.1 |  1.11
+Comm    | 0.12108    | 1.8002     | 3.4243     |  74.5 |  7.54
+Output  | 0.0057505  | 0.006482   | 0.0079982  |   0.8 |  0.03
+Modify  | 8.6376     | 8.6386     | 8.6397     |   0.0 | 36.18
+Other   |            | 0.002142   |            |       |  0.01
+
+Nlocal:        2432.00 ave        2436 max        2427 min
+Histogram: 1 1 0 1 1 0 1 0 1 2
+Nghost:        10687.4 ave       10697 max       10680 min
+Histogram: 3 0 0 0 2 1 0 0 1 1
+Neighs:        824028.0 ave      825512 max      822595 min
+Histogram: 1 1 2 0 0 0 1 1 0 2
+
+Total # of neighbors = 6592221
+Ave neighs/atom = 338.82715
+Neighbor list builds = 5
+Dangerous builds not checked
+Total wall time: 0:00:24
 ```
 
 You can look at the second pod to see the follower broker bootstrap with the lead broker, and then cleanup when LAMMPS is done running.
 
 ```bash
 kubectl logs lammps-flux-node-0-1-glj22 -c node -f
+```
+```console
+Defaulted container "node" out of: node, flux-installer (init)
+Python version: /mnt/flux/view/bin/python3.11
+Python root: /mnt/flux/view/lib/python3.11
+🌀 flux start  -o --config /mnt/flux/config/etc/flux/config -Scron.directory=/mnt/flux/config/etc/flux/system/cron.d   -Stbon.fanout=256   -Srundir=/mnt/flux/config/run/flux    -Sstatedir=/mnt/flux/config/var/lib/flux -Slocal-uri=local:///mnt/flux/config/run/flux/local   -Slog-stderr-level=0    -Slog-stderr-mode=local
+The follower worker exited cleanly. Goodbye!
 ```
 
 ## Interactive Mode
@@ -88,10 +124,9 @@ A cool feature of the Flux plugin is the ability to launch an interactive HPC cl
 
 ### Switch to Interactive Mode
 
-Delete the current job and create an interactive lammps cluster:
+Create an interactive lammps cluster:
 
 ```bash
-kubectl delete -f https://raw.githubusercontent.com/kubeflow/trainer/refs/heads/master/examples/flux/lammps-train-job.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubeflow/trainer/refs/heads/master/examples/flux/flux-interactive.yaml
 ```
 
@@ -132,7 +167,7 @@ For environment variables, we currently support a small set:
 - FLUX_VIEW_IMAGE: The flux view base image, which defaults to `ghcr.io/converged-computing/flux-view-ubuntu:tag-jammy`
 - FLUX_NETWORK_DEVICE: The network device for the Flux overlay network only (not necessarily your application). Defaults to `eth0`
 
-This can be easily expanded. [Let us know](https://github.com/flux-framework).
+This can be easily expanded. If you would like help creating a custom image, please open an issue in the [Flux GitHub organization](https://github.com/flux-framework).
 For the view, you primarily want it to make the base container platform, OS and version. We currently also provide:
 
 - ghcr.io/converged-computing/flux-view-rocky:arm-9
@@ -151,3 +186,4 @@ Thanks for stopping by!
 
 - Check out [the Flux Operator](https://github.com/flux-framework/flux-operator).
 - Learn more about [Flux Framework APIs](https://flux-framework.org).
+- For more about Flux and its context for Kubeflow Trainer, see [KEP-2841](https://github.com/kubeflow/trainer/tree/master/docs/proposals/2841-flux-hpc).


### PR DESCRIPTION
### Description of Changes

This changeset adds documentation (a user guide) to use the Flux Policy in the Kubeflow Trainer. The example includes running a popular simulation, LAMMPS, with CPU. A GPU example is desired and will be added likely in a separate changeset.

### Related Issues

This is linked with a pull request to the trainer,

Related:  https://github.com/kubeflow/trainer/pull/3064. 

I did not open an issue here (and can if needed, please let me know).

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment

cc @milroy 