### PR TITLE
website: add Kubeflow Kale documentation section

### DIFF
--- a/content/en/docs/components/kale/_index.md
+++ b/content/en/docs/components/kale/_index.md
@@ -1,0 +1,5 @@
++++
+title = "Kubeflow Kale"
+description = "Documentation for Kubeflow Kale."
+weight = 75
++++

--- a/content/en/docs/components/kale/overview.md
+++ b/content/en/docs/components/kale/overview.md
@@ -1,0 +1,38 @@
++++
+title = "Overview"
+description = "An overview for Kubeflow Kale"
+weight = 10
++++
+
+## What is Kubeflow Kale?
+
+Kale (Kubeflow Automated pipeLines Engine) turns annotated Jupyter notebooks
+into production-ready [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/)
+without requiring you to write a single line of KFP SDK code.
+
+Tag cells in your notebook, let Kale figure out the data dependencies between
+them, and compile the whole thing into a KFP v2 pipeline you can run on any
+Kubeflow cluster.
+
+## Why Kale?
+
+- **No SDK boilerplate:** Annotate cells, compile, run. Kale generates the KFP v2 DSL for you — no need to learn components, artifacts, or Python decorators.
+- **Automatic data passing:** Variables flow between steps as if you were still in a single notebook. Kale's type-aware marshalling handles numpy, pandas, scikit-learn, PyTorch, Keras, TensorFlow, XGBoost and more.
+- **JupyterLab integration:** Tag cells visually, define step dependencies, and submit pipelines from the Kale side panel inside JupyterLab 4.
+- **KFP v2 native:** Compiles to the modern KFP v2 pipeline DSL with full artifact support. Runs on any compliant Kubeflow Pipelines backend.
+
+## Kale in the Kubeflow Ecosystem
+
+Kale is part of the Kubeflow **ML Experience Working Group**, alongside the
+[Kubeflow SDK](https://sdk.kubeflow.org/).
+It lives at the notebook layer — where data scientists prototype — and bridges
+the gap to the pipeline layer, where production workloads run.
+
+If KFP is the "how" of running ML pipelines on Kubernetes, Kale is the "what
+you meant": take the notebook you already have, and turn it into a pipeline
+without rewriting anything.
+
+## Next Steps
+
+- Compile and run your first notebook on Kubeflow Pipelines with the [quickstart guide](https://kubeflow-kale.readthedocs.io/en/latest/getting-started/quickstart.html).
+- Understand cell annotations, data marshalling, and how Kale compiles to KFP in the [core concepts](https://kubeflow-kale.readthedocs.io/en/latest/concepts/index.html).

--- a/content/en/docs/components/kale/overview.md
+++ b/content/en/docs/components/kale/overview.md
@@ -34,5 +34,5 @@ without rewriting anything.
 
 ## Next Steps
 
-- Compile and run your first notebook on Kubeflow Pipelines with the [quickstart guide](https://kubeflow-kale.readthedocs.io/en/latest/getting-started/quickstart.html).
-- Understand cell annotations, data marshalling, and how Kale compiles to KFP in the [core concepts](https://kubeflow-kale.readthedocs.io/en/latest/concepts/index.html).
+- Compile and run your first notebook on Kubeflow Pipelines with the [quickstart guide](https://kale.kubeflow.org/en/latest/getting-started/quickstart.html).
+- Understand cell annotations, data marshalling, and how Kale compiles to KFP in the [core concepts](https://kale.kubeflow.org/en/latest/concepts/index.html).

--- a/content/en/docs/components/kale/website.md
+++ b/content/en/docs/components/kale/website.md
@@ -2,8 +2,8 @@
 title = "Kubeflow Kale Website"
 description = "LINK | Kubeflow Kale Documentation Website"
 weight = 998
-manualLink = "https://kubeflow-kale.readthedocs.io/"
+manualLink = "https://kale.kubeflow.org/"
 icon = "fa-solid fa-arrow-up-right-from-square"
 +++
 
-Kubeflow Kale has its own documentation website hosted at [`kubeflow-kale.readthedocs.io`](https://kubeflow-kale.readthedocs.io/).
+Kubeflow Kale has its own documentation website hosted at [`kale.kubeflow.org`](https://kale.kubeflow.org/).

--- a/content/en/docs/components/kale/website.md
+++ b/content/en/docs/components/kale/website.md
@@ -1,0 +1,9 @@
++++
+title = "Kubeflow Kale Website"
+description = "LINK | Kubeflow Kale Documentation Website"
+weight = 998
+manualLink = "https://kubeflow-kale.readthedocs.io/"
+icon = "fa-solid fa-arrow-up-right-from-square"
++++
+
+Kubeflow Kale has its own documentation website hosted at [`kubeflow-kale.readthedocs.io`](https://kubeflow-kale.readthedocs.io/).

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -27,10 +27,12 @@ training or model serving.
 | Kubeflow Project                                                                    | Source Code                                                             |
 | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | [Kubeflow KServe](https://www.kubeflow.org/docs/components/kserve/)                 | [`kserve/kserve`](https://github.com/kserve/kserve)                     |
+| [Kubeflow Kale](https://www.kubeflow.org/docs/components/kale/)                     | [`kubeflow/kale`](https://github.com/kubeflow/kale)                     |
 | [Kubeflow Katib](https://www.kubeflow.org/docs/components/katib/)                   | [`kubeflow/katib`](https://github.com/kubeflow/katib)                   |
 | [Kubeflow Model Registry](https://www.kubeflow.org/docs/components/model-registry/) | [`kubeflow/model-registry`](https://github.com/kubeflow/model-registry) |
 | [Kubeflow Notebooks](https://www.kubeflow.org/docs/components/notebooks/)           | [`kubeflow/notebooks`](https://github.com/kubeflow/notebooks)           |
 | [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/)           | [`kubeflow/pipelines`](https://github.com/kubeflow/pipelines)           |
+| [Kubeflow SDK](https://www.kubeflow.org/docs/components/sdk/)                       | [`kubeflow/sdk`](https://github.com/kubeflow/sdk) |
 | [Kubeflow Spark Operator](https://www.kubeflow.org/docs/components/spark-operator/) | [`kubeflow/spark-operator`](https://github.com/kubeflow/spark-operator) |
 | [Kubeflow Trainer](https://www.kubeflow.org/docs/components/trainer/)               | [`kubeflow/trainer`](https://github.com/kubeflow/trainer)               |
 


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

  - Add Kubeflow Kale section under Kubeflow Projects with overview and external link pages
  - Overview content sourced from the Kale documentation site
  - Add Kale and SDK entries to the projects table in the introduction page

### Checklist

- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [X] (for big changes) I will post screenshots of the changes in a PR comment


<img width="1007" height="659" alt="Screenshot 2026-04-28 at 2 08 19 PM" src="https://github.com/user-attachments/assets/371fab26-d640-4d58-ace0-d100fda7a0df" />
<img width="1015" height="864" alt="Screenshot 2026-04-28 at 2 08 10 PM" src="https://github.com/user-attachments/assets/27a54ce0-5a1a-4572-bd56-2d5cd1e560d4" />
<img width="1239" height="1075" alt="Screenshot 2026-04-28 at 2 07 59 PM" src="https://github.com/user-attachments/assets/4d04e8e0-18f6-4778-a4b4-c64ea259a164" />
