### PR TITLE
Add missing milestone dates to GSoC 2026 Key Dates section (#4320)

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -43,13 +43,12 @@ Here are the key dates for GSoC 2025, the [full timeline](https://developers.goo
 | **Applications Open**            | March 16 @ 18:00 UTC |
 | **Applications Deadline**        | March 31 @ 18:00 UTC |
 | **Accepted Proposals Announced** | April 30             |
-<!--
 | **Community Bonding**            | May 8 - June 1       |
 | **Coding Begins**                | June 2               |
 | **Midterm Evaluations**          | July 14 - 18         |
 | **Coding Ends**                  | September 1          |
 | **Final Evaluations**            | September 1 - 8      |
--->
+
 </div>
 </div>
 


### PR DESCRIPTION
The GSoC 2026 Key Dates section now includes the missing milestone dates thanks to this PR.

Closes: #4320