### PR TITLE
trainer: add Helm install commands for ClusterTrainingRuntimes to website

### DIFF
--- a/content/en/docs/components/trainer/operator-guides/installation.md
+++ b/content/en/docs/components/trainer/operator-guides/installation.md
@@ -85,6 +85,34 @@ For the latest changes run:
 kubectl apply --server-side -k "https://github.com/kubeflow/trainer.git/manifests/overlays/runtimes?ref=master"
 ```
 
+### Install with Helm Charts
+
+You can also deploy ClusterTrainingRuntimes as part of the Helm installation.
+
+To enable all default runtimes (torch, deepspeed, mlx, jax, torchtune):
+
+```bash
+helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
+    --namespace kubeflow-system \
+    --create-namespace \
+    --version ${VERSION#v} \
+    --set runtimes.defaultEnabled=true
+```
+
+To enable specific runtimes:
+
+```bash
+helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
+    --namespace kubeflow-system \
+    --create-namespace \
+    --version ${VERSION#v} \
+    --set runtimes.torchDistributed.enabled=true \
+    --set runtimes.deepspeedDistributed.enabled=true
+```
+
+For the available Helm values to configure runtimes, see the
+[kubeflow-trainer Helm chart documentation](https://github.com/kubeflow/trainer/tree/master/charts/kubeflow-trainer).
+
 ## Next Steps
 
 - How to [migrate from Kubeflow Training Operator v1](/docs/components/trainer/operator-guides/migration).


### PR DESCRIPTION
### Description of Changes

This PR adds documentation for installing ClusterTrainingRuntimes via Helm charts to the Kubeflow Trainer installation guide, as requested by @andreyvelich in https://github.com/kubeflow/trainer/pull/3124#pullrequestreview-3797492419.

The change adds a new "Install with Helm Charts" sub-section under "Installing the Kubeflow Training Runtimes" that complements the existing kubectl installation method. This aligns with the runtime support added in PR #3124.

**Changes:**
- Added "Install with Helm Charts" sub-section with examples for:
  - Enabling all default runtimes via `--set runtimes.defaultEnabled=true`
  - Enabling specific runtimes (torch, deepspeed) individually
- Linked to the Helm chart documentation for full configuration reference
- Follows the same documentation pattern used in the data-cache guide

### Related Issues

Related: kubeflow/trainer#3124

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment