### PR TITLE
gsoc: KFP Pod Lifecycle Failure Support for GSoC 2026

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -609,3 +609,35 @@ Tryout reading and connecting to data warehouse and data lakehouse:
 - Apache Spark (Architecture, Configuration)
 - Testing (Unit, Integration, E2E)
 - Technical Writing (Documentation)
+
+----
+
+### Project 13: Kubeflow Pipelines - Enhance Support for Pod Lifecycle Failure
+**Component:**
+[kubeflow/pipelines](https://www.github.com/kubeflow/pipelines)
+
+**Mentors:** [@alyssacgoins](https://github.com/alyssacgoins)
+
+**Contributor:**
+
+**Details:**
+A pipeline in Kubeflow Pipelines (KFP) fails for one of two reasons: the user-defined pipeline script returns an error, or a pod lifecycle failure occurs. The latter failure can be classified according to lifecycle stage; a failure is either at the provisioning level (e.g., ImagePullBackOff or Unschedulable), runtime level (e.g., CrashLoopBackOff or OOMKilled), or node level (e.g., NodeLost or Preempted).
+
+KFP currently provides limited support when a pipeline run hits a pod lifecycle failure. While the Kubernetes CLI allows users to view the status of their pipeline pods in real time on the terminal, the KFP UI currently provides only minimal visualization. When a pod lifecycle failure occurs, the KFP UI displays a pipeline frozen at the current pod – not progressing, finishing or failing. The cause of failure is not displayed. This creates a confusing and frustrating user experience.  KFP intends to function as a Kubernetes abstraction for data scientists and AI engineers, meaning that not all KFP users are experienced with Kubernetes. Requiring use of Kubernetes tools and skills leaks that abstraction.
+
+This project implements error timeouts and enhanced visualization for pod lifecycle failures in KFP:
+- Implement parameterized time limits (with defaults), with an optional mapping of pod status (e.g. ImagePullBackOff) to timeout value.
+- Implement visualization of pod failure reasons in the KFP UI, similar to the current visualization of pipeline script errors.
+- In addition to the time management component, it would enhance user experience to visually log these failures in the UI.
+
+**Related Issues/PRs:**
+[kubeflow/pipelines#12843](https://github.com/kubeflow/pipelines/issues/12843)
+
+**Difficulty:** Medium
+
+**Size:** 175 hours
+
+**Skills Required/Preferred:**
+- Typescript (core development)
+- Go (backend development)
+- Kubernetes


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

<!-- Please include a summary of the changes and which issue is fixed. -->
Adds a GSoC 2026 project proposal for extending KFP support for pod lifecycle failures recorded during pipeline runs.

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

Closes: #<issue number>

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: [#12843](https://github.com/kubeflow/pipelines/issues/12843)


### Checklist

- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
