### PR TITLE
trainer: Add KAI Scheduler documentation to job scheduling guide

### DIFF
--- a/content/en/docs/components/trainer/operator-guides/job-scheduling/kai.md
+++ b/content/en/docs/components/trainer/operator-guides/job-scheduling/kai.md
@@ -1,0 +1,71 @@
++++
+title = "KAI Scheduler"
+description = "Configure gang scheduling with NVIDIA KAI Scheduler"
+weight = 40
++++
+
+This guide describes how to enable **gang scheduling** and advanced resource management with the [NVIDIA KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) in Kubeflow Trainer.
+
+By integrating KAI Scheduler, you ensure "all-or-nothing" scheduling for distributed training jobs. This means the job only starts if all requested GPU resources are available simultaneously, preventing resource deadlocks in multi-node training.
+
+## Prerequisites
+
+1. **Install KAI Scheduler:** Follow the [KAI Installation Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/docs/installation/README.md) to set up the scheduler and the `podgrouper` service in your Kubernetes cluster.
+2. **Define a Queue:** KAI uses queues to manage resources. Ensure you have a KAI Queue created (e.g., `training-queue`) or use the `default-queue` created during installation.
+
+## Enable KAI Plugin
+
+KAI scheduling can be enabled through the `podGroupPolicy` field in your `TrainingRuntime` or `ClusterTrainingRuntime` specification. 
+
+> **Note:** `podGroupPolicy` is not defined directly on the `TrainJob`. You must define it in the runtime and reference that runtime from your job.
+
+### Example: ClusterTrainingRuntime with KAI
+
+You can enforce KAI scheduling at the runtime level. This ensures that every job using this runtime automatically utilizes KAI gang-scheduling.
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: pytorch-kai-runtime
+spec:
+  podGroupPolicy:
+    kai: {}
+  mlPolicy:
+    torch:
+      numNodes: 1
+  template:
+    spec:
+      containers:
+        - name: train
+          image: pytorch/pytorch:latest
+```
+
+### Example: TrainJob with KAI
+
+Once your runtime is created, you can submit a `TrainJob` that references it. You can also add the `runai/queue` label to your job to route it to a specific resource queue in KAI.
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: pytorch-kai-job
+  labels:
+    runai/queue: "prod-queue" # KAI Scheduler uses this to route the job
+spec:
+  runtimeRef:
+    name: pytorch-kai-runtime
+  trainer:
+    numNodes: 4
+    resourcesPerNode:
+      limits:
+        nvidia.com/gpu: 1
+```
+
+## How it Works
+
+When a `TrainJob` is created using a runtime with the `kai` policy:
+
+1. **Metadata Propagation:** The Trainer Operator applies the necessary labels and annotations to the underlying `JobSet`.
+2. **Pod Grouping:** The KAI `podgrouper` component detects the training pods via the `OwnerReference` chain and automatically creates a KAI `PodGroup` resource.
+3. **Gang Scheduling:** The KAI Scheduler identifies the `PodGroup` and ensures all replicas (workers) are scheduled at once on nodes assigned to the specified queue.

--- a/content/en/docs/components/trainer/operator-guides/job-scheduling/kai.md
+++ b/content/en/docs/components/trainer/operator-guides/job-scheduling/kai.md
@@ -1,23 +1,23 @@
 +++
 title = "KAI Scheduler"
 description = "Configure gang scheduling with NVIDIA KAI Scheduler"
-weight = 40
+weight = 50
 +++
 
