### PR TITLE
website: fix broken redirect chain for /docs/examples/shared-resources/

### DIFF
--- a/content/en/_redirects
+++ b/content/en/_redirects
@@ -48,8 +48,8 @@
 /docs/pipelines/sdk/gcp/enable-gpu-and-tpu/         /docs/distributions/gke/pipelines/enable-gpu-and-tpu/
 /docs/pipelines/preemptible/                        /docs/distributions/gke/pipelines/preemptible/
 /docs/pipelines/sdk/gcp/preemptible/                /docs/distributions/gke/pipelines/preemptible/
-/docs/pipelines/reusable-components/                /docs/examples/shared-resources/
-/docs/pipelines/sdk/reusable-components/            /docs/examples/shared-resources/
+/docs/pipelines/reusable-components/                /docs/components/pipelines/user-guides/components/load-and-share-components/
+/docs/pipelines/sdk/reusable-components/            /docs/components/pipelines/user-guides/components/load-and-share-components/
 /docs/pipelines/sdk/build-component/                /docs/components/pipelines/legacy-v1/sdk/build-pipeline/
 /docs/components/pipelines/sdk/build-component/     /docs/components/pipelines/legacy-v1/sdk/build-pipeline/
 /docs/components/pipelines/upgrade/                 /docs/components/pipelines/legacy-v1/installation/upgrade/
@@ -102,7 +102,7 @@ docs/started/requirements/                    /docs/started/getting-started/
 /docs/use-cases/job-scheduling/                /docs/other-guides/job-scheduling/
 
 # Remove examples docs
-/docs/examples/*                                /docs/started/kubeflow-examples
+/docs/examples/*                                /docs/started/introduction
 
 # Move the kustomize guide to the config section
 /docs/components/misc/kustomize/              /docs/distributions/kfctl/kustomize/

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/build-pipeline.ipynb
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/build-pipeline.ipynb
@@ -229,7 +229,7 @@
     "[python-function-component]: https://www.kubeflow.org/docs/components/pipelines/legacy-v1/sdk/python-function-components/\n",
     "[component-dev]: https://www.kubeflow.org/docs/components/pipelines/legacy-v1/sdk/component-development/\n",
     "[python-function-component-data-passing]: https://www.kubeflow.org/docs/components/pipelines/legacy-v1/sdk/python-function-components/#understanding-how-data-is-passed-between-components\n",
-    "[prebuilt-components]: https://www.kubeflow.org/docs/examples/shared-resources/"
+    "[prebuilt-components]: https://www.kubeflow.org/docs/components/pipelines/user-guides/components/load-and-share-components/"
    ]
   },
   {

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/build-pipeline.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/build-pipeline.md
@@ -231,7 +231,7 @@ when designing a pipeline.
 [python-function-component]: /docs/components/pipelines/legacy-v1/sdk/python-function-components/
 [component-dev]: /docs/components/pipelines/legacy-v1/sdk/component-development/
 [python-function-component-data-passing]: /docs/components/pipelines/legacy-v1/sdk/python-function-components/#understanding-how-data-is-passed-between-components
-[prebuilt-components]: /docs/examples/shared-resources/
+[prebuilt-components]: /docs/components/pipelines/user-guides/components/load-and-share-components/
 
 
 ```python

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/component-development.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/component-development.md
@@ -604,5 +604,5 @@ See this [sample component][org-sample] for a real-life component example.
 * Visualize the output of your component by
   [adding metadata for an output
   viewer](/docs/components/pipelines/legacy-v1/sdk/output-viewer/).
-* Explore the [reusable components and other shared
-  resources](/docs/examples/shared-resources/).
+* Explore how to [load and share reusable
+  components](/docs/components/pipelines/user-guides/components/load-and-share-components/).

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md
@@ -197,7 +197,7 @@ Use the following options to create or reuse pipeline components.
 
 *   You can reuse prebuilt components in your pipeline.
 
-    [Learn more about reusing prebuilt components](/docs/examples/shared-resources/).
+    [Learn more about reusing prebuilt components](/docs/components/pipelines/user-guides/components/load-and-share-components/).
 
 
 ## Next steps


### PR DESCRIPTION
## Summary

Fixes a broken redirect chain affecting three legacy-v1 SDK documentation pages.

The `/docs/examples/shared-resources/` page was removed in **#2846**, which introduced a redirect from `/docs/examples/*` to `/docs/started/kubeflow-examples`. That redirect target was later removed in **#4385**, leaving the redirect pointing to a non-existent page. At the same time, three legacy-v1 SDK documentation pages (along with their companion notebook) continued linking directly to the removed `/docs/examples/shared-resources/` page, and two legacy redirect rules still routed through it.

This PR updates both the redirect rules and the remaining documentation links to point directly to the current documentation.

Fixes **#4440**.

---

## Changes

### Redirects (`content/en/_redirects`)

- Updated `/docs/pipelines/reusable-components/` to redirect directly to:
  - `/docs/components/pipelines/user-guides/components/load-and-share-components/`
- Updated `/docs/pipelines/sdk/reusable-components/` to redirect directly to:
  - `/docs/components/pipelines/user-guides/components/load-and-share-components/`
- Updated `/docs/examples/*` to redirect to:
  - `/docs/started/introduction`
  instead of the removed `/docs/started/kubeflow-examples`.

### Documentation

Updated links in:

- `content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md`
- `content/en/docs/components/pipelines/legacy-v1/sdk/component-development.md`
- `content/en/docs/components/pipelines/legacy-v1/sdk/build-pipeline.md`
- `content/en/docs/components/pipelines/legacy-v1/sdk/build-pipeline.ipynb`

All references to:

```text
/docs/examples/shared-resources/
```

now point to:

```text
/docs/components/pipelines/user-guides/components/load-and-share-components/
```

---

## Testing

Verified there are no remaining references to either the removed page or its previous redirect target:

```bash
grep -rn "shared-resources\|kubeflow-examples" \
  content/en/_redirects \
  content/en/docs
```

Also verified that:

- The updated links resolve correctly.
- The documentation builds successfully.
- The links render as expected when running:

```bash
hugo server -D
```

---

## Note for Reviewers

Issue **#4440** also notes that the live site currently serves stale content at `/docs/examples/shared-resources/` (a cached 2021 page with no corresponding source markdown). This appears to be a Netlify/CDN caching artifact rather than a repository issue, so it is not addressed in this PR. It should disappear after this change is deployed and the site cache is refreshed.