### PR TITLE
pipelines: document PostgreSQL as development-only for KFP 2.18

### DIFF
--- a/content/en/docs/components/pipelines/operator-guides/configure-database.md
+++ b/content/en/docs/components/pipelines/operator-guides/configure-database.md
@@ -1,0 +1,186 @@
++++
+title = "Database Configuration"
+description = ""
+weight = 4
++++
+
+{{% kfp-v2-keywords %}}
+
+Kubeflow Pipelines (KFP) uses a relational database to store pipeline definitions, run history, and other metadata. The API server is the main component that interacts with the database.
+
+By default, KFP deploys with MySQL. PostgreSQL is also available for a limited set of deployment configurations.
+
+## MySQL (Default)
+
+MySQL is the default database backend for KFP. It is automatically configured when you deploy KFP using the standard kustomize manifests. No additional database configuration is needed.
+
+To deploy KFP with MySQL using the platform-agnostic overlay:
+
+```bash
+export PIPELINE_VERSION={{% pipelines/latest-version %}}
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
+kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic?ref=$PIPELINE_VERSION"
+```
+
+For full installation instructions, see the [Installation](/docs/components/pipelines/operator-guides/installation/) guide.
+
+MySQL is the fully supported backend, and it is the backend assumed by the deployment overlays for proxy-enabled, cache-disabled, pod-to-pod TLS, and artifact proxy configurations.
+
+## PostgreSQL (Limited Support)
+
+{{% alert title="Warning" color="warning" %}}
+PostgreSQL support is not yet part of a tagged Kubeflow Pipelines release. The instructions in this section apply to the `master` branch and are intended for development and evaluation, not for production. Production deployments should use MySQL until PostgreSQL support ships in a release.
+{{% /alert %}}
+
+KFP can be deployed with PostgreSQL as its database backend using the `pgx` driver. Dedicated kustomize overlays are provided for this purpose:
+
+- `manifests/kustomize/env/platform-agnostic-postgresql` — standalone (single-user)
+- `manifests/kustomize/env/platform-agnostic-multi-user-postgresql` — multi-user
+
+### Support Scope
+
+PostgreSQL support is deliberately scoped to the core deployment path. Only the following configuration is tested and supported:
+
+- execution cache **enabled**
+- proxy **disabled**
+- pod-to-pod TLS **disabled**
+
+No PostgreSQL overlay exists for the following combinations, so they are **not supported**:
+
+| Mode | Unsupported combination |
+| --- | --- |
+| Standalone | PostgreSQL with pod-to-pod TLS enabled |
+| Standalone | PostgreSQL with the execution cache disabled |
+| Standalone | PostgreSQL with proxy enabled |
+| Multi-user | PostgreSQL with the execution cache disabled |
+| Multi-user | PostgreSQL with the artifact proxy enabled |
+
+These combinations are also rejected explicitly by the project's CI deployment script, so they are not exercised in testing.
+
+{{% alert title="Warning" color="warning" %}}
+**Pod-to-pod TLS is not available with PostgreSQL.** The only pod-to-pod TLS overlay, `platform-agnostic-standalone-tls`, is a standalone MySQL-based configuration, and there is no PostgreSQL equivalent for either standalone or multi-user deployments. Enabling pod-to-pod TLS on a PostgreSQL deployment does not encrypt traffic between pods.
+
+Note that the absence of a multi-user TLS overlay is not specific to PostgreSQL: no multi-user pod-to-pod TLS overlay exists for any database backend. Switching to MySQL does not enable pod-to-pod TLS in multi-user mode.
+{{% /alert %}}
+
+For proxy-enabled, cache-disabled, and artifact-proxy deployments, use the MySQL-backed configuration. Extending PostgreSQL support to these combinations is tracked in [kubeflow/pipelines#13822](https://github.com/kubeflow/pipelines/issues/13822).
+
+### Configuring `sslmode`
+
+The API server requires `sslmode` to be set explicitly in the PostgreSQL connection parameters; it will not start without it. The base overlay leaves `sslmode` unset so that deployments fail fast rather than silently running without TLS.
+
+Add `patches` to your local overlay to set `sslmode` on both the API server and the cache server. The following example extends the overlay from the next section with `sslmode=disable` for local development:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-postgresql?ref=master
+
+images:
+  - name: ghcr.io/kubeflow/kfp-api-server
+    newTag: master
+  - name: ghcr.io/kubeflow/kfp-cache-server
+    newTag: master
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ml-pipeline
+      spec:
+        template:
+          spec:
+            containers:
+              - name: ml-pipeline-api-server
+                env:
+                  - name: DBCONFIG_POSTGRESQLCONFIG_EXTRAPARAMS
+                    value: '{"sslmode":"disable"}'
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cache-server
+      spec:
+        template:
+          spec:
+            containers:
+              - name: server
+                args:
+                  - "--db_driver=$(DBCONFIG_DRIVER)"
+                  - "--db_host=$(DBCONFIG_POSTGRESQLCONFIG_HOST)"
+                  - "--db_port=$(DBCONFIG_POSTGRESQLCONFIG_PORT)"
+                  - "--db_name=$(DBCONFIG_DB_NAME)"
+                  - "--db_user=$(DBCONFIG_POSTGRESQLCONFIG_USER)"
+                  - "--db_password=$(DBCONFIG_POSTGRESQLCONFIG_PASSWORD)"
+                  - "--db_extra_params={\"sslmode\":\"disable\"}"
+                  - "--namespace_to_watch=$(NAMESPACE_TO_WATCH)"
+                  - "--listen_port=$(WEBHOOK_PORT)"
+```
+
+For production deployments with TLS certificates, replace `disable` with `verify-full` (or another [PostgreSQL sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS)).
+
+### Deploying with PostgreSQL from `master`
+
+Because PostgreSQL support is not yet in a tagged release, the released container images do not include it. Deploying the overlay at a release tag will not produce a working PostgreSQL deployment. You must use both the manifests and the container images built from `master`.
+
+The base manifests use placeholder image tags (dummy) , so you need a small local overlay that references the remote manifests as a base and overrides those two images.
+
+Create a directory and add a `kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-postgresql?ref=master
+
+images:
+  - name: ghcr.io/kubeflow/kfp-api-server
+    newTag: master
+  - name: ghcr.io/kubeflow/kfp-cache-server
+    newTag: master
+```
+
+For a multi-user deployment, use the multi-user overlay as the base instead. Multi-user mode requires Istio; see the [multi-user guide](/docs/components/pipelines/operator-guides/multi-user/).
+
+```yaml
+resources:
+  - github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-multi-user-postgresql?ref=master
+```
+
+
+
+Then apply the cluster-scoped resources followed by your overlay:
+
+```bash
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=master"
+kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
+kubectl apply -k .
+```
+
+Note the following when using this path:
+
+- The `resources` entry must be a remote URL or a relative path. Kustomize rejects absolute paths with a `new root ... cannot be absolute` error.
+- `kustomize edit set image` only modifies a local `kustomization.yaml`. It has no effect on a remote base, which is why the image overrides are declared in the file above.
+- `master` is a mutable tag. The images it points to change as commits land, so a redeployment may pick up different code.
+
+### Deploying with PostgreSQL After Release
+
+Once PostgreSQL support is included in a Kubeflow Pipelines release, the released images will include it and no image overrides are needed. Deploy the overlay directly:
+
+```bash
+export PIPELINE_VERSION=<version-with-postgresql-support>
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
+kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-postgresql?ref=$PIPELINE_VERSION"
+```
+
+For a multi-user deployment, use the `platform-agnostic-multi-user-postgresql` overlay instead:
+
+```bash
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-multi-user-postgresql?ref=$PIPELINE_VERSION"
+```

--- a/content/en/docs/components/pipelines/operator-guides/configure-database.md
+++ b/content/en/docs/components/pipelines/operator-guides/configure-database.md
@@ -1,0 +1,169 @@
++++
+title = "Database Configuration"
+description = ""
+weight = 4
++++
+
+{{% kfp-v2-keywords %}}
+
+Kubeflow Pipelines (KFP) uses a relational database to store pipeline definitions, run history, and other metadata. The API server is the main component that interacts with the database.
+
+By default, KFP deploys with MySQL. PostgreSQL configuration is available only for development and evaluation.
+
+## MySQL (Default)
+
+MySQL is the default database backend for KFP. It is automatically configured when you deploy KFP using the standard kustomize manifests. No additional database configuration is needed.
+
+To deploy KFP with MySQL using the platform-agnostic overlay:
+
+```bash
+export PIPELINE_VERSION={{% pipelines/latest-version %}}
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=$PIPELINE_VERSION"
+kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic?ref=$PIPELINE_VERSION"
+```
+
+For full installation instructions, see the [Installation](/docs/components/pipelines/operator-guides/installation/) guide.
+
+MySQL is the fully supported backend, and it is the backend assumed by the deployment overlays for proxy-enabled, cache-disabled, pod-to-pod TLS, and artifact proxy configurations.
+
+## PostgreSQL (Development and Evaluation Only)
+
+{{% alert title="Warning" color="warning" %}}
+**PostgreSQL is for development and evaluation only; it is not supported for production KFP 2.18 deployments.** KFP 2.18 still depends on ML Metadata (MLMD), whose PostgreSQL backend has a [known concurrency limitation](https://github.com/kubeflow/pipelines/issues/14353): concurrent first-time metadata type creation can fail runs and leave duplicate metadata type records. PostgreSQL will not be supported until KFP 3.0, when MLMD is removed. Use MySQL for production deployments.
+{{% /alert %}}
+
+Some KFP components and manifests can be configured to use PostgreSQL through the `pgx` driver. The following kustomize overlays are available for development and evaluation:
+
+- `manifests/kustomize/env/platform-agnostic-postgresql` — standalone (single-user)
+- `manifests/kustomize/env/platform-agnostic-multi-user-postgresql` — multi-user
+
+### Available development and evaluation configurations
+
+The available PostgreSQL overlays use the following configuration:
+
+- execution cache **enabled**
+- proxy **disabled**
+- pod-to-pod TLS **disabled**
+
+No PostgreSQL overlay is available for the following combinations:
+
+| Mode | Unavailable combination |
+| --- | --- |
+| Standalone | PostgreSQL with pod-to-pod TLS enabled |
+| Standalone | PostgreSQL with the execution cache disabled |
+| Standalone | PostgreSQL with proxy enabled |
+| Multi-user | PostgreSQL with the execution cache disabled |
+| Multi-user | PostgreSQL with the artifact proxy enabled |
+
+These combinations are also rejected explicitly by the project's CI deployment script and are not exercised in testing.
+
+{{% alert title="Warning" color="warning" %}}
+**Pod-to-pod TLS is not available with PostgreSQL.** The only pod-to-pod TLS overlay, `platform-agnostic-standalone-tls`, is a standalone MySQL-based configuration, and there is no PostgreSQL equivalent for either standalone or multi-user deployments. Enabling pod-to-pod TLS on a PostgreSQL deployment does not encrypt traffic between pods.
+
+Note that the absence of a multi-user TLS overlay is not specific to PostgreSQL: no multi-user pod-to-pod TLS overlay exists for any database backend. Switching to MySQL does not enable pod-to-pod TLS in multi-user mode.
+{{% /alert %}}
+
+For proxy-enabled, cache-disabled, and artifact-proxy deployments, use the MySQL-backed configuration. MySQL is also the required choice for all production deployments.
+
+### Configuring `sslmode`
+
+The API server requires `sslmode` to be set explicitly in the PostgreSQL connection parameters; it will not start without it. The base overlay leaves `sslmode` unset so that deployments fail fast rather than silently running without TLS.
+
+Add `patches` to your local overlay to set `sslmode` on both the API server and the cache server. The following example extends the overlay from the next section with `sslmode=disable` for local development:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-postgresql?ref=master
+
+images:
+  - name: ghcr.io/kubeflow/kfp-api-server
+    newTag: master
+  - name: ghcr.io/kubeflow/kfp-cache-server
+    newTag: master
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ml-pipeline
+      spec:
+        template:
+          spec:
+            containers:
+              - name: ml-pipeline-api-server
+                env:
+                  - name: DBCONFIG_POSTGRESQLCONFIG_EXTRAPARAMS
+                    value: '{"sslmode":"disable"}'
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cache-server
+      spec:
+        template:
+          spec:
+            containers:
+              - name: server
+                args:
+                  - "--db_driver=$(DBCONFIG_DRIVER)"
+                  - "--db_host=$(DBCONFIG_POSTGRESQLCONFIG_HOST)"
+                  - "--db_port=$(DBCONFIG_POSTGRESQLCONFIG_PORT)"
+                  - "--db_name=$(DBCONFIG_DB_NAME)"
+                  - "--db_user=$(DBCONFIG_POSTGRESQLCONFIG_USER)"
+                  - "--db_password=$(DBCONFIG_POSTGRESQLCONFIG_PASSWORD)"
+                  - "--db_extra_params={\"sslmode\":\"disable\"}"
+                  - "--namespace_to_watch=$(NAMESPACE_TO_WATCH)"
+                  - "--listen_port=$(WEBHOOK_PORT)"
+```
+
+For a development or evaluation deployment with TLS certificates, replace `disable` with `verify-full` (or another [PostgreSQL sslmode](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS)).
+
+### Deploying with PostgreSQL for development or evaluation
+
+KFP 2.18 release images will not include PostgreSQL configuration. For development or evaluation, use both the manifests and container images built from `master`. Do not use this mutable development path for production deployments.
+
+The base manifests use placeholder image tags (dummy) , so you need a small local overlay that references the remote manifests as a base and overrides those two images.
+
+Create a directory and add a `kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-postgresql?ref=master
+
+images:
+  - name: ghcr.io/kubeflow/kfp-api-server
+    newTag: master
+  - name: ghcr.io/kubeflow/kfp-cache-server
+    newTag: master
+```
+
+For a multi-user deployment, use the multi-user overlay as the base instead. Multi-user mode requires Istio; see the [multi-user guide](/docs/components/pipelines/operator-guides/multi-user/).
+
+```yaml
+resources:
+  - github.com/kubeflow/pipelines/manifests/kustomize/env/platform-agnostic-multi-user-postgresql?ref=master
+```
+
+
+
+Then apply the cluster-scoped resources followed by your overlay:
+
+```bash
+kubectl apply -k "github.com/kubeflow/pipelines/manifests/kustomize/cluster-scoped-resources?ref=master"
+kubectl wait --for condition=established --timeout=60s crd/applications.app.k8s.io
+kubectl apply -k .
+```
+
+Note the following when using this path:
+
+- The `resources` entry must be a remote URL or a relative path. Kustomize rejects absolute paths with a `new root ... cannot be absolute` error.
+- `kustomize edit set image` only modifies a local `kustomization.yaml`. It has no effect on a remote base, which is why the image overrides are declared in the file above.
+- `master` is a mutable tag. The images it points to change as commits land, so a redeployment may pick up different code.

--- a/content/en/docs/components/pipelines/operator-guides/installation/_index.md
+++ b/content/en/docs/components/pipelines/operator-guides/installation/_index.md
@@ -55,6 +55,14 @@ Kubeflow Pipelines can be deployed with pod-to-pod TLS enabled. The API server s
 
 Deploy KFP on a KinD cluster with pod-to-pod TLS enabled using the Makefile target [here](https://github.com/kubeflow/pipelines/blob/master/backend/Makefile). The corresponding manifests can be manually accessed [here](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls). 
 
+## Deploying Kubeflow Pipelines with PostgreSQL
+
+Kubeflow Pipelines uses MySQL as its database backend by default. It can alternatively be deployed with PostgreSQL, using the `pgx` driver, through the `platform-agnostic-postgresql` and `platform-agnostic-multi-user-postgresql` overlays.
+
+PostgreSQL support is currently scoped to the core deployment path: execution cache enabled, proxy disabled, and pod-to-pod TLS disabled. No PostgreSQL overlay exists for proxy-enabled deployments, cache-disabled deployments, pod-to-pod TLS, or the multi-user artifact proxy. For those configurations, use the default MySQL-backed deployment.
+
+For deployment instructions and the full support scope, see [Database Configuration](/docs/components/pipelines/operator-guides/configure-database/).
+
 ## Accessing the Kubeflow Pipelines UI
 
 The Kubeflow Pipelines deployment requires approximately 3 minutes to complete.

--- a/content/en/docs/components/pipelines/operator-guides/installation/_index.md
+++ b/content/en/docs/components/pipelines/operator-guides/installation/_index.md
@@ -55,6 +55,14 @@ Kubeflow Pipelines can be deployed with pod-to-pod TLS enabled. The API server s
 
 Deploy KFP on a KinD cluster with pod-to-pod TLS enabled using the Makefile target [here](https://github.com/kubeflow/pipelines/blob/master/backend/Makefile). The corresponding manifests can be manually accessed [here](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls). 
 
+## Deploying Kubeflow Pipelines with PostgreSQL
+
+PostgreSQL configuration is available only for development and evaluation; it is not supported for production KFP 2.18 deployments. KFP 2.18 still depends on ML Metadata (MLMD), whose PostgreSQL backend has a [known concurrency limitation](https://github.com/kubeflow/pipelines/issues/14353): concurrent first-time metadata type creation can fail runs and leave duplicate metadata type records. Use the default MySQL-backed deployment for production.
+
+For development or evaluation, KFP components and manifests can be configured with PostgreSQL using the `pgx` driver through the `platform-agnostic-postgresql` and `platform-agnostic-multi-user-postgresql` overlays. The available overlays require the execution cache enabled, with proxy and pod-to-pod TLS disabled.
+
+For development and evaluation instructions, see [Database Configuration](/docs/components/pipelines/operator-guides/configure-database/).
+
 ## Accessing the Kubeflow Pipelines UI
 
 The Kubeflow Pipelines deployment requires approximately 3 minutes to complete.


### PR DESCRIPTION
## Summary

- Add KFP database configuration guidance.
- Document PostgreSQL as development/evaluation-only for KFP 2.18.
- Recommend MySQL for all production deployments.
- Link the MLMD PostgreSQL concurrency limitation in kubeflow/pipelines#14353.
- Remove language implying PostgreSQL support will arrive in the next tagged release.

## Validation

- `git diff --check`
- `hugo --renderToMemory --quiet`

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [x] (for big changes) I will post screenshots of the changes in a PR comment
