### PR TITLE
docs: add warning about multi-namespace Spark Operator deployments

### DIFF
--- a/content/en/docs/components/spark-operator/user-guide/running-multiple-instances-of-the-operator.md
+++ b/content/en/docs/components/spark-operator/user-guide/running-multiple-instances-of-the-operator.md
@@ -5,6 +5,20 @@ description: |
 weight: 70
 ---
 
+{{% alert title="Important" color="warning" %}}
+Spark Operator creates **cluster-scoped resources** such as
+`MutatingWebhookConfiguration`, `ValidatingWebhookConfiguration`, and `ClusterRole`.
+
+Because of this, running Spark Operator instances in **different namespaces**
+within the same Kubernetes cluster is **not supported** and will result in
+resource conflicts.
+
+The recommended approach is to:
+- Deploy Spark Operator **once** (or multiple releases) in a **single operator namespace**
+- Configure each instance to watch **different Spark job namespaces**
+  using `spark.jobNamespaces`
+{{% /alert %}}
+
 If you need to run multiple instances of the Spark operator within the same k8s cluster, then you need to ensure that the running instances should not watch the same spark job namespace.
 For example, you can deploy two Spark operator instances in the `spark-operator` namespace, one with release name `spark-operator-1` which watches the `spark-1` namespace:
 


### PR DESCRIPTION

### What this PR does

Adds an **Important** alert to the Spark Operator documentation explaining that
the operator creates cluster-scoped resources (such as webhooks and ClusterRoles),
which makes running instances in different namespaces within the same cluster
unsupported.

### Why this change is needed

Users attempting to deploy multiple Spark Operator instances may encounter
resource conflicts that are not clearly documented today. This change makes the
limitation explicit and guides users toward the recommended approach of using a
single operator namespace with different Spark job namespaces.

### Related issue

- Feedback: docs/components/spark-operator/user-guide/running-multiple-instances-of-the-operator.md (#4256)
