### PR TITLE
fix: correct year from 2025 to 2026 in GSoC Key Dates Section

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -31,7 +31,7 @@ Please carefully read the following information to learn how to participate in G
 
 ### Key Dates
 
-Here are the key dates for GSoC 2025, the [full timeline](https://developers.google.com/open-source/gsoc/timeline) is available on the GSoC website:
+Here are the key dates for GSoC 2026, the [full timeline](https://developers.google.com/open-source/gsoc/timeline) is available on the GSoC website:
 
 <div class="table-responsive">
 <div class="table table-bordered">


### PR DESCRIPTION
### Description

This PR fixes a typo in the Future Events → GSoC 2026 → Key Dates section.

The text incorrectly mentioned:
"Here are the key dates for GSoC 2025..."

Since the page refers to GSoC 2026, the year has been updated from 2025 to 2026 to ensure consistency and avoid confusion.
Affected page: https://www.kubeflow.org/events/upcoming-events/gsoc-2026/

Fixes #4318 