### PR TITLE
community: Add ROAMAP to subproject table

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -2,36 +2,36 @@
 name: Bug Report
 about: Report a bug encountered with Kubeflow Website
 labels:
-- kind/bug
+  - kind/bug
 title: "bug(<component>): <Bug Name>"
 ---
+
 **This is a Bug Report**
 
 <!-- Thanks for filing an issue! Before submitting, please fill in the following information. -->
 <!-- See https://www.kubeflow.org/docs/about/contributing/ for guidance on writing an actionable issue description. -->
 
 <!--Required Information-->
+
 **Problem:**
 
-
 **Proposed Solution:**
-
 
 **Page to Update (provide the full path):**
 https://kubeflow.org/...
 
-
 <!--Component/Kubeflow Version:-->
+
 **Component/Kubeflow Version:**
 
-
 <!--Additional Information:-->
+
 ### Labels
+
 <!-- Please include labels below by uncommenting them to help us better triage issues -->
 
 <!-- /area central-dashboard -->
 <!-- /area katib -->
-<!-- /area kserve -->
 <!-- /area hub -->
 <!-- /area notebooks -->
 <!-- /area pipelines -->
@@ -40,7 +40,7 @@ https://kubeflow.org/...
 <!-- /area gsoc -->
 <!-- /area website -->
 <!-- /area community -->
----
 
 <!-- Don't delete message below to encourage users to support your issue! -->
+
 Impacted by this bug? Give it a 👍.

