### PR TITLE
community: Account for the restructuring within `kubeflow/community`

### DIFF
--- a/content/en/docs/about/contributing.md
+++ b/content/en/docs/about/contributing.md
@@ -30,9 +30,8 @@ Details about the different types of Kubeflow members as well as membership crit
 
 ### Companies/organizations
 
-If you would like your company or organization to be acknowledged for contributing to Kubeflow, or participating in the community (being a user counts), please send a PR adding the relevant info to [member_organizations.yaml](https://github.com/kubeflow/community/blob/master/member_organizations.yaml).
-
-Additionally, if your company has adopted Kubeflow internally, we encouraage you to add yourself to [ADOPTERS.md](https://github.com/kubeflow/community/blob/master/ADOPTERS.md)!
+If your company has adopted Kubeflow internally, we encourage you to add
+yourself to [ADOPTERS.md](https://github.com/kubeflow/community/blob/master/ADOPTERS.md)!
 
 If you want your employee's GitHub contributions to be attributed to your company,
 please ask them to set the company field in their GitHub profile.

--- a/content/en/docs/about/membership.md
+++ b/content/en/docs/about/membership.md
@@ -19,7 +19,7 @@ Responsibilities for most roles are scoped to these repositories.
 | Approver | Contributions acceptance approval| Highly experienced active reviewer and contributor to a repository | [OWNERS](/docs/about/contributing/#owners) file approver entry|
 | WG Lead  | Provides technical leadership for a Working Group | Have sufficient domain knowledge to provide effective technical leadership | [wgs.yaml] entry |
 | WG Chair | Provides overall leadership for a Working Group | Have sufficient domain knowledge to provide effective leadership | [wgs.yaml] entry |
-| Kubeflow Steering Commitee Member | The KSC provides leadership for the overall Kubeflow project | [Details](https://github.com/kubeflow/community/blob/master/KUBEFLOW-STEERING-COMMITTEE.md#charter) | [Members](https://github.com/kubeflow/community/blob/master/KUBEFLOW-STEERING-COMMITTEE.md#charter) |
+| Kubeflow Steering Commitee Member | The KSC provides leadership for the overall Kubeflow project | [Details](https://github.com/kubeflow/community/blob/master/committee-steering/charter.md) | [Members](https://github.com/kubeflow/community/tree/master/committee-steering#members) |
 
 </div>
 </div>


### PR DESCRIPTION
### Description of Changes

This PR fixes the 404 issues after the restructurings of the community repo, see i.e. the following PRs:

- https://github.com/kubeflow/community/pull/959
- https://github.com/kubeflow/community/pull/968

### Related Issues

_None_

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
