### PR TITLE
website: Send feedback events with GA4

### DIFF
--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -27,16 +27,12 @@
     noButton.disabled = true;
   };
   const sendFeedback = (value) => {
-    if (typeof ga !== 'function') return;
-    const args = {
-      command: 'send',
-      hitType: 'event',
-      category: 'Helpful',
-      action: 'click',
-      label: window.location.pathname,
-      value: value
-    };
-    ga(args.command, args.hitType, args.category, args.action, args.label, args.value);
+    if (typeof gtag !== 'function') return;
+    gtag('event', 'page_helpful', {
+      'event_category': 'Helpful',
+      'event_label': window.location.pathname,
+      'value': value
+    });
   };
   yesButton.addEventListener('click', () => {
     yesResponse.classList.add('feedback--response__visible');


### PR DESCRIPTION
### Description of Changes

The feedback widget still calls the old `ga()` API, while production only loads GA4's `gtag()`. Right now its a silent no-op

This sends a `page_helpful` event through `gtag()` and keeps the existing Yes and No values and UI behavior

Repro:
1. Open any docs page and click Yes or No.
2. Check `dataLayer`. No feedback event is added before this fix.
3. With this fix, one `page_helpful` event is added with the page path and value `1` or `0`.

Tests: Hugo 0.124.1 production build, browser checks for both buttons and the no analytics fallback, Netlify link check with 2421 passes and 1 tolerated external timeout.

### Related Issues

Related: #3629

### Checklist

- [x] Signed off the commit
- [x] Followed the contributing guide
- [x] Small behavior-only change, no screenshot needed
