### PR TITLE
fix(#3940): Add missing release navigation links

### DIFF
--- a/content/en/docs/kubeflow-platform/releases/_index.md
+++ b/content/en/docs/kubeflow-platform/releases/_index.md
@@ -3,3 +3,20 @@ title = "Releases"
 description = "Information about past and future Kubeflow AI reference platform releases"
 weight = 100
 +++
+
+## Kubeflow Releases
+
+- [Kubeflow 1.11](kubeflow-1.11.md)
+- [Kubeflow 1.10](kubeflow-1.10.md)
+- [Kubeflow 1.9](kubeflow-1.9.md)
+- [Kubeflow 1.8](kubeflow-1.8.md)
+- [Kubeflow 1.7](kubeflow-1.7.md)
+- [Kubeflow 1.6](kubeflow-1.6.md)
+- [Kubeflow 1.5](kubeflow-1.5.md)
+- [Kubeflow 1.4](kubeflow-1.4.md)
+- [Kubeflow 1.3](kubeflow-1.3.md)
+- [Kubeflow 1.2](kubeflow-1.2.md)
+- [Kubeflow 1.1](kubeflow-1.1.md)
+- [Kubeflow 1.0](kubeflow-1.0.md)
+- [Kubeflow 0.7](kubeflow-0.7.md)
+- [Kubeflow 0.6](kubeflow-0.6.md)


### PR DESCRIPTION
### Description of Changes
Added missing release navigation links to the releases page to fix "file not found" issue.

### Related Issues
Closes: #3940

### Checklist
- [x] Signed off commits
- [x] Followed contributing guide