### PR TITLE
Open external links in new tab (fixes #4314)

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,7 @@
+{{- $dest := .Destination -}}
+{{- $isExternal := or (strings.HasPrefix $dest "http://") (strings.HasPrefix $dest "https://") (strings.HasPrefix $dest "//") -}}
+<a href="{{ $dest | safeURL }}"
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+  {{- if $isExternal }} target="_blank" rel="noopener noreferrer"{{ end -}}>
+  {{- .Text | safeHTML -}}
+</a>

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -12,7 +12,7 @@
       {{- if .File }}
       {{- $gh_repo := ($.Param "github_repo") }}
       {{- $issuesURL := printf "%s/issues/new?title=[Feedback]+%s" $gh_repo (safeURL .File.Path) }}
-      If you have a moment, please <a href="{{ $issuesURL }}" target="_blank">share your feedback</a> so we can improve.
+      If you have a moment, please <a href="{{ $issuesURL }}" target="_blank" rel="noopener noreferrer">share your feedback</a> so we can improve.
       {{- end }}
     </p>
   </div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -49,7 +49,7 @@
         <a {{/**/ -}}
           class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
           href="{{ with $e.Page }}{{ $e.RelPermalink }}{{ else }}{{ $e.URL | relLangURL }}{{ end }}"
-          {{- if ne $url.Host $baseurl.Host }} target="_blank" {{- end -}}
+          {{- if ne $url.Host $baseurl.Host }} target="_blank" rel="noopener noreferrer"{{ end -}}
         >
             {{- with $e.Pre }}{{ $pre }}{{ end -}}
             <span {{- if $active }} class="active" {{- end }}>


### PR DESCRIPTION
- Add Hugo link render hook so markdown external links get target=_blank and rel=noopener noreferrer
- Add rel=noopener noreferrer to navbar and feedback partials for external links

Closes #4314 