### PR TITLE
website: fix swapped release component source links

### DIFF
--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.10.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.10.md
@@ -137,13 +137,13 @@ weight = 91
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.10.0/components/crud-web-apps/volumes">v1.10.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.10.0/components/crud-web-apps/tensorboards">v1.10.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.10.0/components/crud-web-apps/tensorboards">v1.10.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.10.0/components/crud-web-apps/volumes">v1.10.0</a>
         </td>
       </tr>
       <!-- ======================= -->

--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.11.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.11.md
@@ -139,13 +139,13 @@ weight = 90
       <tr>
         <td>Tensorboard Web Application</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.10.0/components/crud-web-apps/volumes">v1.10.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.10.0/components/crud-web-apps/tensorboards">v1.10.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web Application</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.10.0/components/crud-web-apps/tensorboards">v1.10.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.10.0/components/crud-web-apps/volumes">v1.10.0</a>
         </td>
       </tr>
       <!-- ======================= -->

--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.3.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.3.md
@@ -119,13 +119,13 @@ weight = 101
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.3.1-rc.0/components/crud-web-apps/volumes">v1.3.1-rc.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.3.1-rc.0/components/crud-web-apps/tensorboards">v1.3.1-rc.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.3.1-rc.0/components/crud-web-apps/tensorboards">v1.3.1-rc.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.3.1-rc.0/components/crud-web-apps/volumes">v1.3.1-rc.0</a>
         </td>
       </tr>
       <!-- ======================= -->
@@ -307,13 +307,13 @@ weight = 101
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.3.0-rc.1/components/crud-web-apps/volumes">v1.3.0-rc.1</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.3.0-rc.1/components/crud-web-apps/tensorboards">v1.3.0-rc.1</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.3.0-rc.1/components/crud-web-apps/tensorboards">v1.3.0-rc.1</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.3.0-rc.1/components/crud-web-apps/volumes">v1.3.0-rc.1</a>
         </td>
       </tr>
       <!-- ======================= -->

--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.4.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.4.md
@@ -125,13 +125,13 @@ weight = 100
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/volumes">v1.4.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/tensorboards">v1.4.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/tensorboards">v1.4.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/volumes">v1.4.0</a>
         </td>
       </tr>
       <!-- ======================= -->
@@ -301,13 +301,13 @@ weight = 100
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/volumes">v1.4.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/tensorboards">v1.4.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/tensorboards">v1.4.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.4.0/components/crud-web-apps/volumes">v1.4.0</a>
         </td>
       </tr>
       <!-- ======================= -->

--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.5.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.5.md
@@ -137,13 +137,13 @@ weight = 99
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/volumes">v1.5.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/tensorboards">v1.5.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/tensorboards">v1.5.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/volumes">v1.5.0</a>
         </td>
       </tr>
       <!-- ======================= -->
@@ -414,13 +414,13 @@ This information is only for the manifests found in the <a href="https://github.
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/volumes">v1.5.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/tensorboards">v1.5.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/tensorboards">v1.5.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/volumes">v1.5.0</a>
         </td>
       </tr>
       <!-- ======================= -->

--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.6.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.6.md
@@ -135,13 +135,13 @@ weight = 98
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/crud-web-apps/volumes">v1.6.1</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/crud-web-apps/tensorboards">v1.6.1</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/crud-web-apps/tensorboards">v1.6.1</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/crud-web-apps/volumes">v1.6.1</a>
         </td>
       </tr>
       <!-- ======================= -->
@@ -407,13 +407,13 @@ This information is only for the manifests found in the <a href="https://github.
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.6.0/components/crud-web-apps/volumes">v1.6.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.6.0/components/crud-web-apps/tensorboards">v1.6.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.6.0/components/crud-web-apps/tensorboards">v1.6.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.6.0/components/crud-web-apps/volumes">v1.6.0</a>
         </td>
       </tr>
       <!-- ======================= -->

--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.7.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.7.md
@@ -133,13 +133,13 @@ weight = 97
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.7.0/components/crud-web-apps/volumes">v1.7.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.7.0/components/crud-web-apps/tensorboards">v1.7.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.7.0/components/crud-web-apps/tensorboards">v1.7.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.7.0/components/crud-web-apps/volumes">v1.7.0</a>
         </td>
       </tr>
       <!-- ======================= -->

--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.8.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.8.md
@@ -139,13 +139,13 @@ weight = 96
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.8.0/components/crud-web-apps/volumes">v1.8.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.8.0/components/crud-web-apps/tensorboards">v1.8.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.8.0/components/crud-web-apps/tensorboards">v1.8.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.8.0/components/crud-web-apps/volumes">v1.8.0</a>
         </td>
       </tr>
       <!-- ======================= -->
@@ -412,13 +412,13 @@ This information is only for the manifests found in the <a href="https://github.
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.8.0/components/crud-web-apps/volumes">v1.8.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.8.0/components/crud-web-apps/tensorboards">v1.8.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.8.0/components/crud-web-apps/tensorboards">v1.8.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.8.0/components/crud-web-apps/volumes">v1.8.0</a>
         </td>
       </tr>
       <!-- ======================= -->

--- a/content/en/docs/kubeflow-distribution/releases/kubeflow-1.9.md
+++ b/content/en/docs/kubeflow-distribution/releases/kubeflow-1.9.md
@@ -133,13 +133,13 @@ weight = 95
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.9.0/components/crud-web-apps/volumes">v1.9.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.9.0/components/crud-web-apps/tensorboards">v1.9.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.9.0/components/crud-web-apps/tensorboards">v1.9.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.9.0/components/crud-web-apps/volumes">v1.9.0</a>
         </td>
       </tr>
       <!-- ======================= -->
@@ -413,13 +413,13 @@ This information is only for the manifests found in the <a href="https://github.
       <tr>
         <td>Tensorboard Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.9.0/components/crud-web-apps/volumes">v1.9.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.9.0/components/crud-web-apps/tensorboards">v1.9.0</a>
         </td>
       </tr>
       <tr>
         <td>Volumes Web App</td>
         <td>
-          <a href="https://github.com/kubeflow/kubeflow/tree/v1.9.0/components/crud-web-apps/tensorboards">v1.9.0</a>
+          <a href="https://github.com/kubeflow/kubeflow/tree/v1.9.0/components/crud-web-apps/volumes">v1.9.0</a>
         </td>
       </tr>
       <!-- ======================= -->


### PR DESCRIPTION
### Description of Changes

Fix swapped GitHub source links in the Kubeflow release pages.

The `Tensorboard Web App` rows were pointing to `crud-web-apps/volumes`, and the `Volumes Web App` rows were pointing to `crud-web-apps/tensorboards`. So if you clicked through, you landed on the wrong component page. Kinda confusing, yep.

How to reproduce:
1. Open a release page like `1.10` or `1.5`.
2. In `Component Versions`, click `Tensorboard Web App`.
3. Before this fix it opens the `volumes` directory, and `Volumes Web App` opens `tensorboards`.
4. With this fix, each row opens the matching source directory.

### Related Issues

Closes: n/a

Related: n/a

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
