### PR TITLE
Add GKE to packaged distributions table

### DIFF
--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -202,6 +202,21 @@ The following table lists distributions which are <em>maintained</em> by their r
       </tr>
       <tr>
         <td>
+          Google Cloud
+            <br><small>Kubeflow on Google Kubernetes Engine</small>
+        </td>
+        <td>
+          {{< kf-version-notice >}}{{% gke/latest-version %}}{{< /kf-version-notice >}}
+        </td>
+        <td>
+          Google Kubernetes Engine (GKE)
+        </td>
+        <td>
+          <a href="https://googlecloudplatform.github.io/kubeflow-gke-docs/docs/deploy/">Website</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
           Nutanix
         </td>
         <td>


### PR DESCRIPTION
### Description of Changes
Adds Google Cloud / Kubeflow on Google Kubernetes Engine to the packaged distributions table on the Installing Kubeflow page.

The row uses the existing GKE version shortcode and links to the GKE deployment docs.

### Related Issues
Closes: #4363

### Validation
- `git diff --check HEAD~1..HEAD`
- GKE deployment docs link returned HTTP 200
- GKE deployment docs `dev` link from the issue returned HTTP 200
- `HUGO_IGNORELOGS=error-remote-getjson hugo --gc --minify` with Hugo 0.124.1, 304 pages built

The Hugo ignore setting suppresses unrelated GitHub API rate-limit errors from the examples page remote metadata fetches.

### Checklist
- [x] You have signed off your commits
- [x] Ensure you follow best practices from the contributing guide
- [ ] (for big changes) I will post screenshots of the changes in a PR comment