### PR TITLE
notebooks: correct WorkspaceKind sample links in new Kubeflow Workspace page

### DIFF
--- a/content/en/docs/components/workspaces/operator-guides/deployment-guide.md
+++ b/content/en/docs/components/workspaces/operator-guides/deployment-guide.md
@@ -168,9 +168,9 @@ kubectl annotate storageclass standard \
 Start from the upstream samples, which include ready-to-use `WorkspaceKind` definitions and adjust
 them for your usecase and cluster resources:
 
-- [JupyterLab](https://github.com/kubeflow/notebooks/blob/{{% kf-workspaces-version %}}/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml) (contains a lot of comments/explanations)
+- [JupyterLab](https://github.com/kubeflow/notebooks/blob/{{% kf-workspaces-version %}}/workspaces/controller/manifests/kustomize/samples/jupyterlab_v1beta1_workspacekind.yaml) (contains a lot of comments/explanations)
 - [VSCode (code-server)](https://github.com/kubeflow/notebooks/blob/{{% kf-workspaces-version %}}/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml)
-- [RStudio](https://github.com/kubeflow/notebooks/blob/{{% kf-workspaces-version %}}/workspaces/controller/manifests/kustomize/samples/codeserver_v1beta1_workspacekind.yaml)
+- [RStudio](https://github.com/kubeflow/notebooks/blob/{{% kf-workspaces-version %}}/workspaces/controller/manifests/kustomize/samples/rstudio_v1beta1_workspacekind.yaml)
 
 ```bash
 # Apply the sample WorkspaceKinds (and an example Workspace)


### PR DESCRIPTION
### Description of Changes

## Summary

Correct the WorkspaceKind sample links in the Workspaces deployment guide:

* Point JupyterLab to the JupyterLab sample.
* Point RStudio to the RStudio sample.
* Keep VS Code pointing to the Code Server sample.

## Why

All three entries currently point to the Code Server sample, which directs JupyterLab and RStudio users to the wrong manifests.

## Verification

* Verified that `jupyterlab_v1beta1_workspacekind.yaml`, `codeserver_v1beta1_workspacekind.yaml`, and `rstudio_v1beta1_workspacekind.yaml` exist at tag `v2.0.0-beta.0` in `kubeflow/notebooks` (all returned HTTP 200).
* Ran `git diff --check`.
* Ran `python3 scripts/validate-urls.py -d content/en/docs/components/workspaces/operator-guides`.

---

### Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] Ensure you follow best practices from our [contributing guide](https://github.com/kubeflow/website/blob/master/content/en/docs/about/contributing.md).
- [ ] (for big changes) I will post screenshots of the changes in a PR comment
