### PR TITLE
website: Add GSoC 2026 logo to navbar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -66,12 +66,12 @@ ignoreFiles = []
     pre = "<span style='display:inline-flex; align-items:center;'><img src='/events/images/kubeflow-virtual.png' style='height:60px; width:auto; margin-right:8px;'><span style='display:flex; flex-direction:column; justify-content:center;'><span class='badge badge-warning' style='margin-bottom:4px;'>August 19th, 2026</span><span class='badge badge-warning'>Virtual</span></span></span>"
     post = ""
     url = "https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-kubeflow-community-showcase-2026-genai-and-mlops-in-action/"
-#  [[menu.main]]
-#    name = "GSoC 2025"
-#    weight = -900
-#    pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' style='height: 1.22em;'></i>"
-#    post = "<br><span class='badge badge-success'>Ongoing</span>"
-#    url = "/events/gsoc-2025/"
+[[menu.main]]
+    name = "GSoC 2026"
+    weight = -900
+    pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' style='height: 1.22em;'></i>"
+    post = "<br><span class='badge badge-success'>Ongoing</span>"
+    url = "/events/gsoc-2026/"
   [[menu.main]]
     name = "Docs"
     weight = -102

--- a/config.toml
+++ b/config.toml
@@ -69,9 +69,9 @@ ignoreFiles = []
 [[menu.main]]
     name = "GSoC 2026"
     weight = -900
-    pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' style='height: 1.22em;'></i>"
+    pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' alt='' style='height: 1.22em;'></i>"
     post = "<br><span class='badge badge-success'>Ongoing</span>"
-    url = "/events/upcoming-events/gsoc-2026/"
+    url = "/events/gsoc-2026/"
   [[menu.main]]
     name = "Docs"
     weight = -102

--- a/config.toml
+++ b/config.toml
@@ -71,7 +71,7 @@ ignoreFiles = []
     weight = -900
     pre = "<i class='fas pr-2'><img src='/docs/images/logos/gsoc.svg' style='height: 1.22em;'></i>"
     post = "<br><span class='badge badge-success'>Ongoing</span>"
-    url = "/events/gsoc-2026/"
+    url = "/events/upcoming-events/gsoc-2026/"
   [[menu.main]]
     name = "Docs"
     weight = -102

--- a/content/en/events/upcoming-events/gsoc-2026.md
+++ b/content/en/events/upcoming-events/gsoc-2026.md
@@ -2,7 +2,7 @@
 title = "Google Summer of Code 2026"
 description = "Google Summer of Code 2026"
 icon = "fas fa-calendar-day"
-
+url = "/events/gsoc-2026/"
 +++
 
 ---


### PR DESCRIPTION
Fixes #4351

![screenshot description](https://github.com/user-attachments/assets/11bb5fd6-96ca-4265-bde9-0b3f794877d5)

## What this PR does
Adds the GSoC 2026 logo, label, and "Ongoing" status badge to the top navbar,
using the same pattern previously used for GSoC 2025 (which was already
present in `config.toml` as a commented-out template).

- Uncommented and updated the `[[menu.main]]` entry in `config.toml` to point
  to GSoC 2026 (logo, label, badge).
- Added a stable `url` front-matter field to
  `content/en/events/upcoming-events/gsoc-2026.md`, matching the convention
  used in the 2024/2025 GSoC event pages, so the link won't break once this
  page moves to `/past-events/`.

## Testing
Built and previewed locally with `hugo server` and verified the navbar
renders the logo, label, and badge correctly, linking to `/events/gsoc-2026/`
without a 404. Also confirmed `hugo --gc --minify` completes cleanly.

## Notes
I'd asked on the issue whether this was still wanted but hadn't gotten a
response yet — opening this PR now so there's concrete code to review.
Happy to close or rework if this turns out to be unnecessary.