### PR TITLE
website: Fix link to Kubeflow community contributor month

### DIFF
--- a/content/en/docs/about/contributor-of-the-month.md
+++ b/content/en/docs/about/contributor-of-the-month.md
@@ -7,7 +7,7 @@ aliases = ["/docs/contributor-of-the-month/"]
 
 ## Learn about the Program
 
-Please review the elegibilily criteria and process in the [Kubeflow community](https://github.com/varodrig/community/blob/contributor-month/committee-outreach/contributor-month.md). The program will start in July 1st, 2026.
+Please review the elegibilily criteria and process in the [Kubeflow community](https://github.com/kubeflow/community/blob/master/committee-outreach/contributor-month.md). The program will start in July 1st, 2026.
 
 ## How to apply
 


### PR DESCRIPTION
Corrected the link to the Kubeflow community contributor month document.

### Description of Changes

Corrected the link to the Kubeflow community contributor month document.


### Checklist

- [x ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x ] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
