### PR TITLE
spark-operator: Update Notebooks integration to use Enterprise Gateway 3.3.0 defaults

### DIFF
--- a/content/en/docs/components/spark-operator/user-guide/notebooks-spark-operator.md
+++ b/content/en/docs/components/spark-operator/user-guide/notebooks-spark-operator.md
@@ -52,7 +52,7 @@ Save the following manifest as `enterprise-gateway-helm.yaml` which will be used
 global:
   rbac: true
 
-image: elyra/enterprise-gateway:3.2.3
+image: elyra/enterprise-gateway:3.3.0
 imagePullPolicy: Always
 logLevel: DEBUG
 
@@ -67,7 +67,7 @@ kernel:
 
 kip:
   enabled: false
-  image: elyra/kernel-image-puller:3.2.3
+  image: elyra/kernel-image-puller:3.3.0
   imagePullPolicy: Always
   pullPolicy: Always
   defaultContainerRegistry: quay.io
@@ -80,7 +80,7 @@ The command below uses a YAML file named enterprise-gateway-helm.yaml, which inc
 
 ```bash
 helm upgrade --install enterprise-gateway \
-  https://github.com/jupyter-server/enterprise_gateway/releases/download/v3.2.3/jupyter_enterprise_gateway_helm-3.2.3.tar.gz \
+  https://github.com/jupyter-server/enterprise_gateway/releases/download/v3.3.0/jupyter_enterprise_gateway_helm-3.3.0.tar.gz \
   --namespace enterprise-gateway \
   --values enterprise-gateway-helm.yaml \
   --create-namespace \
@@ -190,7 +190,7 @@ Next, add the kernelspecs to the mounted volume at `/jupyter-gateway/kernelspecs
 
 You can download and extract them with:
 ```bash
-mkdir spark_python_operator && cd spark_python_operator && curl -sL https://github.com/jupyter-server/enterprise_gateway/releases/download/v3.2.3/jupyter_enterprise_gateway_kernelspecs_kubernetes-3.2.3.tar.gz | tar -xz --strip-components=1 "spark_python_operator/*" 
+mkdir spark_python_operator && cd spark_python_operator && curl -sL https://github.com/jupyter-server/enterprise_gateway/releases/download/v3.3.0/jupyter_enterprise_gateway_kernelspecs_kubernetes-3.3.0.tar.gz | tar -xz --strip-components=1 "spark_python_operator/*" 
 ```
 Once extracted, make any necessary customizations to the kernelspecs.
 


### PR DESCRIPTION
## Summary

Updates the [Integration with Kubeflow Notebooks](https://www.kubeflow.org/docs/components/spark-operator/user-guide/notebooks-spark-operator/) guide so the Jupyter Enterprise Gateway install matches current chart defaults and the latest release.

Fixes: #<issue-number> <!-- if you opened one; otherwise delete this line -->

## Motivation

The current docs pin Jupyter Enterprise Gateway to `3.2.3` and ask readers to deploy with a custom `values.yaml`. That custom config, plus the PVC / `hostPath` kernelspecs mount path, caused real install friction: mounted kernelspecs were not detected reliably.

The Enterprise Gateway Helm chart already:

- Ships `elyra/enterprise-gateway:3.3.0` and `elyra/kernel-image-puller:3.3.0`
- Includes `spark_python_operator` in `kernel.allowedKernels`
- Keeps `kernelspecsPvc.enabled: false` by default

So the docs should install with chart defaults and avoid recommending PVC-mounted kernelspecs for the common path.

## Changes

- Bump Helm chart / image references from `3.2.3` → `3.3.0`
- Replace the custom `enterprise-gateway-helm.yaml` install with the default chart install (no `--values` override)
- Optionally note `--set kernel.defaultKernelName=spark_python_operator` if readers want that kernel as default
- Remove (or clearly de-emphasize) the PVC / `hostPath` kernelspecs customization steps
- Point advanced customization to the upstream [Jupyter Enterprise Gateway docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/)
- Correct the kernel name in the “what happens next” steps to `spark_python_operator` (was `pyspark`)

## Test plan

- [ ] Preview the page locally (or via Netlify/preview if available) and confirm Step 1 shows only the default Helm install for `v3.3.0`
- [ ] Confirm there is no custom values YAML required for the happy path
- [ ] Confirm the PVC kernelspecs section is removed or marked as not recommended
- [ ] Confirm remaining download/image URLs use `3.3.0`
- [ ] Confirm “select kernel” text uses `spark_python_operator`
- [ ] Manually verified Helm install against a cluster using chart defaults (optional but recommended):

```bash
helm upgrade --install enterprise-gateway \
  https://github.com/jupyter-server/enterprise_gateway/releases/download/v3.3.0/jupyter_enterprise_gateway_helm-3.3.0.tar.gz \
  --namespace enterprise-gateway \
  --create-namespace \
  --wait