### PR TITLE
gsoc: add dynamic llm trainer for gsoc 2026

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -305,9 +305,8 @@ Tracking issue: https://github.com/kubeflow/sdk/issues/238
 [kubeflow/sdk](https://www.github.com/kubeflow/sdk)
 
 **Mentors:**
-[@andreyvelich](https://github.com/andreyvelich),
 [@tariq-hasan](https://github.com/tariq-hasan),
-[TBD]
+[@andreyvelich](https://github.com/andreyvelich)
 
 **Contributor:**
 


### PR DESCRIPTION
This PR adds a GSoC project proposal for implementing a dynamic LLM Trainer framework in Kubeflow Trainer.

Relevant issue: https://github.com/kubeflow/trainer/issues/2839.