### PR TITLE
website: set archive banner for 1.10 branch

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -140,16 +140,16 @@ enable = true
   gcs_engine_id = "007239566369470735695:624rglujm-w"
 
   # Text label for the version menu in the top bar of the website.
-  version_menu = "Version"
+  version_menu = "v1.10"
 
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "master"
+  version = "v1.10"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.
-  archived_version = false
+  archived_version = true
 
   # A link to latest version of the docs. Used in the "version-banner" partial to
   # point people to the main doc site.
@@ -175,7 +175,7 @@ enable = true
 
   # These entries appear in the drop-down menu at the top of the website.
   [[params.versions]]
-    version = "master"
+    version = "Latest"
     githubbranch = "master"
     url = "https://master.kubeflow.org"
   [[params.versions]]

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -5,12 +5,16 @@
   <style>
     .version-banner {
       padding: 1.5rem;
+      color: #222222;
       margin: 2rem 0;
       max-width: 40rem;
       border-style: solid;
       border-color: #f0ad4e;
       background-color: #faf5b6;
       border-radius: 0.25rem;
+    }
+    [data-theme="dark"] .version-banner {
+      color: #222222;
     }
     .version-banner h3 {
       margin-top: 0;


### PR DESCRIPTION

<img width="714" height="314" alt="image" src="https://github.com/user-attachments/assets/4c7cb827-e0af-46e1-98bf-b826a5a9d30d" />



### Description of Changes

Setting v1.10 as archived. 

### Related Issues

#4121 

Closes: #<issue number>

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: #<issue number>


### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment

cc: @thesuperzapper @tarekabouzeid 