### PR TITLE
katib: Add guide to handle with PSS Errors

### DIFF
--- a/content/en/docs/components/katib/getting-started.md
+++ b/content/en/docs/components/katib/getting-started.md
@@ -44,6 +44,16 @@ namespace: `KatibClient(namespace="kubeflow-user-example-com")`.
 in other namespaces, you can attach this label following the instructions in the 
 [Metrics Collector](/docs/components/katib/user-guides/metrics-collector/#prerequisites).
 
+**Note**. If you are running Katib on a Kubernetes cluster with strict [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) (PSS) enabled (which is common in K8s v1.25+ or Kind environments), the Katib Controller might fail to create Suggestion pods or Trial pods due to security context violations.
+
+If your Experiment gets stuck in the Created state, check the controller logs. You may need to relax the security policy for your experiment's namespace by running:
+
+```bash
+# Allow Katib components to run with required privileges
+# In this example, the namespace is `kubeflow`
+kubectl label namespace <your-namespace> pod-security.kubernetes.io/enforce=privileged --overwrite
+```
+
 ```python
 # [1] Create an objective function.
 def objective(parameters):


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

While following the Katib Python SDK guide, I found that experiments get stuck on K8s 1.25+ due to PSS (Restricted). I have reported the underlying issue in kubeflow/katib#2613. We should add a troubleshooting note or a privileged label instruction to the documentation to prevent new users from getting stuck.

### Related Issues

Closes: kubeflow/katib#2613

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: kubeflow/katib#2613


### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
