### PR TITLE
website: Added non-code contributions header in contributing.md

### DIFF
--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -5,7 +5,7 @@ weight = 20
 aliases = ["/docs/contributing/"]
 +++
 
-This document is the single source of truth for how to contribute to the code base.
+This document is the single source of truth for how to contribute to Kubeflow.
 We'd love to accept your patches and contributions to this project.
 There are just a few small guidelines you need to follow.
 
@@ -94,6 +94,12 @@ To ensure smooth collaboration and avoid duplicate work, please follow these gui
   - A maintainer has explicitly asked for additional contributions
 
 Following these guidelines helps maintain a collaborative and efficient community, reduces wasted effort, and ensures everyone's contributions are valued.
+
+### Non-code contributions
+
+- **Documentation**: Improve the accuracy and clarity of our technical docs by fixing stale information and ensuring all new content follows the standards set in the [Kubeflow Documentation Style Guide](style-guide.md).
+- **Blog posts and user stories**: Share your technical insights or success stories on the Kubeflow blog to help the community learn from real-world use cases.
+- **Event outreach**: Help spread awareness by speaking at events, and representing Kubeflow at community booths.
 
 ## Owners files and PR workflow
 

--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -99,7 +99,8 @@ Following these guidelines helps maintain a collaborative and efficient communit
 
 - **Documentation**: Improve the accuracy and clarity of our technical docs by fixing stale information and ensuring all new content follows the standards set in the [Kubeflow Documentation Style Guide](style-guide.md).
 - **Blog posts**: Share your technical insights or success stories on the Kubeflow blog or CNCF about Kubeflow to help the community to gain more knowledge on kubeflow. These content can take different forms from  learn from real-world use cases, Kubeflow integrations, news about releases or practical use cases.
-- **Event outreach**: Help spread awareness by speaking at events, and representing Kubeflow at community booths.
+- **Event outreach**: Contribute to outreach activities by bringing awareness of kubeflow with activities such as:
+speaking at events, representing Kubeflow at community booths/tables, helping organize an event, Program committee or Program Chairs.
 
 ## Owners files and PR workflow
 

--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -95,12 +95,15 @@ To ensure smooth collaboration and avoid duplicate work, please follow these gui
 
 Following these guidelines helps maintain a collaborative and efficient community, reduces wasted effort, and ensures everyone's contributions are valued.
 
-### Non-code contributions
+### Contributions outside the Kubeflow components (including non-technical contributions)
 
 - **Documentation**: Contribute to technical documentation by improving the accuracy and clarity of Kubeflow technical documentation and/or fixing stale information and ensuring all new content follows the standards set in the [Kubeflow Documentation Style Guide](style-guide.md).
-- **Blog posts**: Share your technical insights or success stories on the Kubeflow blog or CNCF about Kubeflow to help the community to gain more knowledge on kubeflow. These content can take different forms from  learn from real-world use cases, Kubeflow integrations, news about releases or practical use cases.
+- **Blog posts**: Contribute to Kubeflow blog and/or CNCF about Kubeflow to help the community to gain more knowledge on Kubeflow. The content can take different forms from learn from real-world use cases, Kubeflow integrations, news about releases, contributions or practical use cases.
 - **Event outreach**: Contribute to outreach activities by bringing awareness of kubeflow with activities such as:
 speaking at events, representing Kubeflow at community booths/tables, helping organize an event, Program committee or Program Chairs.
+- **Community Engagement**: Engagement with end-users, contributors (Kubeflow community) participating or leading community meetings, social media management/promotion, discussions with end-users and contributors to enrich the kubeflow ecosystem.
+- **Technical Content**: Creating webinars, demos, tutorials that showcase Kubeflow use cases and Kubeflow ecosystem including integrations, solution architectures, publications, e-books, books, white papers.
+- **Website contributions**: Contributing to website desing, new content creation, website maintenance and/or contributing to PR's review.
 
 ## Owners files and PR workflow
 

--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -97,7 +97,7 @@ Following these guidelines helps maintain a collaborative and efficient communit
 
 ### Non-code contributions
 
-- **Documentation**: Improve the accuracy and clarity of our technical docs by fixing stale information and ensuring all new content follows the standards set in the [Kubeflow Documentation Style Guide](style-guide.md).
+- **Documentation**: Contribute to technical documentation by improving the accuracy and clarity of Kubeflow technical documentation and/or fixing stale information and ensuring all new content follows the standards set in the [Kubeflow Documentation Style Guide](style-guide.md).
 - **Blog posts**: Share your technical insights or success stories on the Kubeflow blog or CNCF about Kubeflow to help the community to gain more knowledge on kubeflow. These content can take different forms from  learn from real-world use cases, Kubeflow integrations, news about releases or practical use cases.
 - **Event outreach**: Contribute to outreach activities by bringing awareness of kubeflow with activities such as:
 speaking at events, representing Kubeflow at community booths/tables, helping organize an event, Program committee or Program Chairs.

