### PR TITLE
website: Add Kale ROADMAP link to subproject table

### DIFF
--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -60,7 +60,7 @@ functionality is stable, it is still maturing toward a final release.
 
 | Kubeflow Subproject                                             | Roadmap                                                         |
 | --------------------------------------------------------------- | --------------------------------------------------------------- |
-| [Kubeflow Kale](https://www.kubeflow.org/docs/components/kale/) | Progressing                                                     |
+| [Kubeflow Kale](https://www.kubeflow.org/docs/components/kale/) | [Roadmap](https://github.com/kubeflow/kale/blob/main/ROADMAP.md) |
 | [Kubeflow SDK](https://sdk.kubeflow.org/en/latest/)             | [Roadmap](https://github.com/kubeflow/sdk/blob/main/ROADMAP.md) |
 
 ### Experimental Projects


### PR DESCRIPTION
## Summary
- Link the Kale entry in the Incubating Projects table to its [GitHub ROADMAP.md](https://github.com/kubeflow/kale/blob/main/ROADMAP.md), matching the format already used by the Kubeflow SDK row.

## Test plan
- [x] Verified the page renders correctly with `hugo server`
- [x] Confirmed the link points to the correct ROADMAP.md URL