### PR TITLE
gsoc: Add remaining milestone dates to GSoC 2026 Key Dates section

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -43,13 +43,12 @@ Here are the key dates for GSoC 2025, the [full timeline](https://developers.goo
 | **Applications Open**            | March 16 @ 18:00 UTC |
 | **Applications Deadline**        | March 31 @ 18:00 UTC |
 | **Accepted Proposals Announced** | April 30             |
-<!--
-| **Community Bonding**            | May 8 - June 1       |
-| **Coding Begins**                | June 2               |
-| **Midterm Evaluations**          | July 14 - 18         |
-| **Coding Ends**                  | September 1          |
-| **Final Evaluations**            | September 1 - 8      |
--->
+| **Community Bonding**            | May 1 - 24           |
+| **Coding Begins**                | May 25               |
+| **Midterm Evaluations**          | July 6 - 10          |
+| **Coding Ends**                  | August 24            |
+| **Final Evaluations**            | August 24 - 31       |
+
 </div>
 </div>
 


### PR DESCRIPTION
This PR updates the GSoC 2026 → Key Dates section by adding missing milestones that are part of the official GSoC timeline.

The following milestones have been added:

- Community Bonding Period
- Coding Begins
- Midterm Evaluations
- Coding Ends
- Final Evaluations

These updates ensure the Kubeflow GSoC 2026 page is aligned with the official GSoC timeline and provides complete information to prospective contributors.

See the official gsoc timeline here: https://developers.google.com/open-source/gsoc/timeline

### Before
<img width="785" height="366" alt="Screenshot from 2026-02-20 07-22-57" src="https://github.com/user-attachments/assets/74903f3f-ce69-4309-9552-62b09e8adc0e" />

### After

<img width="837" height="575" alt="Screenshot from 2026-02-20 07-22-39" src="https://github.com/user-attachments/assets/763f743d-a377-4f9a-8256-6880119a00ff" />

Closes #4320 