### PR TITLE
fix: add Makefile local setup commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: setup serve build
+
+setup:
+	git submodule update --init --recursive
+	npm install
+
+serve:
+	hugo server -D
+
+build:
+	hugo

--- a/README.md
+++ b/README.md
@@ -96,25 +96,16 @@ Follow the usual GitHub workflow of forking the repository on GitHub and then cl
 3. Initialize the Docsy submodule:
 
    ```bash
-   git submodule update --init --recursive
+   make setup
    ```
 
-4. Install Docsy dependencies:
+4. Start your local Hugo server:
 
    ```bash
-   # install the node packages (at the root of the repo)
-   # NOTE: ensure you have node 18 installed, possibly using nvm
-   npm install
+   make serve
    ```
 
-5. Start your local Hugo server:
-
-   ```bash
-   # NOTE: You should ensure that you are in the root directory of the repository.
-   hugo server -D
-   ```
-
-6. You can access your website at [http://localhost:1313/](http://localhost:1313/)
+5. You can access your website at [http://localhost:1313/](http://localhost:1313/)
 
 ### Useful docs
 


### PR DESCRIPTION
### Description of Changes

This PR adds a root `Makefile` with simple local development commands for the website:

- `make setup` to initialize the Docsy submodule and install Node dependencies
- `make serve` to start the local Hugo server
- `make build` to build the site

It also updates the README local setup instructions to use these `make` commands instead of the longer manual sequence.

This improves the contributor experience and makes the local setup flow easier to follow.

### Related Issues

Closes: #4453

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment