### PR TITLE
website: add RAICS.AI to commercial providers table

### DIFF
--- a/content/en/docs/started/support.md
+++ b/content/en/docs/started/support.md
@@ -64,6 +64,7 @@ Below is a table of organizations that contribute to Kubeflow and offer commerci
 | Aranui Solutions             | [Aranui Solutions](https://www.aranui.solutions/services)                                                                                                       |
 | Canonical                    | [Charmed Kubeflow](https://ubuntu.com/kubeflow)                                                                                                     |
 | Freelancer Julius von Kohout | [LinkedIn](https://de.linkedin.com/in/juliusvonkohout/), [Slack](https://cloud-native.slack.com/team/U06LW431SJF), [GitHub](https://github.com/juliusvonkohout) |
+| RAICS.AI                     | [RAICS.AI](https://raics.ai/) |
 | Red Hat                      | [Red Hat](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai)                                                                        |
 | Other Providers              | Please reach out to the Kubeflow Steering Committee with proof of significant contributions to the Kubeflow open source project                                 |
 


### PR DESCRIPTION
Adds RAICS.AI to the commercial providers table.

RAICS.AI is a managed Kubeflow services provider based in Sydney, Australia, focused on sovereign / regulated deployments on AWS.

Recent Kubeflow contributions:
- kubeflow/community-distribution#3586 — adds sparkconnects and
  sparkconnects/status to the kubeflow-edit and kubeflow-view aggregated roles
- kubeflow/spark-operator#3100— documentation for mesh-aware webhook configuration
- Speaker, Kubeflow Community Showcase 2026 (19 Aug) — Spark Connect on Kubeflow

Happy to provide more contributions if needed