### PR TITLE
community: Add meeting links to the website overview

### DIFF
--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -73,7 +73,7 @@ The following list shows available Kubeflow community meetings with the correspo
 | [Kubeflow SDK and ML Experience call][2]  | [Google Doc](https://bit.ly/kf-ml-experience)        | [YouTube playlist](https://youtu.be/VkbVVk2OGUI?list=PLmzRWLV1CK_wSO2IMPnzChxESmaoXNfrY)     |
 | [Kubeflow Hub call][3]                    | [Google Doc](https://bit.ly/kf-model-registry-notes) | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ymLhMu0UMeaWPsLDPIjNnW) |
 | [Kubeflow Notebooks call][4]              | [Google Doc](https://bit.ly/kf-notebooks-wg-notes)   | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_wpsjmJYTo50xe2eYu1-HvP) |
-| [Kubeflow Pipelines call][5]              | [Google Doc](http://bit.ly/kfp-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_zxNI1k5aF1cJreIymqAFBo) |
+| [Kubeflow Pipelines call][5]              | [Google Doc](https://bit.ly/kfp-meeting-notes)       | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_zxNI1k5aF1cJreIymqAFBo) |
 | [Kubeflow Spark Operator call][6]         | [Google Doc](https://bit.ly/3VGzP4n)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xXuM6gALgBG8vDZHFCNxce) |
 | [Kubeflow Community Distribution call][7] | [Google Doc](https://bit.ly/kf-release-team-notes)   | [YouTube playlist](https://youtu.be/hSWhr6JyXe0?list=PLmzRWLV1CK_wdWP58XoaJ0kczgHTdsOph)     |
 

--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -66,16 +66,25 @@ The following list shows available Kubeflow community meetings with the correspo
 <div class="table-responsive">
 <div class="table table-bordered">
 
-| Meeting Name                         | Meeting Notes                                        | Recordings                                                                                   |
-| ------------------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Kubeflow community call              | [Google Doc](https://bit.ly/kf-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ypvsQu10SGRmhf2S7mbYL5) |
-| Kubeflow Trainer and Katib call      | [Google Doc](https://bit.ly/2PWVCkV)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xAiAY-3Vw94lrUs4xeNZ3j) |
-| Kubeflow SDK and ML Experience call  | [Google Doc](https://bit.ly/kf-ml-experience)        | [YouTube playlist](https://youtu.be/VkbVVk2OGUI?list=PLmzRWLV1CK_wSO2IMPnzChxESmaoXNfrY)     |
-| Kubeflow Hub call                    | [Google Doc](https://bit.ly/kf-model-registry-notes) | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ymLhMu0UMeaWPsLDPIjNnW) |
-| Kubeflow Notebooks call              | [Google Doc](https://bit.ly/kf-notebooks-wg-notes)   | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_wpsjmJYTo50xe2eYu1-HvP) |
-| Kubeflow Pipelines call              | [Google Doc](http://bit.ly/kfp-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_zxNI1k5aF1cJreIymqAFBo) |
-| Kubeflow Spark Operator call         | [Google Doc](https://bit.ly/3VGzP4n)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xXuM6gALgBG8vDZHFCNxce) |
-| Kubeflow Community Distribution call | [Google Doc](https://bit.ly/kf-release-team-notes)   | [YouTube playlist](https://youtu.be/hSWhr6JyXe0?list=PLmzRWLV1CK_wdWP58XoaJ0kczgHTdsOph)     |
+| Meeting Link                              | Meeting Notes                                        | Recordings                                                                                   |
+| ----------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [Kubeflow Community call][0]              | [Google Doc](https://bit.ly/kf-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ypvsQu10SGRmhf2S7mbYL5) |
+| [Kubeflow Trainer and Katib call][1]      | [Google Doc](https://bit.ly/2PWVCkV)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xAiAY-3Vw94lrUs4xeNZ3j) |
+| [Kubeflow SDK and ML Experience call][2]  | [Google Doc](https://bit.ly/kf-ml-experience)        | [YouTube playlist](https://youtu.be/VkbVVk2OGUI?list=PLmzRWLV1CK_wSO2IMPnzChxESmaoXNfrY)     |
+| [Kubeflow Hub call][3]                    | [Google Doc](https://bit.ly/kf-model-registry-notes) | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ymLhMu0UMeaWPsLDPIjNnW) |
+| [Kubeflow Notebooks call][4]              | [Google Doc](https://bit.ly/kf-notebooks-wg-notes)   | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_wpsjmJYTo50xe2eYu1-HvP) |
+| [Kubeflow Pipelines call][5]              | [Google Doc](http://bit.ly/kfp-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_zxNI1k5aF1cJreIymqAFBo) |
+| [Kubeflow Spark Operator call][6]         | [Google Doc](https://bit.ly/3VGzP4n)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xXuM6gALgBG8vDZHFCNxce) |
+| [Kubeflow Community Distribution call][7] | [Google Doc](https://bit.ly/kf-release-team-notes)   | [YouTube playlist](https://youtu.be/hSWhr6JyXe0?list=PLmzRWLV1CK_wdWP58XoaJ0kczgHTdsOph)     |
+
+[0]: https://zoom-lfx.platform.linuxfoundation.org/meeting/91956494486?password=6b63548e-98e0-4cb2-b63f-6b408090a5f9
+[1]: https://zoom-lfx.platform.linuxfoundation.org/meeting/94838800520?password=07cd1676-1c31-4fb3-8536-732cf7dad502
+[2]: https://zoom-lfx.platform.linuxfoundation.org/meeting/99885200814?password=12a9c369-1b62-4025-9f10-421678026350
+[3]: https://zoom-lfx.platform.linuxfoundation.org/meeting/96514587367?password=647fd9fb-4419-4a1f-9590-224157419168
+[4]: https://zoom-lfx.platform.linuxfoundation.org/meeting/91703267161?password=34d61440-cca9-4249-9fc9-31df1d5db746
+[5]: https://zoom-lfx.platform.linuxfoundation.org/meeting/91355917913?password=a81a7846-1fcb-4ffc-9b83-6eb897da0c3a
+[6]: https://zoom-lfx.platform.linuxfoundation.org/meeting/91692004209?password=e48ce50b-b41d-459a-9f32-7313fa388380
+[7]: https://zoom-lfx.platform.linuxfoundation.org/meeting/92113176338?password=883a2c39-41a9-4395-b9f2-d2bd73e8c39e
 
 </div>
 </div>

--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -76,6 +76,8 @@ The following list shows available Kubeflow community meetings with the correspo
 | [Kubeflow Pipelines call][5]              | [Google Doc](https://bit.ly/kfp-meeting-notes)       | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_zxNI1k5aF1cJreIymqAFBo) |
 | [Kubeflow Spark Operator call][6]         | [Google Doc](https://bit.ly/3VGzP4n)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xXuM6gALgBG8vDZHFCNxce) |
 | [Kubeflow Community Distribution call][7] | [Google Doc](https://bit.ly/kf-release-team-notes)   | [YouTube playlist](https://youtu.be/hSWhr6JyXe0?list=PLmzRWLV1CK_wdWP58XoaJ0kczgHTdsOph)     |
+| [Kubeflow Docs Agent call][8]             | [Google Doc][notes-docs-agent]                       |                                                                                              |
+| [Kubeflow Outreach Program call][9]       | [Google Doc][notes-outreach-program]                 |                                                                                              |
 
 [0]: https://zoom-lfx.platform.linuxfoundation.org/meeting/91956494486?password=6b63548e-98e0-4cb2-b63f-6b408090a5f9
 [1]: https://zoom-lfx.platform.linuxfoundation.org/meeting/94838800520?password=07cd1676-1c31-4fb3-8536-732cf7dad502
@@ -85,6 +87,11 @@ The following list shows available Kubeflow community meetings with the correspo
 [5]: https://zoom-lfx.platform.linuxfoundation.org/meeting/91355917913?password=a81a7846-1fcb-4ffc-9b83-6eb897da0c3a
 [6]: https://zoom-lfx.platform.linuxfoundation.org/meeting/91692004209?password=e48ce50b-b41d-459a-9f32-7313fa388380
 [7]: https://zoom-lfx.platform.linuxfoundation.org/meeting/92113176338?password=883a2c39-41a9-4395-b9f2-d2bd73e8c39e
+[8]: https://zoom-lfx.platform.linuxfoundation.org/meeting/99511158809?password=29577223-6733-4df0-828b-75a95f474555
+[9]: https://zoom-lfx.platform.linuxfoundation.org/meeting/99427447261?password=0d90a0ca-d31e-4fe1-a95f-363c3ec0e3c3
+
+[notes-docs-agent]: https://docs.google.com/document/d/1E1SGYGhKHhvIHRDsk--0vIVOmboKWByZy45H-obZ3sc/edit?usp=sharing
+[notes-outreach-program]: https://docs.google.com/document/d/1IblkZ0z61mjpSccIK7qDaMqUbFADZiIoOX9g8uDq_qc/edit?usp=sharing
 
 </div>
 </div>

--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -69,7 +69,7 @@ The following list shows available Kubeflow community meetings with the correspo
 | Meeting Name                         | Meeting Link  | Meeting Notes                                        | Recordings                                                                                   |
 | ------------------------------------ | --------------| ---------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | Kubeflow Community call              | [Register][0] | [Google Doc](https://bit.ly/kf-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ypvsQu10SGRmhf2S7mbYL5) |
-| Kubeflow Trainer and Katib call      | [Register][1] | [Google Doc](https://bit.ly/2PWVCkV)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xAiAY-3Vw94lrUs4xeNZ3j) |
+| Kubeflow Trainer and Katib call      | [Register][1] | [Google Doc](https://bit.ly/kf-trainer-meeting)      | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xAiAY-3Vw94lrUs4xeNZ3j) |
 | Kubeflow SDK and ML Experience call  | [Register][2] | [Google Doc](https://bit.ly/kf-ml-experience)        | [YouTube playlist](https://youtu.be/VkbVVk2OGUI?list=PLmzRWLV1CK_wSO2IMPnzChxESmaoXNfrY)     |
 | Kubeflow Hub call                    | [Register][3] | [Google Doc](https://bit.ly/kf-model-registry-notes) | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ymLhMu0UMeaWPsLDPIjNnW) |
 | Kubeflow Notebooks call              | [Register][4] | [Google Doc](https://bit.ly/kf-notebooks-wg-notes)   | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_wpsjmJYTo50xe2eYu1-HvP) |

--- a/content/en/docs/about/community.md
+++ b/content/en/docs/about/community.md
@@ -66,18 +66,18 @@ The following list shows available Kubeflow community meetings with the correspo
 <div class="table-responsive">
 <div class="table table-bordered">
 
-| Meeting Link                              | Meeting Notes                                        | Recordings                                                                                   |
-| ----------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [Kubeflow Community call][0]              | [Google Doc](https://bit.ly/kf-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ypvsQu10SGRmhf2S7mbYL5) |
-| [Kubeflow Trainer and Katib call][1]      | [Google Doc](https://bit.ly/2PWVCkV)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xAiAY-3Vw94lrUs4xeNZ3j) |
-| [Kubeflow SDK and ML Experience call][2]  | [Google Doc](https://bit.ly/kf-ml-experience)        | [YouTube playlist](https://youtu.be/VkbVVk2OGUI?list=PLmzRWLV1CK_wSO2IMPnzChxESmaoXNfrY)     |
-| [Kubeflow Hub call][3]                    | [Google Doc](https://bit.ly/kf-model-registry-notes) | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ymLhMu0UMeaWPsLDPIjNnW) |
-| [Kubeflow Notebooks call][4]              | [Google Doc](https://bit.ly/kf-notebooks-wg-notes)   | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_wpsjmJYTo50xe2eYu1-HvP) |
-| [Kubeflow Pipelines call][5]              | [Google Doc](https://bit.ly/kfp-meeting-notes)       | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_zxNI1k5aF1cJreIymqAFBo) |
-| [Kubeflow Spark Operator call][6]         | [Google Doc](https://bit.ly/3VGzP4n)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xXuM6gALgBG8vDZHFCNxce) |
-| [Kubeflow Community Distribution call][7] | [Google Doc](https://bit.ly/kf-release-team-notes)   | [YouTube playlist](https://youtu.be/hSWhr6JyXe0?list=PLmzRWLV1CK_wdWP58XoaJ0kczgHTdsOph)     |
-| [Kubeflow Docs Agent call][8]             | [Google Doc][notes-docs-agent]                       |                                                                                              |
-| [Kubeflow Outreach Program call][9]       | [Google Doc][notes-outreach-program]                 |                                                                                              |
+| Meeting Name                         | Meeting Link  | Meeting Notes                                        | Recordings                                                                                   |
+| ------------------------------------ | --------------| ---------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Kubeflow Community call              | [Register][0] | [Google Doc](https://bit.ly/kf-meeting-notes)        | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ypvsQu10SGRmhf2S7mbYL5) |
+| Kubeflow Trainer and Katib call      | [Register][1] | [Google Doc](https://bit.ly/2PWVCkV)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xAiAY-3Vw94lrUs4xeNZ3j) |
+| Kubeflow SDK and ML Experience call  | [Register][2] | [Google Doc](https://bit.ly/kf-ml-experience)        | [YouTube playlist](https://youtu.be/VkbVVk2OGUI?list=PLmzRWLV1CK_wSO2IMPnzChxESmaoXNfrY)     |
+| Kubeflow Hub call                    | [Register][3] | [Google Doc](https://bit.ly/kf-model-registry-notes) | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_ymLhMu0UMeaWPsLDPIjNnW) |
+| Kubeflow Notebooks call              | [Register][4] | [Google Doc](https://bit.ly/kf-notebooks-wg-notes)   | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_wpsjmJYTo50xe2eYu1-HvP) |
+| Kubeflow Pipelines call              | [Register][5] | [Google Doc](https://bit.ly/kfp-meeting-notes)       | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_zxNI1k5aF1cJreIymqAFBo) |
+| Kubeflow Spark Operator call         | [Register][6] | [Google Doc](https://bit.ly/3VGzP4n)                 | [YouTube playlist](https://www.youtube.com/playlist?list=PLmzRWLV1CK_xXuM6gALgBG8vDZHFCNxce) |
+| Kubeflow Community Distribution call | [Register][7] | [Google Doc](https://bit.ly/kf-release-team-notes)   | [YouTube playlist](https://youtu.be/hSWhr6JyXe0?list=PLmzRWLV1CK_wdWP58XoaJ0kczgHTdsOph)     |
+| Kubeflow Docs Agent call             | [Register][8] | [Google Doc][notes-docs-agent]                       |                                                                                              |
+| Kubeflow Outreach Program call       | [Register][9] | [Google Doc][notes-outreach-program]                 |                                                                                              |
 
 [0]: https://zoom-lfx.platform.linuxfoundation.org/meeting/91956494486?password=6b63548e-98e0-4cb2-b63f-6b408090a5f9
 [1]: https://zoom-lfx.platform.linuxfoundation.org/meeting/94838800520?password=07cd1676-1c31-4fb3-8536-732cf7dad502


### PR DESCRIPTION
### Description of Changes

Add meeting links to the website overview

_Note_: Even though one component in the meeting link is called "password" it's value is actually publicly available (verified by viewing the calandar in a firefox private tab).

If there is consensus that this is something we want I'll also propose the same change for the WG List in the community repo 🤗 

<img width="2255" height="1328" alt="image" src="https://github.com/user-attachments/assets/15f87347-9547-4dad-b236-4bed33bd77c2" />



### Related Issues

_none_

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment

---

/cc @thesuperzapper 