### PR TITLE
website: Remove outdated distributions

### DIFF
--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -162,50 +162,6 @@ The following table lists distributions which are <em>maintained</em> by their r
       </tr>
       <tr>
         <td>
-          Microsoft Azure
-        </td>
-        <td>
-          {{< kf-version-notice >}}{{% azure/latest-version %}}{{< /kf-version-notice >}}
-          <sup><a href="https://github.com/Azure/kubeflow-aks/releases">[release notes]</a></sup>
-        </td>
-        <td>
-          Azure Kubernetes Service (AKS)
-        </td>
-        <td>
-          <a href="https://azure.github.io/kubeflow-aks/main">Website</a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Nutanix
-        </td>
-        <td>
-          {{< kf-version-notice >}}{{% nutanix/latest-version %}}{{< /kf-version-notice >}}
-        </td>
-        <td>
-          Nutanix Kubernetes Platform
-        </td>
-        <td>
-          <a href="https://nutanix.github.io/kubeflow-manifests">Website</a>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          QBO GPU Cloud
-        </td>
-        <td>
-          {{< kf-version-notice >}}{{% qbo/latest-version %}}{{< /kf-version-notice >}}
-          <sup><a href="https://docs.qbo.io/news/2025/05/09/api-1-5-14-released/">[release notes]</a></sup>
-        </td>
-        <td>
-          QBO Kubernetes Engine (QKE)
-        </td>
-         <td>
-          <a href="https://docs.qbo.io/demos/kubeflow">Website</a>
-        </td>
-      </tr>
-      <tr>
-        <td>
           Red Hat
             <br><small>Open Data Hub</small>
         </td>

--- a/content/en/docs/started/installing-kubeflow/index.md
+++ b/content/en/docs/started/installing-kubeflow/index.md
@@ -162,6 +162,21 @@ The following table lists distributions which are <em>maintained</em> by their r
       </tr>
       <tr>
         <td>
+          Microsoft Azure
+        </td>
+        <td>
+          {{< kf-version-notice >}}{{% azure/latest-version %}}{{< /kf-version-notice >}}
+          <sup><a href="https://github.com/Azure/kubeflow-aks/releases">[release notes]</a></sup>
+        </td>
+        <td>
+          Azure Kubernetes Service (AKS)
+        </td>
+        <td>
+          <a href="https://azure.github.io/kubeflow-aks/main">Website</a>
+        </td>
+      </tr>
+      <tr>
+        <td>
           Red Hat
             <br><small>Open Data Hub</small>
         </td>


### PR DESCRIPTION
### Description of Changes

The KSC has voted and approved https://github.com/kubeflow/community/pull/1002

so 

For AKS @ritazh @mosabami @asw101 as in https://github.com/kubeflow/website/pull/4153
For Nutanix @johnugeorge https://github.com/kubeflow/website/pull/4122
For QBO @alexeadem https://github.com/kubeflow/website/pull/4111

please update your distributions.


We had 1.10.0 -> 1.10.1  -> 1.10.2 -> 1.11.0 -> 26.03.0 -> 26.03.1 https://github.com/kubeflow/community-distribution/releases, so some of your distribution are missing out for 5 releases.

"If a distribution no longer qualifies to be listed as a Kubeflow Distribution, its owners will
be notified of the reasons why via their contact details and will have 90 days to implement the
necessary changes.

If the distribution owners do not implement the changes or do not respond to requests, then the
distribution will be removed and will no longer be listed in the Kubeflow website."

You qualify hereby as notified.
cc @kubeflow/kubeflow-distribution-committee and @kubeflow/kubeflow-steering-committee 

### Related Issues

https://github.com/kubeflow/website/pull/4406
