### PR TITLE
website: add machine-readable documentation index (llms.txt)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -92,6 +92,25 @@ ignoreFiles = []
     weight = -99
     pre = "<i class='fab fa-github pr-2'></i>"
     url = "https://github.com/kubeflow/"
+  [[menu.main]]
+    name = "AI-Ready Docs"
+    identifier = "llms"
+    weight = -98
+    pre = "<i class='fas fa-robot pr-2'></i>"
+  [[menu.main]]
+    name = "llms.txt"
+    parent = "llms"
+    weight = 1
+    pre = "<i class='fas fa-file-alt pr-2'></i>"
+    post = "<br><small class='text-muted'>Curated index</small>"
+    url = "/llms.txt"
+  [[menu.main]]
+    name = "llms-full.txt"
+    parent = "llms"
+    weight = 2
+    pre = "<i class='fas fa-file pr-2'></i>"
+    post = "<br><small class='text-muted'>Full documentation</small>"
+    url = "/llms-full.txt"
 
 ###############################################################################
 # Docsy - Output Formats

--- a/config.toml
+++ b/config.toml
@@ -96,8 +96,21 @@ ignoreFiles = []
 ###############################################################################
 # Docsy - Output Formats
 ###############################################################################
+[outputFormats.LLMS]
+  mediaType = "text/plain"
+  baseName = "llms"
+  isPlainText = true
+  notAlternative = true
+
+[outputFormats.LLMSFull]
+  mediaType = "text/plain"
+  baseName = "llms-full"
+  isPlainText = true
+  notAlternative = true
+
 [outputs]
