### PR TITLE
notebooks: (actually its workspaces) add Spark Connect operator and user guides

### DIFF
--- a/content/en/docs/components/workspaces/operator-guides/spark-connect.md
+++ b/content/en/docs/components/workspaces/operator-guides/spark-connect.md
@@ -1,0 +1,96 @@
+---
+title: Enabling Spark
+description: How to let Workspace users start Spark Connect sessions
+weight: 20
+---
+
+{{< workspaces-beta-notice >}}
+
+This guide is for platform administrators. It covers the one change you must make so that
+Workspace users can start a Spark Connect session with the
+[Kubeflow SDK](https://sdk.kubeflow.org/en/latest/spark/index.html).
+
+Everything else is configured by the user at session creation time — see the
+[user guide](/docs/components/workspaces/user-guides/spark-connect/).
+
+## Prerequisites
+
+- Kubeflow Workspaces `{{% kf-workspaces-version %}}` or later
+- [Kubeflow Spark Operator](https://spark.kubeflow.org/) with the `SparkConnect` CRD
+  installed and the operator watching your user namespaces
+- The aggregated `kubeflow-spark-edit` ClusterRole present in the cluster
+
+## Grant the Workspace access to Spark
+
+Each Workspace runs under its own ServiceAccount, `ws-{WORKSPACE_NAME}`.
+
+Since Workspaces `v2.0.0-beta.0` this ServiceAccount **no longer inherits the Kubeflow
+ClusterRoles** the way the old shared `default-editor` did. Until you grant it explicitly,
+a Workspace cannot create `SparkConnect` resources.
+
+Bind the Spark role on the WorkspaceKind:
+
+```yaml
+spec:
+  podTemplate:
+    serviceAccount:
+      clusterRoles:
+        # create/get/list/delete sparkconnects and sparkapplications
+        - name: "kubeflow-spark-edit"
+```
+
+Bind `kubeflow-spark-edit`, not `kubeflow-edit`. The Spark role grants only what is needed
+to manage `SparkApplication` and `SparkConnect` resources; `kubeflow-edit` is far broader
+and reintroduces exactly the permissions the per-Workspace ServiceAccount change removed.
+
+That is the only WorkspaceKind change required.
+
+## Verify
+
+```bash
+kubectl auth can-i create sparkconnects \
+  --as="system:serviceaccount:${NAMESPACE}:ws-${WORKSPACE_NAME}" \
+  -n "${NAMESPACE}"
+```
+
+If this returns `no`, fix the binding before users try to connect. Without the permission
+`connect()` does not fail fast — it fails on a multi-minute Spark timeout, well away from
+the actual cause.
+
+## What users still have to configure
+
+Three settings are supplied by the user in the `connect()` call rather than by you, because
+they apply per session. They are documented in the
+[user guide](/docs/components/workspaces/user-guides/spark-connect/), but they are worth
+knowing about when a user reports a broken session:
+
+**The driver needs a different ServiceAccount.** `kubeflow-spark-edit` lets the Workspace
+create the `SparkConnect` resource, but the Spark driver pod separately creates and watches
+its own executor pods. That is not covered by the Spark role, so the driver runs as
+`default-editor`.
+
+**Spark pods must leave the Istio mesh.** The driver and executors exchange data on ports
+7078 and 7079. Executors register with the driver and then fail fetching broadcast blocks,
+so tasks never complete. Both pods set `sidecar.istio.io/inject: "false"`.
+
+**The executor container must be named `spark-kubernetes-executor`.** Spark submits with
+`executor.podTemplateContainerName=spark-kubernetes-executor` and looks the container up by
+that name, so a template must declare it even though the operator supplies the image.
+
+## Image requirements
+
+The Workspace image needs the Kubeflow SDK with its `spark` extra (`kubeflow[spark]`), plus
+a `pyspark-connect` release matching the Spark version the SDK provisions, which it exposes
+as `kubeflow.spark.backends.kubernetes.constants.DEFAULT_SPARK_VERSION`.
+
+Installing the extra alone is not enough: it pins a `pyspark-connect` release that does not
+currently match that constant. Build images against the constant rather than relying on the
+extra or choosing a Spark version independently — a mismatch surfaces as an opaque protocol
+error rather than a version complaint.
+
+## Reference
+
+The end-to-end setup is exercised in CI by the Workspaces Spark Connect test in
+[`kubeflow/community-distribution`](https://github.com/kubeflow/community-distribution/tree/master/tests):
+`workspaces_spark_connect_test.sh`, `workspacekind.spark.test.yaml`, and
+`spark_connect_from_workspace.py`. That test is the authoritative working example.

--- a/content/en/docs/components/workspaces/operator-guides/spark-connect.md
+++ b/content/en/docs/components/workspaces/operator-guides/spark-connect.md
@@ -15,7 +15,7 @@ Everything else is configured by the user at session creation time — see the
 
 ## Prerequisites
 
-- Kubeflow Workspaces `{{% kf-workspaces-version %}}` or later
+- Kubeflow Workspaces `{{% workspaces/kf-workspaces-version %}}` or later
 - [Kubeflow Spark Operator](https://spark.kubeflow.org/) with the `SparkConnect` CRD
   installed and the operator watching your user namespaces
 - The aggregated `kubeflow-spark-edit` ClusterRole present in the cluster

--- a/content/en/docs/components/workspaces/user-guides/_index.md
+++ b/content/en/docs/components/workspaces/user-guides/_index.md
@@ -1,0 +1,9 @@
+---
+title: User Guides
+description: Documentation for users of Kubeflow Workspaces
+weight: 25
+---
+
+{{< workspaces-beta-notice >}}
+
+Guides for data scientists and other users working inside a Kubeflow Workspace.

--- a/content/en/docs/components/workspaces/user-guides/spark-connect.md
+++ b/content/en/docs/components/workspaces/user-guides/spark-connect.md
@@ -1,0 +1,133 @@
+---
+title: Running Spark
+description: Start a Spark Connect session from inside your Workspace
+weight: 10
+---
+
+{{< workspaces-beta-notice >}}
+
+You can run distributed Spark from a notebook in your Workspace without writing any
+Kubernetes manifests. The [Kubeflow SDK](https://sdk.kubeflow.org/en/latest/spark/index.html)
+creates the Spark cluster for you and hands back an ordinary PySpark session.
+
+## Before you start
+
+Your administrator has to grant your WorkspaceKind access to Spark first — see the
+[operator guide](/docs/components/workspaces/operator-guides/spark-connect/). Confirm it is
+done from a Workspace terminal:
+
+```bash
+kubectl auth can-i create sparkconnects
+```
+
+If this prints `no`, stop here and ask your administrator. Without the permission
+`connect()` does not fail immediately; it fails on a multi-minute Spark timeout.
+
+## Install the client
+
+If your Workspace image does not already ship it:
+
+```bash
+pip install "kubeflow[spark]"
+```
+
+Then pin `pyspark-connect` to the Spark version the SDK will provision. The `spark` extra
+installs a `pyspark-connect` release that does not currently match the SDK's
+`DEFAULT_SPARK_VERSION`, so this second step is required rather than belt-and-braces:
+
+```bash
+SPARK_VERSION="$(python -c \
+  'from kubeflow.spark.backends.kubernetes import constants; print(constants.DEFAULT_SPARK_VERSION)')"
+pip install "pyspark-connect==${SPARK_VERSION}"
+```
+
+## Start a session
+
+```python
+from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.spark import Name, PodTemplateOverride, SparkClient
+
+client = SparkClient(backend_config=KubernetesBackendConfig(namespace="my-namespace"))
+
+spark = client.connect(
+    options=[
+        Name("my-spark-session"),
+        PodTemplateOverride(
+            role="driver",
+            template={
+                "metadata": {"labels": {"sidecar.istio.io/inject": "false"}},
+                "spec": {"serviceAccountName": "default-editor"},
+            },
+        ),
+        PodTemplateOverride(
+            role="executor",
+            template={
+                "metadata": {"labels": {"sidecar.istio.io/inject": "false"}},
+                "spec": {"containers": [{"name": "spark-kubernetes-executor"}]},
+            },
+        ),
+    ]
+)
+```
+
+The two overrides are not optional. Each one works around something that would otherwise
+fail in a way that does not point at its cause:
+
+`serviceAccountName: default-editor` — your Workspace ServiceAccount can create the
+`SparkConnect` resource, but the driver pod separately creates and watches its own executor
+pods, which that role does not cover. Without this, executors never appear.
+
+`sidecar.istio.io/inject: "false"` — the driver and executors exchange data on ports 7078
+and 7079, and that traffic does not survive the service mesh. Executors register with the
+driver, then fail fetching broadcast blocks, so tasks hang rather than error.
+
+`containers: [{"name": "spark-kubernetes-executor"}]` — Spark submits with
+`executor.podTemplateContainerName=spark-kubernetes-executor` and looks the container up by
+name, so the template must declare it even though the operator supplies the image.
+
+## Run a query
+
+From here it is ordinary PySpark:
+
+```python
+rows = (
+    spark.range(0, 100_000, numPartitions=4)
+    .selectExpr("id % 8 AS bucket")
+    .groupBy("bucket")
+    .count()
+    .collect()
+)
+```
+
+## Shut the session down
+
+The Spark cluster holds resources until you delete it:
+
+```python
+spark.stop()
+client.delete_session("my-spark-session")
+```
+
+## Troubleshooting
+
+**`connect()` hangs, then times out.** Usually RBAC. Run the
+`kubectl auth can-i create sparkconnects` check above.
+
+**The session connects but no executors appear.** The driver override is missing or the
+driver ServiceAccount lacks pod permissions.
+
+**Executors start, register, then tasks hang.** Istio. Check that both pod templates carry
+the `sidecar.istio.io/inject: "false"` label. Excluding ports 7078 and 7079 individually is
+not enough — the pods have to leave the mesh.
+
+**The driver exits with status 1.** Check the executor container is named exactly
+`spark-kubernetes-executor`.
+
+**Protocol errors on a session that started cleanly.** Client and server Spark versions have
+drifted. Compare `pyspark.__version__` against `spark.version` and re-pin.
+
+## Reference
+
+A complete working example runs in CI as the Workspaces Spark Connect test in
+[`kubeflow/community-distribution`](https://github.com/kubeflow/community-distribution/tree/master/tests)
+(`spark_connect_from_workspace.py`).


### PR DESCRIPTION
## What this does

Adds two guides covering how to run Spark from a Kubeflow Workspace using the Kubeflow SDK, so users can start a Spark Connect session from a notebook without hand-authoring `SparkApplication` manifests.

Addresses kubeflow/notebooks#1362. Scope confirmed with @christian-heusel on that issue: guides live here, no sample WorkspaceKind, the docs instead explain what to modify on an existing WorkspaceKind and why.

## Changes

Three new files, nothing modified or removed.

- `workspaces/operator-guides/spark-connect.md` — the one WorkspaceKind change an administrator has to make (binding `kubeflow-spark-edit` via `podTemplate.serviceAccount.clusterRoles`), why the narrow role rather than `kubeflow-edit`, how to verify with `kubectl auth can-i`, and image requirements.
- `workspaces/user-guides/spark-connect.md` — the `SparkClient` / `connect()` flow, version pinning, the three required `PodTemplateOverride` settings with the reasoning for each, and troubleshooting.
- `workspaces/user-guides/_index.md` — new section, since Workspaces had Operator and Contributor guides but no User guides.

## How the split landed

Worth flagging, because it isn't what I expected going in: the only administrator-side change is the RBAC binding. The driver ServiceAccount, Istio sidecar exclusion, and the executor container name are all supplied per session by the user in the `connect()` call, not configured on the WorkspaceKind. So the operator guide is short and most of the substance sits in the user guide.

On the Notebooks-side follow-ups asked for in kubeflow/notebooks#1362: the only candidate I found was a sample `jupyterlab-spark` WorkspaceKind, which @christian-heusel has already ruled out. I don't think anything else is needed in `kubeflow/notebooks` for this.

## Depends on kubeflow/community-distribution#3590

**Please hold this until that PR merges.** Both guides link to the integration test it adds, so the reference links 404 until then and the Netlify link check will flag them. Every configuration snippet here is taken from that test rather than written from scratch, so it should also merge first for the docs to describe verified behaviour.

Raising now so review can start in parallel. Happy to convert to a draft if you'd rather.

## Related

kubeflow/spark-operator#3141 replaces the Jupyter Enterprise Gateway notebooks guide with the same SDK approach, on the Spark Operator docs side. It states the platform-specific requirements inline as a stopgap; I'll swap those for links to these pages once both land.