### PR TITLE
website: fix duplicated origin in generated sitemap URLs

### DIFF
--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,8 +1,9 @@
 {{ `<?xml version="1.0" encoding="UTF-8"?>` | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{- range .Data.Pages }}
+  {{- if .Permalink }}
   <url>
-    <loc>https://www.kubeflow.org{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
@@ -17,5 +18,6 @@
                 href="{{ .Permalink }}"
                 />{{ end }}
   </url>
+  {{- end }}
   {{- end }}
 </urlset>


### PR DESCRIPTION
### What this PR does / why we need it:
Fixes #4455

The production sitemap at `https://www.kubeflow.org/sitemap.xml` contained malformed URLs with a duplicated origin prefix (e.g. `https://www.kubeflow.orghttps://www.kubeflow.org/...`). 

This happened because `layouts/sitemap.xml` prepended `https://www.kubeflow.org` to `{{ .Permalink }}`, even though Hugo already generates `.Permalink` as an absolute URL based on `--baseURL` during Netlify builds.

This PR:
- Replaces `<loc>https://www.kubeflow.org{{ .Permalink }}</loc>` with `<loc>{{ .Permalink }}</loc>` in `layouts/sitemap.xml`.
- Adds `{{- if .Permalink }}` check to prevent emitting empty `<url>` blocks.

### Which issue(s) this PR fixes:
Fixes #4455
