### PR TITLE
website : Add copy to clipboard and language banner for code snippets

### DIFF
--- a/assets/js/click-to-copy.js
+++ b/assets/js/click-to-copy.js
@@ -1,0 +1,105 @@
+
+(function () {
+  'use strict';
+
+  const COPY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
+  const CHECK_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+
+  function setText(btn, icon, label, copied) {
+    btn.innerHTML = icon + `<span class="c2c-label">${label}</span>`;
+    btn.setAttribute('aria-label', label);
+    btn.classList.toggle('c2c-btn--copied', copied);
+  }
+
+  function writeToClipboard(text, btn) {
+    function onSuccess() {
+      setText(btn, CHECK_ICON, 'Copied!', true);
+      setTimeout(function () { setText(btn, COPY_ICON, 'Copy', false); }, 2000);
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(onSuccess).catch(onSuccess);
+    } else {
+      // Fallback
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.cssText = 'position:fixed;top:0;left:0;opacity:0;';
+      document.body.appendChild(ta);
+      ta.focus(); ta.select();
+      try { document.execCommand('copy'); } catch (_) {}
+      document.body.removeChild(ta);
+      onSuccess();
+    }
+  }
+
+  function addCopyButtons() {
+    var barePres = document.querySelectorAll('.td-content > pre:not(.mermaid)');
+    barePres.forEach(function (pre) {
+      if (pre.parentNode && pre.parentNode.classList.contains('highlight')) return;
+      var wrapper = document.createElement('div');
+      wrapper.className = 'highlight';
+      pre.parentNode.insertBefore(wrapper, pre);
+      wrapper.appendChild(pre);
+    });
+
+    var highlights = document.querySelectorAll('.td-content .highlight');
+    highlights.forEach(function (hl) {
+      if (hl.querySelector('.c2c-header')) return;
+
+      var codeEl = hl.querySelector('pre code') || hl.querySelector('pre');
+      var lang = '';
+      if (codeEl) {
+        var dataLang = codeEl.getAttribute('data-lang');
+        if (!dataLang && codeEl.className) {
+          var match = codeEl.className.match(/language-(\S+)/);
+          if (match) dataLang = match[1];
+        }
+        if (dataLang) {
+          lang = dataLang.trim().toUpperCase();
+        }
+      }
+
+      if (lang === 'SHELL' || lang === 'BASH' || lang === 'SH') {
+        lang = 'Terminal';
+      } else if (lang === 'YAML' || lang === 'YML') {
+        lang = 'YAML';
+      } else if (lang === 'JSON') {
+        lang = 'JSON';
+      } else if (lang === 'PYTHON' || lang === 'PY') {
+        lang = 'Python';
+      } else if (!lang) {
+        lang = 'Code';
+      }
+
+      var header = document.createElement('div');
+      header.className = 'c2c-header';
+
+      var langBadge = document.createElement('span');
+      langBadge.className = 'c2c-lang-badge';
+      langBadge.textContent = lang;
+      header.appendChild(langBadge);
+
+      // Create copy button
+      var btn = document.createElement('button');
+      btn.className = 'c2c-btn';
+      btn.setAttribute('type', 'button');
+      setText(btn, COPY_ICON, 'Copy', false);
+
+      btn.addEventListener('click', function () {
+        var text = (codeEl.textContent || codeEl.innerText || '').trim();
+        writeToClipboard(text, btn);
+      });
+
+      header.appendChild(btn);
+
+      // Prepend header to highlight block
+      hl.insertBefore(header, hl.firstChild);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', addCopyButtons);
+  } else {
+    document.addCopyButtons || addCopyButtons();
+  }
+})();

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -536,7 +536,7 @@ nav.foldable-nav {
       color: $home-card-body-color;
       background-color: $home-card-body-bg;
 
-      // make links in the card have a dotted underline
+
       a {
         color: lighten($primary, 15%);
         border-bottom: 0.1em dotted lighten($primary, 15%);
@@ -608,7 +608,7 @@ nav.foldable-nav {
   }
 
   #pageContent {
-    // make card body a flex coloumn so github badge can sit at the bottom
+
     .card-deck .card-body,
     .card-columns .card-body {
       display: flex;
@@ -839,17 +839,13 @@ nav.foldable-nav {
   }
 }
 
-// --------------------------------------------------
-// Installing Kubeflow page
-// --------------------------------------------------
+
 .distributions-table thead {
   background-color: $navbar-bg;
   color: $white;
 }
 
-// --------------------------------------------------
-// 404 page
-// --------------------------------------------------
+
 .error-page {
   margin-top: 120px;
 
@@ -882,10 +878,6 @@ nav.foldable-nav {
   }
 }
 
-// --------------------------------------------------
-// for tabbed code blocks
-// https://github.com/kubeflow/website/pull/2779
-// --------------------------------------------------
 .nav-tabs {
   border-bottom: none !important;
 }
@@ -910,9 +902,7 @@ nav.foldable-nav {
   }
 }
 
-// --------------------------------------------------
-// for feedback partial
-// --------------------------------------------------
+
 .feedback--answer {
   display: inline-block;
 }
@@ -930,31 +920,236 @@ nav.foldable-nav {
   display: block;
 }
 
-// --------------------------------------------------
-// code styling
-// --------------------------------------------------
+
 .td-content {
-  // set the background color of inline code
   p code,
   li > code,
   table code {
     background-color: $code-inline-bg;
   }
 
-  // set the background color of code blocks
   .highlight pre {
     background-color: $code-block-bg;
   }
 
-  // ensure links with code in them have the correct color
   a > code {
     color: unset;
   }
 }
 
-// --------------------------------------------------
-// alert styling
-// --------------------------------------------------
+
 .alert {
   background-color: $alert-bg;
+}
+
+
+
+.td-content .highlight {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: visible !important;
+
+  pre {
+    margin: 0 !important;
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+    padding-right: 1.5rem !important;
+  }
+}
+
+// ---- Header container ----
+.c2c-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  // Inherit the card's top-border-radius from .highlight (no explicit radius needed)
+  border-radius: inherit;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+// Theme specific colors for header
+@at-root [data-theme="light"] .c2c-header {
+  background-color: #f3f4f6;
+  border-bottom: 1px solid #e5e7eb;
+  color: #4b5563;
+}
+
+@at-root [data-theme="dark"] .c2c-header {
+  background-color: rgba(0, 0, 0, 0.25);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: #9ca3af;
+}
+
+.c2c-lang-badge {
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  opacity: 0.85;
+}
+
+// ---- The button itself ----
+.c2c-btn {
+  position: relative;
+  z-index: 10;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  padding: 0;
+  border-radius: 0.3rem;
+
+  // Reset browser default <button> styles
+  appearance: none;
+  background: none;
+  border: 1px solid transparent;
+  color: inherit;
+  cursor: pointer;
+
+  opacity: 0.8;
+  transition:
+    opacity       0.18s ease,
+    color         0.18s ease,
+    background    0.18s ease,
+    border-color  0.18s ease,
+    transform     0.15s ease,
+    box-shadow    0.18s ease;
+
+  svg {
+    display: block;
+    flex-shrink: 0;
+    pointer-events: none;
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+// Hover state for the button
+.c2c-btn:hover,
+.c2c-btn--copied,
+.c2c-btn:focus-visible {
+  opacity: 1;
+}
+
+// ---- Floating tooltip ("Copy" / "Copied!") ----
+.c2c-label {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  right: 50%;
+  transform: translateX(50%) translateY(4px);
+
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.65rem;
+  font-family: inherit;
+  font-weight: normal;
+  line-height: 1.3;
+  white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
+
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 4px solid transparent;
+  }
+}
+
+.c2c-btn:hover .c2c-label,
+.c2c-btn--copied .c2c-label {
+  opacity: 1;
+  transform: translateX(50%) translateY(0);
+}
+
+// ---- Light mode ----
+@at-root [data-theme="light"] .c2c-btn {
+  color: #6b7280;
+  background-color: transparent;
+  border-color: transparent;
+
+  &:hover {
+    color: $kf-blue;
+    background-color: #ffffff;
+    border-color: #e5e7eb;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  }
+
+  &.c2c-btn--copied {
+    color: #10b981;
+    background-color: #ecfdf5;
+    border-color: #a7f3d0;
+  }
+
+  .c2c-label {
+    color: #ffffff;
+    background-color: #1f2937;
+    &::after {
+      border-top-color: #1f2937;
+    }
+  }
+
+  &.c2c-btn--copied .c2c-label {
+    background-color: #10b981;
+    &::after {
+      border-top-color: #10b981;
+    }
+  }
+}
+
+// ---- Dark mode ----
+@at-root [data-theme="dark"] .c2c-btn {
+  color: #9ca3af;
+  background-color: transparent;
+  border-color: transparent;
+
+  &:hover {
+    color: lighten($kf-blue, 15%);
+    background-color: #1f2937;
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+
+  &.c2c-btn--copied {
+    color: #34d399;
+    background-color: rgba(52, 211, 153, 0.1);
+    border-color: rgba(52, 211, 153, 0.4);
+  }
+
+  .c2c-label {
+    color: #f3f4f6;
+    background-color: #111827;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    &::after {
+      border-top-color: #111827;
+    }
+  }
+
+  &.c2c-btn--copied .c2c-label {
+    background-color: #065f46;
+    border-color: rgba(52, 211, 153, 0.4);
+    &::after {
+      border-top-color: #065f46;
+    }
+  }
+}
+
+// ---- Keyboard accessibility ----
+.c2c-btn:focus-visible {
+  outline: 2px solid $kf-blue;
+  outline-offset: 2px;
 }

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -80,7 +80,7 @@ window.markmap = {
 
 {{ if .Site.Params.prism_syntax_highlighting -}}
   <script src='{{ "js/prism.js" | relURL }}'></script>
-{{ else if false -}}
+{{ else -}}
   {{ $c2cJS := resources.Get "js/click-to-copy.js" -}}
   {{ if hugo.IsProduction -}}
     {{ $c2cJS = $c2cJS | minify | fingerprint -}}


### PR DESCRIPTION
<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes
What was changed:

assets/js/click-to-copy.js — Rewrote the existing (disabled) copy-to-clipboard script with a new, dependency-free implementation that:

Injects a header bar (.c2c-header) at the top of each .highlight code block containing a language label (e.g. "Terminal", "YAML", "Python") and a copy icon button.
Automatically wraps any bare pre tag elements in a .highlight container so all code blocks render consistently.
Uses the modern navigator.clipboard API with a legacy execCommand fallback for broader browser support.
Switches the button to a checkmark icon with a "Copied!" tooltip on success, reverting after 2 seconds.
assets/scss/_styles_project.scss — Added styles for the copy button feature:

Converts .td-content .highlight to a flex column so the header sits above the pre tag block.
Styles the .c2c-header bar with a language badge on the left and copy button on the right.
Full light and dark theme support using @at-root [data-theme="light/dark"] to correctly target the site's theme attribute.
Resets browser default <button> styles (appearance: none; background: none) to prevent unstyled grey button rendering.
Includes a smooth floating tooltip and keyboard accessibility (focus-visible outline).
layouts/partials/scripts.html — Enabled the click-to-copy script, which was previously gated behind a hardcoded false condition.

Design decisions:

The copy button is placed in a dedicated header bar above the code, so it never overlaps or obscures code text.
Button opacity and hover states follow the existing Kubeflow brand color (#4279f4).
Success state uses green (#10b981 light / #34d399 dark) consistent with standard UX conventions.
No external dependencies added (no Popper.js, no extra libraries).


### Related Issues



Closes: #4327 #4328 #4210 




<img width="1097" height="593" alt="Screenshot 2026-06-10 020249" src="https://github.com/user-attachments/assets/7bd83be6-ee24-47fb-b0eb-26b460a93669" />