### PR TITLE
Clarify KFP getting started endpoint setup

### DIFF
--- a/content/en/docs/components/pipelines/getting-started.md
+++ b/content/en/docs/components/pipelines/getting-started.md
@@ -44,13 +44,19 @@ You can submit the YAML file to a KFP-conformant backend for execution. If you h
 ```python
 from kfp.client import Client
 
-client = Client(host='<MY-KFP-ENDPOINT>')
+client = Client(host='http://localhost:3000')
 run = client.create_run_from_pipeline_package(
     'pipeline.yaml',
     arguments={
         'recipient': 'World',
     },
 )
+```
+
+Replace `http://localhost:3000` with the endpoint for your Kubeflow Pipelines deployment. For a local standalone deployment, port-forward the `ml-pipeline-ui` service first:
+
+```sh
+kubectl port-forward --namespace kubeflow svc/ml-pipeline-ui 3000:80
 ```
 
 The client will print a link to view the pipeline execution graph and logs in the UI. In this case, the pipeline has one task that prints and returns `'Hello, World!'`.


### PR DESCRIPTION
### Details
- Replaces the unresolved KFP endpoint placeholder in the getting started example with the local standalone endpoint used elsewhere in the docs.
- Adds the matching `ml-pipeline-ui` port-forward command and tells readers to replace the endpoint for their deployment.

### Tickets
- Fixes #4287

### Validation
- `git diff --check`
- `npm ci --ignore-scripts`
- `HUGO_IGNORELOGS='error-remote-getjson' /tmp/hugo-0.124.1/hugo --gc --minify`
- Verified the generated page contains the new endpoint and port-forward text.

### AI Assistance
- AI assistance used: yes
- AI was used to prepare this documentation change and run validation.
- Human validation performed: duplicate issue/PR checks, local diff review, and site build verification.