### PR TITLE
kserve: Fix link to models-web-app in manifests repo

### DIFF
--- a/content/en/docs/components/kserve/webapp.md
+++ b/content/en/docs/components/kserve/webapp.md
@@ -11,7 +11,7 @@ This allows users to create, delete, and inspect the state of their Model Server
 
 ## Install as part of Kubeflow
 
-The web app has been [included as a part of the `kubeflow/manifests`](https://github.com/kubeflow/manifests/tree/master/applications/kserve/models-web-app) since Kubeflow 1.5 release.
+The web application has been [included as a part of the `kubeflow/manifests`](https://github.com/kubeflow/manifests/tree/master/applications/kserve/models-web-app) repository since  the Kubeflow 1.5 release.
 
 It is exposed as a manu link in the Kubeflow Central Dashboard by default.
 


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

Fix a broken link caused by the move in the manifests repo away from the contrib folder.
<!-- Please include a summary of the changes and which issue is fixed. -->

### Related Issues

_None_

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
