### PR TITLE
gsoc: Add Agentic RAG on Kubeflow GSoC 2026 proposal

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -82,25 +82,52 @@ To participate in GSoC with Kubeflow, you **must** meet the GSoC [eligibility re
 
 ## Project Ideas
 
-### Project 1: Name of the project
+### Project 1: Agentic RAG on Kubeflow (Expansion of kubeflow/docs-agent)
 
-**Components:** All the components this project will touch 
+**Components:** Kubeflow Pipelines (KFP), KServe, Manifests (Deployment/Infra), LLM Agents
 
-**Mentors:** List all the mentors with their github or slack handle
+**Mentors:** @chasecadet, @tarekabouzeid (Tarek Abouzeid - Kubeflow Platform)
 
-**Contributor:** 
+**Contributor:** Details:
 
-**Details:** Description of the proposal, if you have external doc, please have the doc publicly accessible to view
+**Project Overview & Scope:** This project aims to evolve the existing kubeflow/docs-agent from a simple retrieval tool into a robust Reference Architecture for Agentic RAG on Kubeflow. Currently, the tool performs basic lookups. The GSoC contributor will upgrade this to an agentic workflow that can intelligently parse user questions, access the Kubeflow Git repository and Reference Platform Architecture as tools, and provide cited, technical answers. The core goal is "Dogfooding": We want to use Kubeflow to build the AI that helps users learn Kubeflow.
 
-**Difficulty:** [easy|intermediate|hard]
+**Key Deliverables (GSoC Scope):**
 
-**Size:** [170|250|350 hours]
+- **Agentic Architecture:** Implement an agent (using frameworks like LangGraph or Kagent) running on Kubeflow that can query specialized indices (Documentation, GitHub Issues, Platform Architecture).
+- **Ingestion Pipelines:** Build reusable Kubeflow Pipelines (KFP) to scrape, chunk, and index "Golden Data" from our reference architectures, establishing a best-practice pattern for data handling.
+- **Local Serving via KServe:** Demonstrate how to serve the agent's LLM (e.g., Llama 3) using KServe on the cluster, utilizing Scale-to-Zero to handle bursty workloads efficiently.
+- **Deployment Reference:** Create the Terraform/Manifests required to deploy this entire stack on Oracle Cloud Infrastructure (OCI), serving as a reproducible reference for the community.
 
+**Future Vision (Context for the Contributor):** While beyond the immediate GSoC scope, this project lays the foundation for advanced capabilities:
+- **Fine-Tuning & Routing:** Future iterations will use KFP to fine-tune specialized "Router" models that direct queries to specific agents.
+- **Security (MCP & Istio):** We envision integrating the Model Context Protocol (MCP) and using Istio sidecars to secure agent-to-tool communication.
+
+The GSoC contributor is building the bedrock layer that these future innovations will stand upon.
+
+**Community Value:**
+
+- **"Golden Data" Standard:** By curating the data for this agent, we will identify gaps in our documentation and create a trusted dataset of "verified" configurations that the community can use to benchmark their own internal platforms.
+- **Helm Alignment:** This project will validate the new community Helm charts by acting as a "consumer," providing feedback on their ease of deployment in a complex GenAI stack.
+- **Platform Alignment:** We will work closely with Tarek Abouzeid to align with the Kubeflow Platform Documentation. The project must clearly separate Core Kubeflow Services (portable) from Cloud-Specific Adapters (OCI), ensuring the agentic architecture remains portable for any user.
+
+**Ideas and references:**
+
+- Current Repo: [kubeflow/docs-agent](https://github.com/kubeflow/docs-agent)
+- Platform Standards: [Kubeflow Platform Docs](https://www.kubeflow.org/docs/kubeflow-platform/)
+- Infrastructure: [Terraform OCI Provider Docs](https://registry.terraform.io/providers/oracle/oci/latest/docs)
+
+**Difficulty:** Hard
+
+**Size:** 350 hours
 
 **Skills Required/Preferred:**
 
-- List briefly skills you expect from contributor
-- 
+- Python (Backend, Agent logic)
+- Kubeflow (Pipelines, KServe)
+- GenAI/LLM Ops (RAG, Vector Databases)
+- Infrastructure (Terraform, Docker, Kubernetes)
+- Communication (Ability to document architectural decisions clearly) 
 
 ---
 


### PR DESCRIPTION
This PR adds the 'Agentic RAG on Kubeflow' project proposal to the GSoC 2026 upcoming events page. It includes details on the project scope, deliverables, mentors (myself and @tarekabouzeid), and required skills. This is an expansion of the kubeflow/docs-agent project.