### PR TITLE
website: Fix incorrect year in GSoC 2026 Key Dates section (#4318)

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -31,7 +31,7 @@ Please carefully read the following information to learn how to participate in G
 
 ### Key Dates
 
-Here are the key dates for GSoC 2025, the [full timeline](https://developers.google.com/open-source/gsoc/timeline) is available on the GSoC website:
+Here are the key dates for GSoC 2026, the [full timeline](https://developers.google.com/open-source/gsoc/timeline) is available on the GSoC website:
 
 <div class="table-responsive">
 <div class="table table-bordered">


### PR DESCRIPTION
This PR fixes the incorrect year mentioned in the GSoC 2026 Key Dates section.

Closes: #4318