### PR TITLE
chore: Docs/gsoc 2026 (updated org selection timeline)

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -39,7 +39,7 @@ Here are the key dates for GSoC 2026, the [full timeline](https://developers.goo
 | Event                            | Date                 |
 | -------------------------------- | -------------------- |
 | **Mentor Proposals**             | February 3rd         |
-| **Org Acceptance**               | February 19th        |  
+| **Org Acceptance (Kubeflow Selected)** | February 19th        |  
 | **Applications Open**            | March 16 @ 18:00 UTC |
 | **Applications Deadline**        | March 31 @ 18:00 UTC |
 | **Accepted Proposals Announced** | April 30             |

--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -11,8 +11,8 @@ The Kubeflow Community plans to participate in [**Google Summer of Code 2026**](
 This page aims to help you participate in GSoC 2026 with Kubeflow.
 
 {{% alert title="Note" color="info" %}}
-we are currently awaiting final confirmation of our participation in GSoC 2026.
-Google will announce the final list of accepted organizations on **February 18, 2026**.
+Kubeflow has been selected as a participating organization for GSoC 2026!
+We look forward to welcoming contributors to the program.
 {{% /alert %}}
 
 ## What is GSoC?


### PR DESCRIPTION
### Description of Changes
updated the webwsite to be consistent with the timeline

Related: #4322 


### Checklist