### PR TITLE
website: reserve room for the fixed navbar when scrolling to an anchor

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -6,6 +6,23 @@ html.smooth-scroll {
   scroll-behavior: smooth;
 }
 
+// `.td-navbar` is `position: fixed` only from Bootstrap's `md` breakpoint up, so
+// only reserve room for it there. Without this, following an in-page anchor or a
+// table of contents entry scrolls the target heading underneath the navbar. The
+// navbar is 109px tall between `md` and `lg` and 106px above that; the extra 1rem
+// keeps the heading off it.
+//
+// This has to live in this file. `_docsy_main.scss` and `_styles_project.scss` are
+// imported inside the `[data-theme=...]` blocks in `main.scss`, so an `html` rule
+// there would compile to `[data-theme=light] html` and never match. This file is
+// imported before Bootstrap's mixins, hence the written-out breakpoint rather than
+// `media-breakpoint-up(md)`.
+@media (min-width: 768px) {
+  html {
+    scroll-padding-top: 125px;
+  }
+}
+
 // Bootstrap container-max-widths
 // NOTE: we increase the max-widths to make the content wider compared to the Bootstrap defaults
 $container-max-widths: (


### PR DESCRIPTION
### Description of Changes

`.td-navbar` is `position: fixed` from the `md` breakpoint up, and nothing compensated for it, so following any in-page anchor scrolled the target heading underneath the navbar.

One declaration in `assets/scss/_variables_project.scss`, next to the existing `html.smooth-scroll` rule, scoped to the same breakpoint at which the navbar becomes fixed.

Measured on `/docs/started/introduction/#what-is-kubeflow`, before and after:

| Viewport | Navbar | Heading top, before | after |
|---|---|---|---|
| 1920 | fixed, 106px | 0.2px (covered) | 125.2px |
| 1280 | fixed, 106px | 0.2px (covered) | 125.2px |
| 992 | fixed, 106px | 0.2px (covered) | 125.2px |
| 768 | fixed, 109px | 0.2px (covered) | 125.2px |
| 375 | not fixed | 0.2px (fine) | unchanged |

Also checked the table of contents path from the issue: clicking "Why Kubeflow Pipelines?" on `/docs/components/pipelines/overview/` now lands the heading at 125.2px instead of 0.2px.

Two notes for reviewers:

- The rule is scoped to `min-width: 768px` because the navbar is only fixed there. Below that it scrolls away with the page and needs no compensation, so an unscoped rule would add dead space on mobile.
- It has to live in `_variables_project.scss`. `_docsy_main.scss` and `_styles_project.scss` are imported inside the `[data-theme=...]` blocks in `main.scss`, so an `html` rule in either would compile to `[data-theme=light] html` and never match. That file is imported before Bootstrap's mixins, hence the written-out breakpoint instead of `media-breakpoint-up(md)`.

Tested against a local build at `476e4c1` with Hugo extended 0.124.1, the version pinned in `netlify.toml`. `hugo --gc --minify` builds clean.

### Related Issues

Closes: #4460

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