--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -76,7 +76,6 @@ The following list shows available Kubeflow community meetings with the correspo
 | Kubeflow Pipelines call              | [Google Doc](http://bit.ly/kfp-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_zxNI1k5aF1cJreIymqAFBo) |
 | Kubeflow Spark Operator call         | [Google Doc](https://bit.ly/3VGzP4n)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xXuM6gALgBG8vDZHFCNxce) |
 | Kubeflow Community Distribution call | [Google Doc](https://bit.ly/kf-release-team-notes)   | [YouTube playlist](https://youtu.be/hSWhr6JyXe0?list=PLmzRWLV1CK_wdWP58XoaJ0kczgHTdsOph)     |
-| KServe call                          | [Google Doc](https://bit.ly/3NlKFb3)                 |                                                                                              |
 
 </div>
 </div>

--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -41,14 +41,14 @@ following the defined feature lifecycle for the project.
 <div class="table-responsive">
 <div class="table table-bordered">
 
-| Kubeflow Subproject                                                                 | Source Code                                                           |
-| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| [Kubeflow Hub](https://www.kubeflow.org/docs/components/hub/)                       | [kubeflow/hub](https://github.com/kubeflow/hub)                       |
-| [Kubeflow Katib](https://www.kubeflow.org/docs/components/katib/)                   | [kubeflow/katib](https://github.com/kubeflow/katib)                   |
-| [Kubeflow Notebooks](https://www.kubeflow.org/docs/components/notebooks/)           | [kubeflow/notebooks](https://github.com/kubeflow/notebooks)           |
-| [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/)           | [kubeflow/pipelines](https://github.com/kubeflow/pipelines)           |
-| [Kubeflow Spark Operator](https://www.kubeflow.org/docs/components/spark-operator/) | [kubeflow/spark-operator](https://github.com/kubeflow/spark-operator) |
-| [Kubeflow Trainer](https://www.kubeflow.org/docs/components/trainer/)               | [kubeflow/trainer](https://github.com/kubeflow/trainer)               |
+| Kubeflow Subproject                                                                 | Roadmap                                                                      |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [Kubeflow Hub](https://www.kubeflow.org/docs/components/hub/)                       | [Roadmap](https://github.com/kubeflow/hub/blob/main/ROADMAP.md)              |
+| [Kubeflow Katib](https://www.kubeflow.org/docs/components/katib/)                   | [Roadmap](https://github.com/kubeflow/katib/blob/master/ROADMAP.md)          |
+| [Kubeflow Notebooks](https://www.kubeflow.org/docs/components/notebooks/)           | Progressing                                                                  |
+| [Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/)           | [Roadmap](https://github.com/kubeflow/pipelines/blob/master/ROADMAP.md)      |
+| [Kubeflow Spark Operator](https://www.kubeflow.org/docs/components/spark-operator/) | [Roadmap](https://github.com/kubeflow/spark-operator/blob/master/ROADMAP.md) |
+| [Kubeflow Trainer](https://www.kubeflow.org/docs/components/trainer/)               | [Roadmap](https://github.com/kubeflow/trainer/blob/master/ROADMAP.md)        |
 
 ### Incubating Projects
 
@@ -58,10 +58,10 @@ functionality is stable, it is still maturing toward a final release.
 <div class="table-responsive">
 <div class="table table-bordered">
 
-| Kubeflow Subproject                                             | Source Code                                       |
-| --------------------------------------------------------------- | ------------------------------------------------- |
-| [Kubeflow Kale](https://www.kubeflow.org/docs/components/kale/) | [kubeflow/kale](https://github.com/kubeflow/kale) |
-| [Kubeflow SDK](https://sdk.kubeflow.org/en/latest/)             | [kubeflow/sdk](https://github.com/kubeflow/sdk)   |
+| Kubeflow Subproject                                             | Roadmap                                                         |
+| --------------------------------------------------------------- | --------------------------------------------------------------- |
+| [Kubeflow Kale](https://www.kubeflow.org/docs/components/kale/) | Progressing                                                     |
+| [Kubeflow SDK](https://sdk.kubeflow.org/en/latest/)             | [Roadmap](https://github.com/kubeflow/sdk/blob/main/ROADMAP.md) |
 
 ### Experimental Projects
 
@@ -72,11 +72,11 @@ technical implementation details, and planned use-cases for the projects.
 <div class="table-responsive">
 <div class="table table-bordered">
 
-| Kubeflow Subproject               | Source Code                                                                                             |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Kubeflow MLflow Integration       | [kubeflow/mlflow-integration](https://github.com/kubeflow/mlflow-integration)                           |
-| Kubeflow MCP Server               | [kubeflow/mcp-server](https://github.com/kubeflow/mcp-server)                                           |
-| Kubeflow MCP Spark History Server | [kubeflow/mcp-apache-spark-history-server](https://github.com/kubeflow/mcp-apache-spark-history-server) |
+| Kubeflow Subproject               | Roadmap     |
+| --------------------------------- | ----------- |
+| Kubeflow MLflow Integration       | Progressing |
+| Kubeflow MCP Server               | Progressing |
+| Kubeflow MCP Spark History Server | Progressing |
 
 ### Deprecated Projects
 
@@ -207,6 +207,9 @@ You can also install the master branch of
 [`kubeflow/community-distribution`](https://github.com/kubeflow/community-distribution)
 by following the instructions [here](https://github.com/kubeflow/community-distribution?tab=readme-ov-file#installation)
 and provide us feedback.
+
+Check out [the Kubeflow Community Distribution roadmap](https://github.com/kubeflow/community-distribution/blob/master/ROADMAP.md)
+to learn more about the future releases.
 
 ## Next steps
 

--- a/content/en/docs/started/introduction.md
+++ b/content/en/docs/started/introduction.md
@@ -96,25 +96,13 @@ a foundation of tools for running AI workloads on Kubernetes.
 
 The [Kubeflow logo represents](https://github.com/kubeflow/kubeflow/issues/187#issuecomment-375194419) the letters `K` and `F` inside the heptagon of the Kubernetes logo, which represent two communities: `Kubernetes` (cloud-native) and `flow` (Machine Learning). In this context, `flow` is not only indicating `TensorFlow`, but also all ML frameworks which make use of Dataflow Graph as the normal form for model/algorithm implementation.
 
-## Roadmaps
-
-Kubeflow subprojects have individual roadmaps which established by project maintainers:
-
-- [Kubeflow Pipelines roadmap](https://github.com/kubeflow/pipelines/blob/master/ROADMAP.md)
-- [Kubeflow Trainer roadmap](https://github.com/kubeflow/trainer/blob/master/ROADMAP.md)
-- [Kubeflow SDK roadmap](https://github.com/kubeflow/sdk/blob/main/ROADMAP.md)
-- [Kubeflow Katib roadmap](https://github.com/kubeflow/katib/blob/master/ROADMAP.md)
-- [Kubeflow Hub roadmap](https://github.com/kubeflow/hub/blob/main/ROADMAP.md)
-- [Kubeflow Spark Operator roadmap](https://github.com/kubeflow/spark-operator/blob/master/ROADMAP.md)
-
 ## Kubeflow Community
 
-Kubeflow is a community-led project maintained by the
-[Kubeflow Working Groups](/docs/about/governance/#5-working-groups)
-under the guidance of the [Kubeflow Steering Committee](/docs/about/governance/#2-kubeflow-steering-committee).
+Kubeflow is a community-led project maintained by the Kubeflow Working Groups under the guidance
+of the Kubeflow Outreach Committee, Kubeflow Distribution Committee, and Kubeflow Steering Committee.
 
-We encourage you to learn about the [Kubeflow Community](/docs/about/community/)
-and how to [contribute](/docs/about/contributing/) to the project!
+We encourage you to learn about the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/)
+and how to [contribute](https://www.kubeflow.org/docs/about/contributing/) to the project!
 
 ## Next Steps
 


### PR DESCRIPTION
Ref: https://github.com/kubeflow/community/issues/988

This add the ROADMAP links to the subproject tables, so we can re-link it from the `kubeflow/kubeflow`: https://github.com/kubeflow/kubeflow/pull/7790
So we can maintain it in a single place.


/assign @franciscojavierarceo @juliusvonkohout @chasecadet @thesuperzapper @tarekabouzeid @varodrig