--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -98,7 +98,7 @@ Following these guidelines helps maintain a collaborative and efficient communit
 ### Non-code contributions
 
 - **Documentation**: Improve the accuracy and clarity of our technical docs by fixing stale information and ensuring all new content follows the standards set in the [Kubeflow Documentation Style Guide](style-guide.md).
-- **Blog posts and user stories**: Share your technical insights or success stories on the Kubeflow blog to help the community learn from real-world use cases.
+- **Blog posts**: Share your technical insights or success stories on the Kubeflow blog or CNCF about Kubeflow to help the community to gain more knowledge on kubeflow. These content can take different forms from  learn from real-world use cases, Kubeflow integrations, news about releases or practical use cases.
 - **Event outreach**: Help spread awareness by speaking at events, and representing Kubeflow at community booths.
 
 ## Owners files and PR workflow

--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -98,7 +98,7 @@ Following these guidelines helps maintain a collaborative and efficient communit
 ### Contributions outside the Kubeflow components (including non-technical contributions)
 
 - **Documentation**: Contribute to technical documentation by improving the accuracy and clarity of Kubeflow technical documentation and/or fixing stale information and ensuring all new content follows the standards set in the [Kubeflow Documentation Style Guide](style-guide.md).
-- **Blog posts**: Contribute to Kubeflow blog and/or CNCF about Kubeflow to help the community to gain more knowledge on Kubeflow. The content can take different forms from learn from real-world use cases, Kubeflow integrations, news about releases, contributions or practical use cases.
+- **Blog posts**: Write about Kubeflow for the Kubeflow blog or CNCF publications to help the community learn more about the project. Topics can include lessons from real-world use cases, Kubeflow integrations, release news, contribution stories, or practical guidance.
 - **Event outreach**: Contribute to outreach activities by bringing awareness of kubeflow with activities such as:
 speaking at events, representing Kubeflow at community booths/tables, helping organize an event, Program committee or Program Chairs.
 - **Community Engagement**: Engagement with end-users, contributors (Kubeflow community) participating or leading community meetings, social media management/promotion, discussions with end-users and contributors to enrich the kubeflow ecosystem.

--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -99,11 +99,10 @@ Following these guidelines helps maintain a collaborative and efficient communit
 
 - **Documentation**: Contribute to technical documentation by improving the accuracy and clarity of Kubeflow technical documentation and/or fixing stale information and ensuring all new content follows the standards set in the [Kubeflow Documentation Style Guide](style-guide.md).
 - **Blog posts**: Write about Kubeflow for the Kubeflow blog or CNCF publications to help the community learn more about the project. Topics can include lessons from real-world use cases, Kubeflow integrations, release news, contribution stories, or practical guidance.
-- **Event outreach**: Contribute to outreach activities by bringing awareness of kubeflow with activities such as:
-speaking at events, representing Kubeflow at community booths/tables, helping organize an event, Program committee or Program Chairs.
-- **Community Engagement**: Engagement with end-users, contributors (Kubeflow community) participating or leading community meetings, social media management/promotion, discussions with end-users and contributors to enrich the kubeflow ecosystem.
-- **Technical Content**: Creating webinars, demos, tutorials that showcase Kubeflow use cases and Kubeflow ecosystem including integrations, solution architectures, publications, e-books, books, white papers.
-- **Website contributions**: Contributing to website desing, new content creation, website maintenance and/or contributing to PR's review.
+- **Event outreach**: Raise awareness of Kubeflow by speaking at events, representing Kubeflow at community booths or tables, helping organize events, or serving on program committees or as a program chair.
+- **Community engagement**: Engage with end users and contributors in the Kubeflow community by participating in or leading community meetings, managing or promoting social media, and discussing ways to enrich the Kubeflow ecosystem.
+- **Technical content**: Create webinars, demos, tutorials, publications, e-books, books, and white papers that showcase Kubeflow use cases, integrations, and solution architectures.
+- **Website contributions**: Contribute to website design, create new content, maintain the website, or review PRs.
 
 ## Owners files and PR workflow
 


### PR DESCRIPTION

### Description of Changes

Added non-code contributions examples in contributing.md

Following up from the discussion at the [Kubeflow outreach meeting](https://docs.google.com/document/d/1IblkZ0z61mjpSccIK7qDaMqUbFADZiIoOX9g8uDq_qc/edit?tab=t.0#heading=h.ryf7f4wgkgyk). 

There are no mentions of non-code contributions in contributing.md , non-code contributions mentioned in [community membership](https://www.kubeflow.org/docs/about/membership/#requirements) page, where it directly links to the CNCF explanation.  We are also rephrasing this as contributions outside of the kubeflow components. 

### Related Issues

N/A

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment

cc: @tarekabouzeid @varodrig 
