### PR TITLE
notebooks: document Workspaces concepts and architecture

### DIFF
--- a/content/en/docs/components/workspaces/overview.md
+++ b/content/en/docs/components/workspaces/overview.md
@@ -4,11 +4,11 @@ description: An overview of Kubeflow Workspaces
 weight: 10
 ---
 
-## What does Kubeflow Workspace offer?
+## What do Kubeflow Workspaces offer?
 
 Kubeflow Workspaces provides on-demand, containerized development environments that run directly on
 your Kubernetes cluster. This bridges the gap to give data scientists, machine learning engineers
-and agents a convenient access to the infrastructure in your Kubernetes cluster to code, explore
+and agents convenient access to the infrastructure in your Kubernetes cluster to code, explore
 data, and run experiments, while platform administrators keep full control over the images, hardware
 resources, and security that back those environments.
 
@@ -21,14 +21,29 @@ replacing the original Notebooks controller with a more flexible and extensible 
 
 - **Interactive development environments on Kubernetes**: run your IDE next to your data and
   powerful compute instead of locally on your workstation.
-- **Support for any web-based IDE**, with first-class examples for popular examples such as
+- **Support for any web-based IDE**, with first-class examples for popular IDEs such as
   [JupyterLab](https://github.com/jupyterlab/jupyterlab), [Visual Studio Code
   (code-server)](https://github.com/coder/code-server), and
   [RStudio](https://github.com/rstudio/rstudio).
-- **Persona-based design** Cluster admins curate the available environments through the
+- **Persona-based design**: Cluster admins curate the available environments through the
   `WorkspaceKind` custom resource, including base images, default resources, and pod-level
-  configuration, so endusers can create `Workspace` resources in a guided wizard without having to
+  configuration, so end users can create `Workspace` resources in a guided wizard without having to
   understand the underlying Kubernetes resources.
+
+## Core concepts and architecture
+
+### Custom resources
+
+- **`WorkspaceKind`**: Cluster-scoped resource curated by platform administrators. It defines the Workspace template, image and pod configuration choices, and administrative policies.
+- **`Workspace`**: Namespace-scoped resource representing an individual user development environment. It references a `WorkspaceKind` and records the user-selected configuration.
+
+### Component responsibilities
+
+| Component | Responsibility |
+| --- | --- |
+| **Frontend** | User interface for creating, monitoring, and managing Workspaces. |
+| **Backend** | Backend-for-frontend API used by the UI. |
+| **Controller** | Reconciles `Workspace` and `WorkspaceKind` resources and manages the runtime Kubernetes resources. The controller currently owns a `StatefulSet`, `Service`, `ServiceAccount`, `RoleBindings`, and optionally an Istio `VirtualService`. |
 
 ## Get Started
 


### PR DESCRIPTION
### Description of Changes

#### Summary
- Adds a concise **Core concepts and architecture** section to the Kubeflow Workspaces overview explaining the roles and scopes of `WorkspaceKind` and `Workspace`, as well as component responsibilities (`Frontend`, `Backend`, and `Controller`).
- Streamlines copy updates to focus strictly on objective editorial corrections:
  - Corrects heading grammar: *"What do Kubeflow Workspaces offer?"*
  - Removes the incorrect article in *"a convenient access"* -> *"convenient access"*.
  - Eliminates repetitive phrasing: *"examples for popular examples"* -> *"examples for popular IDEs"*.
  - Fixes missing colon delimiter and corrects closed compound *"endusers"* -> *"end users"*.
  - Preserves upstream sentence structure without subjective tone rewrites.

#### Why
Maintainer feedback on #4474 indicated that subjective wording changes alone did not clearly improve the overview. Adding a foundational architecture summary addresses a concrete documentation gap by clarifying how cluster-scoped configuration (`WorkspaceKind`), user workloads (`Workspace`), and runtime controllers interact, while retaining upstream phrasing and resolving typographical issues.

#### Technical sources
Verified against the `notebooks-v2` branch of [`kubeflow/notebooks`](https://github.com/kubeflow/notebooks):
- `workspaces/controller/api/v1beta1/workspacekind_types.go`: `WorkspaceKind` cluster scope, spawner config, pod templates, activity and filter rules.
- `workspaces/controller/api/v1beta1/workspace_types.go`: `Workspace` namespace scope, kind reference, user configuration.
- `workspaces/frontend/README.md`: Web UI responsibilities.
- `workspaces/backend/README.md`: Backend-for-frontend (BFF) service role.
- `workspaces/controller/README.md`: Reconciliation of custom resources.
- `workspaces/controller/internal/controller/workspace_controller.go`: Ownership and reconciliation of `StatefulSet`, `Service`, `ServiceAccount`, `RoleBindings`, and conditional Istio `VirtualService`.

#### Verification
- Ran `git diff --check` (no whitespace errors).
- Ran `python scripts/validate-urls.py -d content/en/docs/components/workspaces` (all links in `overview.md` return 200).
- Confirmed changes are isolated solely to `content/en/docs/components/workspaces/overview.md`.

Related documentation epic: kubeflow/notebooks#701