### PR TITLE
Fix Slack badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <img src="https://img.shields.io/badge/CNCF%20Landscape-5699C6?logo=cncf&style=social" alt="KubeFlow CNCF Landscape" />
   </a>
 
-  [![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)]((https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels))
+  [![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
   [![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/kubeflow)
   [![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://www.youtube.com/kubeflow)
   [![X](https://img.shields.io/badge/X-%23000000.svg?style=for-the-badge&logo=X&logoColor=white)](https://x.com/kubeflow/)


### PR DESCRIPTION
The Slack badge in README.md was not clickable because the link destination had a duplicated opening parenthesis:

    ]((https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels))

This caused the URL to be parsed incorrectly (including the stray parentheses), breaking the hyperlink so the badge displayed as a plain image instead of a link.

Fix: remove the extra parenthesis so the badge correctly links to the Kubeflow Slack channels page.

    [![Slack](...)](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)

<!-- Add the component name to the PR's title. Example: pipelines: Fixed broken link in Getting Started with Kubeflow Pipelines -->

### Description of Changes

<!-- Please include a summary of the changes and which issue is fixed. -->

### Related Issues

<!-- If this pull request RESOLVES an open issue, include it here with the prefix "Closes: #<issue number>"
     This will automatically close the issue when the PR is merged. -->

Closes: #<issue number>

<!-- If this pull request is RELATED but does NOT resolve an open issue,
     include it here with the prefix "Related: #<issue number>" -->

Related: #<issue number>


### Checklist

- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
