### PR TITLE
docs: fix incorrect project numbering in GSoC 2026 portal

### DIFF
--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -162,7 +162,7 @@ Tracking issue: [kubeflow/katib#2605](https://github.com/kubeflow/katib/issues/2
 * Experience with HPO frameworks
 
 ---
-## Project #: End-to-End ARM64 Support & Validation on Kubeflow
+## Project 3: End-to-End ARM64 Support & Validation on Kubeflow
 
 **Components:** Manifests (Platform), Kubeflow Pipelines (KFP), Katib, Notebooks, Trainer
 
@@ -231,7 +231,7 @@ Scope & Deliverables
 
 
 
-### Project 3: KServe Models Web Application
+### Project 4: KServe Models Web Application
 
 **Components:** Kserve, Kubeflow Common Library, Kubeflow Dashboard
 
@@ -254,7 +254,7 @@ This project modernizes the KServe Models Web Application by upgrading Angular f
 - Docker and CI/CD
 - Kubeflow / KServe (preferred)
 
-### Project 4: Platform Scalability and Security
+### Project 5: Platform Scalability and Security
 
 **Components:** Kubeflow Manifests, Kubeflow Pipelines, Kubeflow Training Operator
 
@@ -294,7 +294,7 @@ Using "Kubernetes user namespaces" for PSS baseline in the level in PSS restrict
 - Networking
 - Linux Security
 
-### Project 5: Helm Charts
+### Project 6: Helm Charts
 
 **Components:** Kubeflow Manifests, Kubeflow Pipelines, Kubeflow Katib
 
@@ -327,7 +327,7 @@ This will therefore also include working with maintainers of other components su
 - Bash
 - Community Coordination
 
-### Project 6: MCP Server for Kubeflow SDK
+### Project 7: MCP Server for Kubeflow SDK
 
 **Components:** [kubeflow/sdk](https://github.com/kubeflow/sdk), [kubeflow/trainer](https://github.com/kubeflow/trainer)
 
@@ -367,7 +367,7 @@ Tracking issue: https://github.com/kubeflow/sdk/issues/238
 - Understanding of the Kubeflow Ecosystem and basic Kubernetes concepts.
 - Engage and contribute to Kubeflow community on Slack and GitHub.
 
-### Project 7 : Integrate Kubeflow SDK with OpenTelemetry
+### Project 8 : Integrate Kubeflow SDK with OpenTelemetry
 
 **Components:** [kubeflow/sdk](https://www.github.com/kubeflow/sdk) 
 
@@ -431,7 +431,7 @@ Bonus requirement to complete
 - Distributed systems and observability concepts
 - Kubernetes and CRDs
 
-### Project 10: Dynamic LLM Trainer Framework for Kubeflow
+### Project 9: Dynamic LLM Trainer Framework for Kubeflow
 
 **Components:**
 [kubeflow/trainer](https://www.github.com/kubeflow/trainer),
@@ -483,7 +483,7 @@ Tracking issue: [kubeflow/trainer#2839](https://github.com/kubeflow/trainer/issu
 * Understanding of distributed training concepts
 * Interest in API and framework design
 
-### Project 11: Composable Kale Notebooks with Visual Pipeline Editor
+### Project 10: Composable Kale Notebooks with Visual Pipeline Editor
 
 **Components:** Kubeflow Kale
 
@@ -534,7 +534,7 @@ Notebook workflows are commonly split across multiple files. Without visual comp
 - Experience or interest in working within established UI frameworks
 ----
 
-### Project 12: Kubeflow SDK/SparkClient - Batch Jobs, Observability & Production Readiness
+### Project 11: Kubeflow SDK/SparkClient - Batch Jobs, Observability & Production Readiness
 
 **Components:** [kubeflow/sdk](https://www.github.com/kubeflow/sdk) (SparkClient), [kubeflow/spark-operator](https://www.github.com/kubeflow/spark-operator)
 
@@ -611,7 +611,7 @@ Tryout reading and connecting to data warehouse and data lakehouse:
 
 ----
 
-### Project 13: Kubeflow Pipelines - Enhance Support for Pod Lifecycle Failure
+### Project 12: Kubeflow Pipelines - Enhance Support for Pod Lifecycle Failure
 **Component:**
 [kubeflow/pipelines](https://www.github.com/kubeflow/pipelines)
 


### PR DESCRIPTION
Corrected inconsistent numbering across project listings.

Ensures proper alignment between project IDs and titles for accurate referencing.

<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

- Renumbered project entries to ensure sequential consistency
- Fixed mismatches between project numbers and titles
- Verified alignment across the entire GSoC 2026 project list

### Related Issues

N/A (no associated issue)

### Why this matters

Accurate project numbering is important for:
- Referencing projects in GSoC proposals
- Avoiding confusion for contributors and applicants
- Maintaining documentation quality and consistency

### Checklist

- [ ] You have signed off your commits
- [ ] Ensure you follow best practices from our contributing guide
- [ ] (for big changes) I will post screenshots of the changes in a PR comment