### PR TITLE
Add global search to website navbar

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,81 +1,84 @@
 {{ $cover := and
-    (.HasShortcode "blocks/cover")
-    (not .Site.Params.ui.navbar_translucent_over_cover_disable)
+(.HasShortcode "blocks/cover")
+(not .Site.Params.ui.navbar_translucent_over_cover_disable)
 -}}
 
 <nav class="js-navbar-scroll navbar navbar-expand-md navbar-dark
             {{- if $cover }} td-navbar-cover {{- end }} td-navbar">
-<div class="container px-0">
-  <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
-    {{- /**/ -}}
-    <span class="navbar-brand__logo navbar-logo">
-      {{- if ne .Site.Params.ui.navbar_logo false -}}
+  <div class="container px-0">
+    <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
+      {{- /**/ -}}
+      <span class="navbar-brand__logo navbar-logo">
+        {{- if ne .Site.Params.ui.navbar_logo false -}}
         <span class="show_light-only">
           {{ with resources.Get "icons/logo.svg" -}}
-            {{ ( . | minify).Content | safeHTML -}}
+          {{ ( . | minify).Content | safeHTML -}}
           {{ end -}}
         </span>
         <span class="show_dark-only">
           {{ with resources.Get "icons/logo-white.svg" -}}
-            {{ ( . | minify).Content | safeHTML -}}
+          {{ ( . | minify).Content | safeHTML -}}
           {{ end -}}
         </span>
-      {{ end -}}
-    </span>
-    {{- /**/ -}}
-    <span class="text-uppercase font-weight-bold">
-      {{- .Site.Title -}}
-    </span>
-    {{- /**/ -}}
-  </a>
-  <div class="filler"></div>
-	<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_navbar" aria-controls="main_navbar" aria-expanded="false" aria-label="Toggle navigation">
-		<span class="navbar-toggler-icon"></span>
-	</button>
-	<div class="collapse navbar-collapse ml-md-auto" id="main_navbar">
-    <ul class="navbar-nav ml-auto pt-4 pt-md-0 my-2 my-md-1">
-      {{ $p := . -}}
-      {{ $last := len .Site.Menus.main -}}
-      {{ range $i, $e := .Site.Menus.main -}}
-      {{ $longContent := gt (len $e.Name) 8 -}}
-      {{ $isLast := eq $i (sub $last 1) -}}
-      <li class="nav-item mt-1 mt-lg-0 {{ if $isLast }}mr-1 mr-lg-3 mr-xl-4{{ else }}mr-2 mr-xl-4{{- end }} {{- if $longContent }} long-content {{- end }}">
-        {{ $active := or ($p.IsMenuCurrent "main" $e) ($p.HasMenuCurrent "main" $e) -}}
-        {{ with $e.Page }}{{ $active = or $active ( $.IsDescendant $e) }}{{ end -}}
-        {{ $pre := $e.Pre -}}
-        {{ $post := $e.Post -}}
-        {{ $url := urls.Parse $e.URL -}}
-        {{ $baseurl := urls.Parse $.Site.Params.Baseurl -}}
-        <a {{/**/ -}}
-          class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
-          href="{{ with $e.Page }}{{ $e.RelPermalink }}{{ else }}{{ $e.URL | relLangURL }}{{ end }}"
-          {{- if ne $url.Host $baseurl.Host }} target="_blank" {{- end -}}
-        >
+        {{ end -}}
+      </span>
+      {{- /**/ -}}
+      <span class="text-uppercase font-weight-bold">
+        {{- .Site.Title -}}
+      </span>
+      {{- /**/ -}}
+    </a>
+    <div class="filler"></div>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_navbar"
+      aria-controls="main_navbar" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse ml-md-auto" id="main_navbar">
+      <ul class="navbar-nav ml-auto pt-4 pt-md-0 my-2 my-md-1">
+        {{ $p := . -}}
+        {{ $last := len .Site.Menus.main -}}
+        {{ range $i, $e := .Site.Menus.main -}}
+        {{ $longContent := gt (len $e.Name) 8 -}}
+        {{ $isLast := eq $i (sub $last 1) -}}
+        <li
+          class="nav-item mt-1 mt-lg-0 {{ if $isLast }}mr-1 mr-lg-3 mr-xl-4{{ else }}mr-2 mr-xl-4{{- end }} {{- if $longContent }} long-content {{- end }}">
+          {{ $active := or ($p.IsMenuCurrent "main" $e) ($p.HasMenuCurrent "main" $e) -}}
+          {{ with $e.Page }}{{ $active = or $active ( $.IsDescendant $e) }}{{ end -}}
+          {{ $pre := $e.Pre -}}
+          {{ $post := $e.Post -}}
+          {{ $url := urls.Parse $e.URL -}}
+          {{ $baseurl := urls.Parse $.Site.Params.Baseurl -}}
+          <a {{/**/ -}} class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
+            href="{{ with $e.Page }}{{ $e.RelPermalink }}{{ else }}{{ $e.URL | relLangURL }}{{ end }}" {{- if ne
+            $url.Host $baseurl.Host }} target="_blank" {{- end -}}>
             {{- with $e.Pre }}{{ $pre }}{{ end -}}
             <span {{- if $active }} class="active" {{- end }}>
               {{- $e.Name -}}
             </span>
             {{- with $e.Post }}{{ $post }}{{ end -}}
-        </a>
-      </li>
-      {{ end -}}
-      <li class="nav-item mr-2 mt-1 mt-lg-0 py-md-2">
-        <div class="vr"></div>
-      </li>
-      <li class="nav-item dropdown mt-1 mt-lg-0 mr-1 mr-xl-2">
-        {{ partial "theme-toggler" . }}
-      </li>
-      {{ if .Site.Params.versions -}}
-      <li class="nav-item dropdown mt-1 mt-lg-0">
-        {{ partial "navbar-version-selector.html" . -}}
-      </li>
-      {{ end -}}
-      {{ if (gt (len .Site.Home.Translations) 0) -}}
-      <li class="nav-item dropdown mt-1 mt-lg-0 mr-2">
-        {{ partial "navbar-lang-selector.html" . -}}
-      </li>
-      {{ end -}}
-    </ul>
+          </a>
+        </li>
+        {{ end -}}
+        <li class="nav-item mr-2 mt-1 mt-lg-0 py-md-2">
+          <div class="vr"></div>
+        </li>
+        <li class="nav-item mr-2 mt-1 mt-lg-0">
+          {{ partial "search-input.html" . }}
+        </li>
+        <li class="nav-item dropdown mt-1 mt-lg-0 mr-1 mr-xl-2">
+          {{ partial "theme-toggler" . }}
+        </li>
+        {{ if .Site.Params.versions -}}
+        <li class="nav-item dropdown mt-1 mt-lg-0">
+          {{ partial "navbar-version-selector.html" . -}}
+        </li>
+        {{ end -}}
+        {{ if (gt (len .Site.Home.Translations) 0) -}}
+        <li class="nav-item dropdown mt-1 mt-lg-0 mr-2">
+          {{ partial "navbar-lang-selector.html" . -}}
+        </li>
+        {{ end -}}
+      </ul>
+    </div>
   </div>
-</div>
 </nav>


### PR DESCRIPTION
## Summary

This PR adds the existing Docsy search component to the global website navigation bar so users can access search functionality from any page.

## Changes

* Added the existing `search-input.html` partial to `navbar.html`
* Made search available outside the documentation section
* Preserved existing navbar functionality

## Why

This improves navigation and discoverability, especially for new users who want to quickly find content without first navigating to the documentation pages.