-This guide describes how to enable **gang scheduling** and advanced resource management with the [NVIDIA KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) in Kubeflow Trainer.
+This guide describes how to enable **gang scheduling** and advanced resource management with the [NVIDIA KAI Scheduler](https://github.com/kai-scheduler/KAI-Scheduler) in Kubeflow Trainer.
 
 By integrating KAI Scheduler, you ensure "all-or-nothing" scheduling for distributed training jobs. This means the job only starts if all requested GPU resources are available simultaneously, preventing resource deadlocks in multi-node training.
 
 ## Prerequisites
 
-1. **Install KAI Scheduler:** Follow the [KAI Installation Guide](https://github.com/NVIDIA/KAI-Scheduler/blob/main/docs/installation/README.md) to set up the scheduler and the `podgrouper` service in your Kubernetes cluster.
+1. **Install KAI Scheduler:** Follow the [KAI Installation Guide](https://github.com/kai-scheduler/KAI-Scheduler/blob/main/README.md) to set up the scheduler and the `podgrouper` service in your Kubernetes cluster.
 2. **Define a Queue:** KAI uses queues to manage resources. Ensure you have a KAI Queue created (e.g., `training-queue`) or use the `default-queue` created during installation.
 
 ## Enable KAI Plugin
 
-KAI scheduling can be enabled through the `podGroupPolicy` field in your `TrainingRuntime` or `ClusterTrainingRuntime` specification. 
+KAI scheduling can be enabled by setting the `schedulerName` to `kai-scheduler` in the pod template of your `TrainingRuntime` or `ClusterTrainingRuntime` specification.
 
-> **Note:** `podGroupPolicy` is not defined directly on the `TrainJob`. You must define it in the runtime and reference that runtime from your job.
+> **Note:** KAI integrates externally via its PodGrouper component, which monitors pods requesting the `kai-scheduler`.
 
 ### Example: ClusterTrainingRuntime with KAI
 
@@ -29,13 +29,12 @@ kind: ClusterTrainingRuntime
 metadata:
   name: pytorch-kai-runtime
 spec:
-  podGroupPolicy:
-    kai: {}
   mlPolicy:
     torch:
       numNodes: 1
   template:
     spec:
+      schedulerName: kai-scheduler
       containers:
         - name: train
           image: pytorch/pytorch:latest
@@ -43,7 +42,7 @@ spec:
 
 ### Example: TrainJob with KAI
 
-Once your runtime is created, you can submit a `TrainJob` that references it. You can also add the `runai/queue` label to your job to route it to a specific resource queue in KAI.
+Once your runtime is created, you can submit a `TrainJob` that references it. You can also add the `kai.scheduler/queue` label to your job to route it to a specific resource queue in KAI.
 
 ```yaml
 apiVersion: trainer.kubeflow.org/v1alpha1
@@ -51,7 +50,7 @@ kind: TrainJob
 metadata:
   name: pytorch-kai-job
   labels:
-    runai/queue: "prod-queue" # KAI Scheduler uses this to route the job
+    kai.scheduler/queue: "prod-queue" # KAI Scheduler uses this to route the job
 spec:
   runtimeRef:
     name: pytorch-kai-runtime
@@ -64,7 +63,7 @@ spec:
 
 ## How it Works
 
-When a `TrainJob` is created using a runtime with the `kai` policy:
+When a `TrainJob` is created using a runtime configured with the kai-scheduler:
 
 1. **Metadata Propagation:** The Trainer Operator applies the necessary labels and annotations to the underlying `JobSet`.
 2. **Pod Grouping:** The KAI `podgrouper` component detects the training pods via the `OwnerReference` chain and automatically creates a KAI `PodGroup` resource.

--- a/content/en/docs/components/trainer/operator-guides/job-scheduling/overview.md
+++ b/content/en/docs/components/trainer/operator-guides/job-scheduling/overview.md
@@ -29,4 +29,4 @@ supported plugins.
 - Learn how to enable gang scheduling with the [Coscheduling plugin](/docs/components/trainer/operator-guides/job-scheduling/coscheduling).
 - Learn how to configure advanced scheduling with [Volcano Scheduler](/docs/components/trainer/operator-guides/job-scheduling/volcano).
 - Learn how to configure job queueing and resource management with [Kueue](/docs/components/trainer/operator-guides/job-scheduling/kueue).
-- Learn how to configure job queueing and resource management with [KAI Scheduler](/docs/components/trainer/operator-guides/job-scheduling/kai).
+- Learn how to configure gang scheduling with [KAI Scheduler](/docs/components/trainer/operator-guides/job-scheduling/kai).

--- a/content/en/docs/components/trainer/operator-guides/job-scheduling/overview.md
+++ b/content/en/docs/components/trainer/operator-guides/job-scheduling/overview.md
@@ -29,3 +29,4 @@ supported plugins.
 - Learn how to enable gang scheduling with the [Coscheduling plugin](/docs/components/trainer/operator-guides/job-scheduling/coscheduling).
 - Learn how to configure advanced scheduling with [Volcano Scheduler](/docs/components/trainer/operator-guides/job-scheduling/volcano).
 - Learn how to configure job queueing and resource management with [Kueue](/docs/components/trainer/operator-guides/job-scheduling/kueue).
+- Learn how to configure job queueing and resource management with [KAI Scheduler](/docs/components/trainer/operator-guides/job-scheduling/kai).


### PR DESCRIPTION
### Description of Changes

This PR adds official documentation for the new NVIDIA KAI Scheduler integration in Kubeflow Trainer V2. 

Specifically, it:
* Creates a new `kai.md` guide under the `operator-guides/job-scheduling` section.
* Provides YAML examples for configuring `podGroupPolicy: kai: {}` inside a `ClusterTrainingRuntime`.
* Demonstrates how to route a `TrainJob` to specific KAI resource queues using the `runai/queue` label.
* Updates the job scheduling `overview.md` to include KAI Scheduler in the Next Steps section.

### Related Issues

Closes: kubeflow/trainer#2628

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment