### PR TITLE
website: Update OWNERS for 2026 KSC members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,9 @@
 approvers:
 - andreyvelich
+- chasecadet
 - franciscojavierarceo
 - juliusvonkohout 
-- johnugeorge
-- terrytangyuan
+- thesuperzapper
 - varodrig
 - zijianjoy
 
@@ -12,4 +12,5 @@ reviewers:
 emeritus_approvers:
 - james-jwu
 - jbottum
-
+- johnugeorge
+- terrytangyuan


### PR DESCRIPTION
Updates the root OWNERS file for the 2026 Kubeflow Steering Committee transition.

Changes:
- add chasecadet and thesuperzapper as approvers
- move johnugeorge and terrytangyuan to emeritus_approvers
- preserve existing non-KSC approvers

Related: kubeflow/community#950