-section = [ "HTML" ]
+  home = ["HTML", "LLMS", "LLMSFull"]
+  section = ["HTML"]
 
 ###############################################################################
 # Docsy - Goldmark markdown parser

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -1,0 +1,46 @@
+{{- $docs := site.GetPage "/docs" -}}
+# Kubeflow
+
+> Kubeflow is the foundation of tools for AI Platforms on Kubernetes, providing a composable, modular, portable, and scalable AI reference platform backed by Kubernetes-native projects covering every stage of the AI lifecycle.
+
+Kubeflow enables AI platform teams to build production-ready ML workflows with tools for training, tuning, serving, pipelines, and notebooks. Each Kubeflow project can be used independently or as part of the full AI reference platform.
+
+- Source code: <https://github.com/kubeflow/>
+- Documentation: <{{ site.BaseURL }}docs/>
+{{ range $docs.Sections.ByWeight -}}
+  {{- if eq .RelPermalink "/docs/components/" -}}
+    {{- range .Sections.ByWeight -}}
+      {{- $sec := . -}}
+      {{- $t := replace (replace $sec.Title "&#39;" "'") "&amp;" "&" -}}
+      {{- printf "\n## %s\n\n" $t -}}
+      {{- if $sec.Params.description -}}
+        {{- $d := replace (replace $sec.Params.description "&#39;" "'") "&amp;" "&" -}}
+        {{- printf "- [%s](%s): %s\n" $t $sec.Permalink $d -}}
+      {{- else -}}
+        {{- printf "- [%s](%s)\n" $t $sec.Permalink -}}
+      {{- end -}}
+      {{- partial "llms-pages.html" (dict "section" $sec "legacy" false) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $sec := . -}}
+    {{- $t := replace (replace $sec.Title "&#39;" "'") "&amp;" "&" -}}
+    {{- printf "\n## %s\n\n" $t -}}
+    {{- if $sec.Params.description -}}
+      {{- $d := replace (replace $sec.Params.description "&#39;" "'") "&amp;" "&" -}}
+      {{- printf "- [%s](%s): %s\n" $t $sec.Permalink $d -}}
+    {{- else -}}
+      {{- printf "- [%s](%s)\n" $t $sec.Permalink -}}
+    {{- end -}}
+    {{- partial "llms-pages.html" (dict "section" $sec "legacy" false) -}}
+  {{- end -}}
+{{- end -}}
+{{- printf "\n## Optional\n\nLegacy (v1) documentation for components that have been upgraded. These pages are kept for historical reference.\n\n" -}}
+{{- range $docs.Sections.ByWeight -}}
+  {{- if eq .RelPermalink "/docs/components/" -}}
+    {{- range .Sections.ByWeight -}}
+      {{- partial "llms-pages.html" (dict "section" . "legacy" true) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- partial "llms-pages.html" (dict "section" . "legacy" true) -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/index.llmsfull.txt
+++ b/layouts/index.llmsfull.txt
@@ -1,0 +1,15 @@
+{{- $docs := site.GetPage "/docs" -}}
+# Kubeflow — Full Documentation Index
+
+> Kubeflow is the foundation of tools for AI Platforms on Kubernetes, providing a composable, modular, portable, and scalable AI reference platform backed by Kubernetes-native projects covering every stage of the AI lifecycle.
+{{ range $docs.Sections.ByWeight -}}
+  {{- if eq .RelPermalink "/docs/components/" -}}
+    {{- range .Sections.ByWeight -}}
+      {{- printf "\n## %s\n\n" .Title -}}
+      {{- partial "llms-full-pages.html" (dict "section" .) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- printf "\n## %s\n\n" .Title -}}
+    {{- partial "llms-full-pages.html" (dict "section" .) -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -33,6 +33,7 @@
         {{ end }}
           <p>
             <small class="text-white">Website <a href="{{ .Site.Params.privacy_policy }}" target="_blank" rel="noopener">Privacy Policy</a></small>
+            <small class="text-white"> | <a href="{{ "llms.txt" | absURL }}" rel="noopener">llms.txt</a> · <a href="{{ "llms-full.txt" | absURL }}" rel="noopener">llms-full.txt</a></small>
           </p>
 	{{ if not .Site.Params.ui.footer_about_disable }}
 		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,6 +4,8 @@
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
+<link rel="alternate" type="text/plain" title="LLM-friendly documentation" href="{{ "llms.txt" | absURL }}">
+<link rel="alternate" type="text/plain" title="LLM-friendly full documentation" href="{{ "llms-full.txt" | absURL }}">
 
 {{ $outputFormat := partial "outputformat.html" . -}}
 {{ if and hugo.IsProduction (ne $outputFormat "print") -}}

--- a/layouts/partials/llms-full-pages.html
+++ b/layouts/partials/llms-full-pages.html
@@ -1,0 +1,16 @@
+{{- $section := .section -}}
+{{- range $section.Pages.ByWeight -}}
+  {{- $p := . -}}
+  {{- printf "### [%s](%s)\n" $p.Title $p.Permalink | safeHTML -}}
+  {{- with $p.Params.description -}}
+    {{- printf "> %s\n" . | safeHTML -}}
+  {{- end -}}
+  {{- printf "\n" -}}
+  {{- with $p.RawContent -}}
+    {{- printf "%s\n" (. | replaceRE `\{\{[<%].*?[>%]\}\}` "") | safeHTML -}}
+  {{- end -}}
+  {{- printf "\n" -}}
+  {{- if $p.IsSection -}}
+    {{- partial "llms-full-pages.html" (dict "section" $p) -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/llms-pages.html
+++ b/layouts/partials/llms-pages.html
@@ -1,0 +1,18 @@
+{{- $section := .section -}}
+{{- $legacy := .legacy -}}
+{{- range $section.Pages.ByWeight -}}
+  {{- $p := . -}}
+  {{- $isLeg := in $p.RelPermalink "legacy-v1" -}}
+  {{- if eq $legacy $isLeg -}}
+    {{- if $p.Params.description -}}
+      {{- printf "- [%s](%s): %s\n" $p.Title $p.Permalink $p.Params.description | safeHTML -}}
+    {{- else -}}
+      {{- printf "- [%s](%s)\n" $p.Title $p.Permalink | safeHTML -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if $p.IsSection -}}
+    {{- if or $legacy (not $isLeg) -}}
+      {{- partial "llms-pages.html" (dict "section" $p "legacy" $legacy) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -39,6 +39,22 @@
       {{ range $i, $e := .Site.Menus.main -}}
       {{ $longContent := gt (len $e.Name) 8 -}}
       {{ $isLast := eq $i (sub $last 1) -}}
+      {{ if $e.HasChildren -}}
+      <li class="nav-item dropdown mt-1 mt-lg-0 {{ if $isLast }}mr-1 mr-lg-3 mr-xl-4{{ else }}mr-2 mr-xl-4{{- end }}">
+        <a class="nav-link dropdown-toggle" href="#" id="nav-dropdown-{{ $e.Identifier }}" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          {{- with $e.Pre }}{{ . }}{{ end -}}
+          <span>{{ $e.Name }}</span>
+        </a>
+        <div class="dropdown-menu" aria-labelledby="nav-dropdown-{{ $e.Identifier }}">
+          {{ range $e.Children -}}
+          <a class="dropdown-item" href="{{ .URL | relLangURL }}">
+            {{- with .Pre }}{{ . }}{{ end }}{{ .Name -}}
+            {{- with .Post }}{{ . }}{{ end -}}
+          </a>
+          {{ end -}}
+        </div>
+      </li>
+      {{ else -}}
       <li class="nav-item mt-1 mt-lg-0 {{ if $isLast }}mr-1 mr-lg-3 mr-xl-4{{ else }}mr-2 mr-xl-4{{- end }} {{- if $longContent }} long-content {{- end }}">
         {{ $active := or ($p.IsMenuCurrent "main" $e) ($p.HasMenuCurrent "main" $e) -}}
         {{ with $e.Page }}{{ $active = or $active ( $.IsDescendant $e) }}{{ end -}}
@@ -58,6 +74,7 @@
             {{- with $e.Post }}{{ $post }}{{ end -}}
         </a>
       </li>
+      {{ end -}}
       {{ end -}}
       <li class="nav-item mr-2 mt-1 mt-lg-0 py-md-2">
         <div class="vr"></div>


### PR DESCRIPTION
### Description of Changes

Introduce `llms.txt` and `llms-full.txt` as Hugo custom output formats following the
[llmstxt.org](https://llmstxt.org/) standard, providing a machine-readable documentation
index for LLM consumption.

**What's included:**
- `llms.txt` — curated index of all docs pages with titles, URLs, and descriptions
- `llms-full.txt` — expanded version with full inline page content for RAG pipelines
- Both files auto-regenerate on every Hugo build (including live reload during development)
- Legacy (v1) docs are separated into an "Optional" section per the llms.txt spec

**Files changed:**
- `config.toml` — added `LLMS` and `LLMSFull` custom output formats
- `layouts/index.llms.txt` — template for `/llms.txt`
- `layouts/index.llmsfull.txt` — template for `/llms-full.txt`
- `layouts/partials/llms-pages.html` — recursive partial for curated index
- `layouts/partials/llms-full-pages.html` — recursive partial for full content

**Results**
<img width="1720" height="961" alt="image" src="https://github.com/user-attachments/assets/2f95dfd8-8392-43bc-8423-a44ec74da13a" />
<img width="1538" height="345" alt="image" src="https://github.com/user-attachments/assets/f684570a-cb7b-4453-9ae4-25c7b7306d82" />
<img width="398" height="195" alt="image" src="https://github.com/user-attachments/assets/e950dafb-bacc-4a85-a00c-d7441dcf53b0" />


### Related Issues

Closes: #4349

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x ] (for big changes) I will post screenshots of the changes in a PR comment