### PR TITLE
Fixed broken link in Architecture with KServe

### DIFF
--- a/content/en/docs/started/architecture.md
+++ b/content/en/docs/started/architecture.md
@@ -95,7 +95,7 @@ See the following links for more information about each Kubeflow project:
 - [Kubeflow Model Registry](/docs/components/model-registry/) can be used to store ML metadata,
   model artifacts, and preparing models for production serving.
 
-- [KServe](https://kserve.github.io/website/master/) can be used for online and batch inference
+- [KServe](/docs/components/kserve/) can be used for online and batch inference
   in the model serving step.
 
 - [Feast](https://feast.dev/) can be used as a feature store and to manage offline and online


### PR DESCRIPTION
wrong link for KServe in Architecture

<img width="1538" height="428" alt="image" src="https://github.com/user-attachments/assets/248c4b21-66be-450d-8c47-39aae01e9bc1" />

<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes
fix to use the KServe url https://www.kubeflow.org/docs/components/kserve/
<!-- Please include a summary of the changes and which issue is fixed. -->

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

Closes: #<issue number>

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: #<issue number>


### Checklist

- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
