### PR TITLE
central-dashboard: Update links that previously pointed to `kubeflow/kubeflow`

### DIFF
--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -199,12 +199,12 @@ The following table outlines which components are maintained by each Working Gro
           <a href="https://github.com/kubeflow/community/tree/master/wg-notebooks">Notebooks</a>
         </td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook">Admission Webhook (PodDefaults)</a>
+          <a href="https://github.com/kubeflow/dashboard/tree/main/components/poddefaults-webhooks">PodDefault Webhooks</a>
         </td>
       </tr>
       <tr>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/master/components/centraldashboard">Central Dashboard</a>
+          <a href="https://github.com/kubeflow/dashboard/tree/main/components/centraldashboard">Central Dashboard</a>
         </td>
       </tr>
       <tr>
@@ -214,7 +214,7 @@ The following table outlines which components are maintained by each Working Gro
       </tr>
       <tr>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/master/components/access-management">Kubeflow Access Management API (KFAM)</a>
+          <a href="https://github.com/kubeflow/dashboard/tree/main/components/access-management">Kubeflow Access Management API (KFAM)</a>
         </td>
       </tr>
       <tr>
@@ -224,7 +224,7 @@ The following table outlines which components are maintained by each Working Gro
       </tr>
       <tr>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/master/components/profile-controller">Profile Controller</a>
+          <a href="https://github.com/kubeflow/dashboard/tree/main/components/profile-controller">Profile Controller</a>
         </td>
       </tr>
       <tr>

--- a/content/en/docs/components/central-dash/profiles.md
+++ b/content/en/docs/components/central-dash/profiles.md
@@ -10,7 +10,7 @@ A Kubeflow Profile is a [Kubernetes CRD](https://kubernetes.io/docs/concepts/ext
 Profiles are owned by a single user, and can have multiple contributors with view or modify access.
 The owner of a profile can add and remove contributors (this can also be done by the cluster administrator).
 
-Profiles and their child Namespaces are reconciled by the [Kubeflow Profile Controller](https://github.com/kubeflow/kubeflow/tree/master/components/profile-controller) and contributors (not owners) are managed by the [Kubeflow Access Management API (KFAM)](https://github.com/kubeflow/kubeflow/tree/master/components/access-management).
+Profiles and their child Namespaces are reconciled by the [Kubeflow Profile Controller](https://github.com/kubeflow/dashboard/tree/main/components/profile-controller) and contributors (not owners) are managed by the [Kubeflow Access Management API (KFAM)](https://github.com/kubeflow/dashboard/tree/main/components/access-management).
 
 ## Profiles in the Central Dashboard
 

--- a/content/en/docs/components/notebooks/quickstart-guide.md
+++ b/content/en/docs/components/notebooks/quickstart-guide.md
@@ -62,7 +62,7 @@ weight = 10
 10. *(Optional)* Specify one or more __"data volumes"__ to be mounted as a PVC Volumes.
 
 11. *(Optional)* Specify one or more additional __"configurations"__
-    - These correspond to [PodDefault resources](https://github.com/kubeflow/kubeflow/blob/master/components/admission-webhook/README.md) which exist in your profile namespace.
+    - These correspond to [PodDefault resources](https://github.com/kubeflow/dashboard/blob/main/components/poddefaults-webhooks/README.md) which exist in your profile namespace.
     - Kubeflow matches the labels in the __"configurations"__ field against the properties specified in the PodDefault manifest.
     - For example, select the label `add-gcp-secret` in the __"configurations"__ field to match to a PodDefault manifest containing the following configuration:
     ```yaml

--- a/content/en/docs/components/pipelines/user-guides/core-functions/connect-api.md
+++ b/content/en/docs/components/pipelines/user-guides/core-functions/connect-api.md
@@ -41,7 +41,7 @@ print(experiments)
 #### ServiceAccount Token Volume
 
 To use the preceding code, you will need to run it from a Pod that has a ServiceAccount token volume mounted.
-You may manually add a `volume` and `volumeMount` to your PodSpec or use Kubeflow's [`PodDefaults`](https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook) to inject the required volume.
+You may manually add a `volume` and `volumeMount` to your PodSpec or use Kubeflow's [`PodDefaults`](https://github.com/kubeflow/dashboard/tree/main/components/poddefaults-webhooks) to inject the required volume.
 
 __Option 1 - manually add a volume to your PodSpec:__
 


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

I generated a local list of outdated links using [`lychee`](https://lychee.cli.rs/) and fixed all that were pointing to `kubeflow/kubeflow` except for those referencing notebooks as this structure will change quite a bit with the upcoming move to notebooks v2.

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

Closes: #<issue number>

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: #<issue number>


### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
