### PR TITLE
pipelines: document custom CA bundle configuration

### DIFF
--- a/content/en/docs/components/pipelines/operator-guides/server-config.md
+++ b/content/en/docs/components/pipelines/operator-guides/server-config.md
@@ -6,7 +6,7 @@ weight = 2
 
 
 By default, you can use Kubeflow Pipelines deployment manifests as provided,
-which aim to offer a standard configuration for most use cases. At the meantime,
+which aim to offer a standard configuration for most use cases. At the same time,
 customizations are available for more advanced usage.
 
 When deploying Kubeflow Pipelines servers, you can pass various environment variables
@@ -84,4 +84,54 @@ spec:
           value: http://squid.squid.svc.cluster.local:3128
         - name: NO_PROXY
           value: localhost,127.0.0.1,.svc.cluster.local,kubernetes.default.svc,metadata-grpc-service,0,1,2,3,4,5,6,7,8,9
+```
+
+## Custom CA Bundle
+
+You can configure the Kubeflow Pipelines API server to use a custom Certificate Authority (CA) bundle for pipeline workloads by providing the CA certificate through a Kubernetes Secret or ConfigMap.
+
+The following environment variables are available:
+
+* **`CABUNDLE_SECRET_NAME`**: The name of the Kubernetes Secret containing the custom CA certificate.
+* **`CABUNDLE_CONFIGMAP_NAME`**: The name of the Kubernetes ConfigMap containing the custom CA certificate.
+* **`CABUNDLE_KEY_NAME`**: The key containing the CA certificate in the Secret or ConfigMap. The default value is `ca.crt`.
+
+`CABUNDLE_SECRET_NAME` takes precedence over `CABUNDLE_CONFIGMAP_NAME`. If `CABUNDLE_SECRET_NAME` is set, KFP uses the specified Secret even if `CABUNDLE_CONFIGMAP_NAME` is also set. If neither is set, KFP does not configure a custom CA bundle.
+
+The CA certificate is mounted into the pipeline workload at `/kfp/certs/ca.crt`.
+
+### Example using a Kubernetes Secret
+
+The following example configures KFP to use a CA certificate from a Kubernetes Secret named `my-ca-secret`:
+
+```yaml
+- name: CABUNDLE_SECRET_NAME
+  value: my-ca-secret
+```
+
+By default, KFP looks for the certificate in the `ca.crt` key of the Secret. If the certificate is stored under a different key, set `CABUNDLE_KEY_NAME` to that key:
+
+```yaml
+- name: CABUNDLE_SECRET_NAME
+  value: my-ca-secret
+- name: CABUNDLE_KEY_NAME
+  value: my-custom-ca
+```
+
+### Example using a Kubernetes ConfigMap
+
+To use a CA certificate stored in a ConfigMap, set `CABUNDLE_CONFIGMAP_NAME`:
+
+```yaml
+- name: CABUNDLE_CONFIGMAP_NAME
+  value: my-ca-configmap
+```
+
+By default, KFP looks for the certificate in the `ca.crt` key. If the certificate is stored under a different key, configure `CABUNDLE_KEY_NAME`:
+
+```yaml
+- name: CABUNDLE_CONFIGMAP_NAME
+  value: my-ca-configmap
+- name: CABUNDLE_KEY_NAME
+  value: my-custom-ca
 ```


### PR DESCRIPTION
# pipelines: Document custom CA bundle server configuration

### Description of Changes

This change adds documentation for the custom CA bundle configuration options CABUNDLE_SECRET_NAME and CABUNDLE_CONFIGMAP_NAME, which were previously undocumented.

The documentation explains how to configure a custom CA bundle using a Kubernetes Secret or ConfigMap, including the use of CABUNDLE_KEY_NAME and the precedence of the Secret over the ConfigMap.

Related Issues

Closes: #4463

Checklist

* [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
* [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
* [ ] (for big changes) I will post screenshots of the changes in a PR comment