### PR TITLE
website: Fix a few dead links

### DIFF
--- a/content/en/docs/components/notebooks/container-images.md
+++ b/content/en/docs/components/notebooks/container-images.md
@@ -32,11 +32,9 @@ graph TD
 
   Jupyter --> PyTorchCuda[PyTorch CUDA]
   Jupyter --> TensorFlowCuda[TensorFlow CUDA]
-  Jupyter --> PyTorchGaudi[PyTorch Gaudi]
 
   PyTorchCuda --> PyTorchCudaFull[PyTorch CUDA Full]
   TensorFlowCuda --> TensorFlowCudaFull[TensorFlow CUDA Full]
-  PyTorchGaudi --> PyTorchGaudiFull[PyTorch Gaudi Full]
 
   click Base "https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/base"
   click Jupyter "https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter"
@@ -53,8 +51,6 @@ graph TD
   click TensorFlowCuda "https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-tensorflow-cuda"
   click PyTorchCudaFull "https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-pytorch-cuda-full"
   click TensorFlowCudaFull "https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-tensorflow-cuda-full"
-  click PyTorchGaudi "https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-pytorch-gaudi"
-  click PyTorchGaudiFull "https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-pytorch-gaudi-full"
 ```
 
 ### Base Images
@@ -85,8 +81,6 @@ Dockerfile | Container Registry | Notes
 [`./jupyter-tensorflow-full`](https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-tensorflow-full) | [`ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-full`](https://ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-full) | JupyterLab + TensorFlow + Common Packages
 [`./jupyter-tensorflow-cuda`](https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-tensorflow-cuda) | [`ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-cuda`](https://ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-cuda) | JupyterLab + TensorFlow + CUDA
 [`./jupyter-tensorflow-cuda-full`](https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-tensorflow-cuda-full) | [`ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-cuda-full`](https://ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-cuda-full) | JupyterLab + TensorFlow + CUDA + Common Packages
-[`./jupyter-pytorch-gaudi`](https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-pytorch-gaudi) | [`ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-gaudi`](https://ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-gaudi) | JupyterLab + PyTorch + Gaudi
-[`./jupyter-pytorch-gaudi-full`](https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/example-notebook-servers/jupyter-pytorch-gaudi-full) | [`ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-gaudi-full`](https://ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-gaudi-full) | JupyterLab + PyTorch + Gaudi + Common Packages
 
 ## Package Installation
 

--- a/content/en/docs/components/pipelines/legacy-v1/introduction.md
+++ b/content/en/docs/components/pipelines/legacy-v1/introduction.md
@@ -8,7 +8,7 @@ weight = 10
 This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
 Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
-For reference, the final release of the V1 SDK was [`kfp==1.8.23`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.23/).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 Kubeflow Pipelines is a platform for building and deploying portable, 

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/python-based-visualizations.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/python-based-visualizations.md
@@ -7,7 +7,7 @@ weight = 1400
 This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
 Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
-For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.23/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.23/).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 {{% alert title="Deprecated" color="warning" %}}

--- a/content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md
+++ b/content/en/docs/components/pipelines/legacy-v1/sdk/sdk-overview.md
@@ -12,7 +12,7 @@ For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.
 {{% /alert %}}
 
 The [Kubeflow Pipelines 
-SDK](https://kubeflow-pipelines.readthedocs.io/en/stable/source/html)
+SDK](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/index.html)
 provides a set of Python packages that you can use to specify and run your 
 machine learning (ML) workflows. A *pipeline* is a description of an ML 
 workflow, including all of the *components* that make up the steps in the 

--- a/content/en/docs/components/pipelines/legacy-v1/tutorials/benchmark-examples.md
+++ b/content/en/docs/components/pipelines/legacy-v1/tutorials/benchmark-examples.md
@@ -7,7 +7,7 @@ weight = 10
 This page is about __Kubeflow Pipelines V1__, please see the [V2 documentation](/docs/components/pipelines) for the latest information.
 
 Note, while the V2 backend is able to run pipelines submitted by the V1 SDK, we strongly recommend [migrating to the V2 SDK](/docs/components/pipelines/user-guides/migration).
-For reference, the final release of the V1 SDK was [`kfp==1.8.23`](https://pypi.org/project/kfp/1.8.23/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.23/).
+For reference, the final release of the V1 SDK was [`kfp==1.8.22`](https://pypi.org/project/kfp/1.8.22/), and its reference documentation is [available here](https://kubeflow-pipelines.readthedocs.io/en/1.8.22/).
 {{% /alert %}}
 
 This guide explains the Kubeflow Pipelines [benchmark scripts](https://github.com/kubeflow/pipelines/tree/sdk/release-1.8/tools/benchmarks)

--- a/content/en/docs/components/spark-operator/developer-guide.md
+++ b/content/en/docs/components/spark-operator/developer-guide.md
@@ -120,7 +120,7 @@ make build-operator
 
 In case you want to build the operator from the source code, e.g., to test a fix or a feature you write, you can do so following the instructions below.
 
-The easiest way to build the operator without worrying about its dependencies is to just build an image using the [Dockerfile](https://github.com/kubeflow/spark-operator/Dockerfile).
+The easiest way to build the operator without worrying about its dependencies is to just build an image using the [Dockerfile](https://github.com/kubeflow/spark-operator/blob/master/Dockerfile).
 
 ```shell
 make docker-build IMAGE_TAG=<image-tag>


### PR DESCRIPTION

### Description of Changes

- **notebooks: Drop the reference to the Gaudi images**
- **spark-operator: Fix dead link to `Dockerfile`**
- **pipelines: Fix a few legacy v1 docs links**

### Related Issues

_none_


### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
