### PR TITLE
feat(docs): add copy-to-clipboard button for code blocks (#4327)

### DIFF
--- a/assets/js/click-to-copy.js
+++ b/assets/js/click-to-copy.js
@@ -1,0 +1,113 @@
+// click-to-copy.js
+// Adds a "Copy" button to all code blocks in the documentation.
+// This script targets both Hugo highlight blocks (.highlight > pre > code)
+// and plain code blocks (pre > code) that are not already processed.
+
+(function () {
+    'use strict';
+
+    // SVG icons for the copy button states
+    var COPY_ICON =
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>' +
+        '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>' +
+        '</svg>';
+
+    var CHECK_ICON =
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<polyline points="20 6 9 17 4 12"></polyline>' +
+        '</svg>';
+
+    /**
+     * Copy the text content of a code element to the clipboard.
+     * Falls back to execCommand for older browsers.
+     */
+    function copyToClipboard(text, button) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () {
+                showCopiedFeedback(button);
+            }).catch(function () {
+                fallbackCopy(text, button);
+            });
+        } else {
+            fallbackCopy(text, button);
+        }
+    }
+
+    /**
+     * Fallback copy method using a temporary textarea.
+     */
+    function fallbackCopy(text, button) {
+        var textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy');
+            showCopiedFeedback(button);
+        } catch (e) {
+            // silently fail
+        }
+        document.body.removeChild(textarea);
+    }
+
+    /**
+     * Show "Copied!" feedback on the button for 2 seconds.
+     */
+    function showCopiedFeedback(button) {
+        button.innerHTML = CHECK_ICON + ' <span>Copied!</span>';
+        button.classList.add('copied');
+
+        setTimeout(function () {
+            button.innerHTML = COPY_ICON + ' <span>Copy</span>';
+            button.classList.remove('copied');
+        }, 2000);
+    }
+
+    /**
+     * Initialize copy buttons on all code blocks.
+     */
+    function init() {
+        // Target Hugo highlight blocks and standalone pre>code blocks
+        var codeBlocks = document.querySelectorAll('.highlight pre, .td-content pre:not(.mermaid)');
+
+        for (var i = 0; i < codeBlocks.length; i++) {
+            var pre = codeBlocks[i];
+            var code = pre.querySelector('code');
+            if (!code) continue;
+
+            // Skip if already processed
+            if (pre.querySelector('.copy-code-button')) continue;
+
+            // Make the pre element a positioning context
+            pre.style.position = 'relative';
+
+            // Create copy button
+            var button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'copy-code-button';
+            button.setAttribute('aria-label', 'Copy code to clipboard');
+            button.setAttribute('title', 'Copy to clipboard');
+            button.innerHTML = COPY_ICON + ' <span>Copy</span>';
+
+            // Capture the code element in a closure
+            (function (codeEl, btn) {
+                btn.addEventListener('click', function () {
+                    var text = codeEl.textContent.trim();
+                    copyToClipboard(text, btn);
+                });
+            })(code, button);
+
+            pre.appendChild(button);
+        }
+    }
+
+    // Run when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -903,3 +903,70 @@ nav.foldable-nav {
 .alert {
   background-color: $alert-bg;
 }
+
+// --------------------------------------------------
+// copy-to-clipboard button for code blocks
+// --------------------------------------------------
+.td-content {
+  .highlight,
+  pre:not(.mermaid) {
+    position: relative;
+  }
+}
+
+.copy-code-button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 10;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+
+  padding: 4px 8px;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  border-radius: 4px;
+  background-color: rgba(128, 128, 128, 0.15);
+  color: $gray-500;
+
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+
+  opacity: 0;
+  transition: opacity 0.2s ease, background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+
+  span {
+    pointer-events: none;
+  }
+
+  svg {
+    pointer-events: none;
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    background-color: rgba(128, 128, 128, 0.3);
+    color: $gray-700;
+    border-color: rgba(128, 128, 128, 0.5);
+  }
+
+  &:active {
+    transform: translateY(1px);
+  }
+
+  &.copied {
+    color: #28a745;
+    border-color: rgba(40, 167, 69, 0.5);
+    background-color: rgba(40, 167, 69, 0.1);
+    opacity: 1;
+  }
+}
+
+// show button on hover of the code block
+.highlight:hover .copy-code-button,
+pre:not(.mermaid):hover .copy-code-button {
+  opacity: 1;
+}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -80,7 +80,7 @@ window.markmap = {
 
 {{ if .Site.Params.prism_syntax_highlighting -}}
   <script src='{{ "js/prism.js" | relURL }}'></script>
-{{ else if false -}}
+{{ else -}}
   {{ $c2cJS := resources.Get "js/click-to-copy.js" -}}
   {{ if hugo.IsProduction -}}
     {{ $c2cJS = $c2cJS | minify | fingerprint -}}


### PR DESCRIPTION
Fixes #4327

All code blocks now have global copy-to-clipboard support.
tested locally on a Hugo server.