### PR TITLE
central-dashboard: Fix two broken links in profiles.md

### DIFF
--- a/content/en/docs/components/central-dash/profiles.md
+++ b/content/en/docs/components/central-dash/profiles.md
@@ -105,11 +105,11 @@ spec:
     name: admin@example.com
 
   ## plugins extend the functionality of the profile
-  ## https://github.com/kubeflow/kubeflow/tree/master/components/profile-controller#plugins
+  ## https://github.com/kubeflow/dashboard/tree/main/components/profile-controller#plugins
   plugins: []
   
   ## optionally create a ResourceQuota for the profile
-  ## https://github.com/kubeflow/kubeflow/tree/master/components/profile-controller#resourcequotaspec
+  ## https://github.com/kubeflow/dashboard/tree/main/components/profile-controller#resourcequotaspec
   ## https://kubernetes.io/docs/reference/kubernetes-api/policy-resources/resource-quota-v1/#ResourceQuotaSpec
   resourceQuotaSpec: {}
 ```


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

<!-- Please include a summary of the changes and which issue is fixed. -->
There were two leftover links to the old dashboard repositories that were pointing to a (no longer) existing file. Replace these links with updated ones to the `kubeflow/dashboard` repository.

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [~] (for big changes) I will post screenshots of the changes in a PR comment
